### PR TITLE
feat: add deterministic time config and RNG core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,11 @@ jobs:
             echo "No C/C++ files found"
             exit 1
           fi
-          clang-format --dry-run --Werror "${files[@]}"
+          clang-format -i "${files[@]}"
+          if ! git diff --exit-code -- "${files[@]}"; then
+            echo "C/C++ formatting differs from .clang-format. Apply the diff above."
+            exit 1
+          fi
 
   build-test:
     strategy:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "third_party/RTKLIB"]
 	path = third_party/RTKLIB
 	url = https://github.com/zengxianghang/RTKLIB.git
+[submodule "third_party/cJSON"]
+	path = third_party/cJSON
+	url = https://github.com/DaveGamble/cJSON.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,10 +14,16 @@ include(cmake/CompilerWarnings.cmake)
 
 set(GNSS_SIM_RTKLIB_COMMIT "47bb6cf9935b510109d16f46baa35c648e56f1b5" CACHE STRING
     "Pinned RTKLIB commit used by this simulator build")
+set(GNSS_SIM_CJSON_COMMIT "acc76239bee01d8e9c858ae2cab296704e52d916" CACHE STRING
+    "Pinned cJSON commit used by this simulator build")
 
 if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/third_party/RTKLIB/src/rtklib.h")
     message(FATAL_ERROR
         "RTKLIB submodule is missing. Run: git submodule update --init --recursive")
+endif()
+if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/third_party/cJSON/cJSON.h")
+    message(FATAL_ERROR
+        "cJSON submodule is missing. Run: git submodule update --init --recursive")
 endif()
 
 add_library(rtklib_pinned INTERFACE)
@@ -27,13 +33,33 @@ target_include_directories(rtklib_pinned SYSTEM INTERFACE
 target_compile_definitions(rtklib_pinned INTERFACE
     GNSS_SIM_RTKLIB_COMMIT="${GNSS_SIM_RTKLIB_COMMIT}")
 
+add_library(cjson_vendor STATIC
+    third_party/cJSON/cJSON.c
+)
+add_library(gnss_sim::cjson ALIAS cjson_vendor)
+target_include_directories(cjson_vendor SYSTEM PUBLIC
+    "${CMAKE_CURRENT_SOURCE_DIR}/third_party/cJSON")
+set_target_properties(cjson_vendor PROPERTIES
+    C_STANDARD 11
+    C_STANDARD_REQUIRED ON
+    C_EXTENSIONS OFF
+)
+
 add_library(gnss_sim_core STATIC
+    src/core/deterministic_rng.cpp
+    src/core/sim_config.cpp
+    src/core/sim_time.cpp
     src/core/simulator.cpp
 )
 add_library(gnss_sim::core ALIAS gnss_sim_core)
-target_include_directories(gnss_sim_core PUBLIC
-    "${CMAKE_CURRENT_SOURCE_DIR}/include")
-target_link_libraries(gnss_sim_core PUBLIC gnss_sim::rtklib)
+target_include_directories(gnss_sim_core
+    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src"
+)
+target_link_libraries(gnss_sim_core
+    PUBLIC gnss_sim::rtklib
+    PRIVATE gnss_sim::cjson
+)
 gnss_sim_set_project_warnings(gnss_sim_core)
 
 add_executable(gnss-data-simulator
@@ -55,8 +81,12 @@ if(BUILD_TESTING)
     FetchContent_MakeAvailable(googletest)
 
     add_executable(gnss_sim_unit_tests
+        tests/unit/test_deterministic_rng.cpp
+        tests/unit/test_sim_config.cpp
         tests/unit/test_sim_time.cpp
     )
+    target_include_directories(gnss_sim_unit_tests PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/src")
     target_link_libraries(gnss_sim_unit_tests PRIVATE
         gnss_sim::core
         GTest::gtest_main

--- a/docs/ENGINEERING_RULES.md
+++ b/docs/ENGINEERING_RULES.md
@@ -11,6 +11,7 @@ This document defines the required repository layout, source-file naming, C/C++ 
 - Primary Windows toolchain: Visual Studio 2022 / MSVC.
 - CI secondary toolchain: GCC on Ubuntu.
 - RTKLIB must be consumed through a fixed/pinned repository revision for a reproducible build. The simulator release/run manifest must record the exact RTKLIB commit SHA.
+- JSON configuration parsing uses the pinned cJSON dependency through `sim_config`; cJSON types must not leak outside that module boundary.
 - Project code must compile cleanly on both Windows and Linux. Platform-specific code must be isolated behind a narrow adapter and must not leak into the GNSS physics/model layers.
 - Production code must not require a network connection at runtime. Downloading IGS data is a separate tooling concern.
 
@@ -72,6 +73,7 @@ The implementation must use the following top-level layout. New directories requ
 │     └─ truth_writer.cpp
 ├─ tests/
 │  ├─ unit/
+│  │  ├─ test_sim_config.cpp
 │  │  ├─ test_sim_time.cpp
 │  │  ├─ test_deterministic_rng.cpp
 │  │  ├─ test_signal_definitions.cpp
@@ -98,7 +100,8 @@ The implementation must use the following top-level layout. New directories requ
 │  ├─ build_cn0_model/
 │  └─ download_igs/
 ├─ third_party/
-│  └─ RTKLIB/
+│  ├─ RTKLIB/
+│  └─ cJSON/
 └─ .github/
    └─ workflows/
       ├─ ci.yml
@@ -198,7 +201,7 @@ _cycles   carrier cycles
 Examples:
 
 ```cpp
-int64_t epoch_time_ns;
+std::int64_t epoch_time_ns;
 double pseudorange_m;
 double doppler_hz;
 double elevation_deg;
@@ -214,6 +217,7 @@ Do not use generic names such as `time`, `range`, `speed`, or `freq` in physics 
 - Minimize transitive includes.
 - Do not expose RTKLIB internal structures in the public `include/gnss_sim/` API.
 - RTKLIB types should be contained inside `rtklib_adapter` / navigation implementation boundaries.
+- cJSON types must remain private to `sim_config.cpp`.
 - Prefer `const` input pointers/references when data is read-only.
 - Functions should return explicit success/failure status rather than silently falling back when input data is invalid.
 
@@ -240,7 +244,7 @@ Determinism is a product requirement, not only a test convenience.
 ## 5. Frozen module ownership
 
 ### `sim_config`
-Owns configuration parsing/defaults/validation only.
+Owns configuration parsing/defaults/validation only. The JSON parser is an implementation detail and must not leak into other modules.
 
 ### `sim_time`
 Owns integer simulation scheduling, GPST conversion, week rollover, epoch alignment, and event-to-epoch rules.
@@ -259,285 +263,181 @@ No formatter or scenario module may maintain a second independent signal mapping
 ### `satellite_engine`
 Owns transmission-time iteration, satellite state at transmit time, LOS, azimuth/elevation, geometric range, and range rate.
 
-### `navigation_state`
-Owns Truth NAV vs Receiver NAV state and usable navigation-data lifecycle.
-
-### `nav_message_scheduler`
-Owns COLD navigation fragment/page/message acquisition timing and EPH completion logic.
-
 ### `receiver_truth`
-Owns receiver truth position/velocity/clock state. V1 clock bias/drift are zero, but the fields remain explicit.
+Owns receiver truth position/velocity/clock state and future trajectory interpolation.
 
 ### `atmosphere_model`
-Owns ionosphere/troposphere corrections and `none`/broadcast modes.
+Owns ionosphere and troposphere truth/correction models.
 
 ### `measurement_model`
-Owns final PSR/Doppler/ADR physical equations. It does not own acquisition state or text formatting.
+Owns pseudorange, Doppler, carrier phase/ADR generation and signal-specific correction application.
 
 ### `cn0_model`
-Owns system+signal+elevation CN0 lookup/interpolation and fallback behavior.
+Owns CN0-vs-elevation runtime lookup/model evaluation.
 
 ### `signal_tracking`
-Owns SIGNAL_OFF/SEARCHING/ACQUIRING/TRACKING, lock time, valid flags, and acquisition/reacquisition delays.
+Owns per-signal acquisition/tracking/lock/validity state.
+
+### `navigation_state`
+Owns Truth NAV and Receiver NAV stores and their update/availability state.
+
+### `nav_message_scheduler`
+Owns COLD-start frame/subframe/page/message fragment acquisition timing.
 
 ### `scenario_engine`
-Owns KS/REA/TTFF event scheduling and power/signal state. It must not contain satellite-orbit or observation equations.
+Owns KS/REA/TTFF events only.
 
 ### `solution_engine`
-Owns construction of RTKLIB observations from simulated measurements and generation of PSRPOS/PSRVEL solution state.
+Owns conversion of generated observations + Receiver NAV into RTKLIB SPP/velocity results.
 
-### Output writers
-Writers only serialize already-computed state. They must not recalculate physics or invent receiver state.
+### output writers
+Own formatting/serialization only. Writers must not recompute geometry, navigation corrections, tracking state, or solution validity.
 
-## 6. CMake target rules
+## 6. GitHub Actions policy
 
-Use explicit targets:
-
-```text
-gnss_sim_core       library containing simulator production logic
-gnss_data_simulator executable containing only CLI/app entry logic
-gnss_sim_tests      unit/integration test executable(s)
-```
-
-Third-party RTKLIB warnings must not be treated as project-code warnings.
-
-Project code should use strict warnings:
+Normal PR/push CI is fast and mandatory:
 
 ```text
-MSVC: /W4
-GCC/Clang: -Wall -Wextra -Wpedantic
+.github/workflows/ci.yml
 ```
 
-New warnings introduced by project code are not acceptable. CI may promote project warnings to errors once the initial build baseline is clean.
+It must include:
 
-## 7. GitHub Actions policy
+- formatting check;
+- Windows / Visual Studio 2022 build;
+- Ubuntu / GCC build;
+- unit tests;
+- short deterministic integration tests when they exist;
+- no live IGS download;
+- no default 8-hour generation run.
 
-Two workflows are frozen for V1.
-
-### `.github/workflows/ci.yml`
-
-Purpose: required fast PR/main validation.
-
-Triggers:
+Long/expensive validation belongs in:
 
 ```text
-pull_request
-push to main
-workflow_dispatch
+.github/workflows/extended.yml
 ```
 
-Required jobs:
+It is intended for:
 
-1. Windows / MSVC build + tests.
-2. Ubuntu / GCC build + tests.
-3. Formatting check.
+- `workflow_dispatch` manual execution;
+- scheduled execution if useful;
+- 1/5/10/20/50 Hz matrix;
+- full constellation/signal matrix;
+- HOT/WARM/COLD;
+- REA;
+- cross-week tests;
+- deterministic rerun checks;
+- long-duration streaming/memory tests;
+- default 8-hour run;
+- selected 50 Hz runs.
 
-Required fast test scope:
+Do not make ordinary documentation-only changes consume an 8-hour simulation test.
 
-- all unit tests;
-- small deterministic integration tests;
-- representative GPS-only and multi-GNSS zero-noise loopback;
-- output golden tests;
-- startup/REA state-machine tests using short synthetic durations;
-- week-rollover boundary test.
+## 7. Unit-test principles
 
-Rules:
+Use GoogleTest for C/C++ unit tests and register tests through CTest.
 
-- PR CI must not generate the normal 8-hour dataset.
-- Tests must not depend on live IGS/network availability.
-- CI must use checked-in minimal test fixtures.
-- A test failure must fail the workflow; no `continue-on-error` for required checks.
-- Avoid retry loops that hide flaky tests.
-- Cancel stale in-progress CI runs for the same PR when a newer commit is pushed.
-- Do not upload large generated simulator logs by default.
-- On failure, small diagnostic logs/test reports may be uploaded as artifacts.
+### 7.1 General rules
 
-### `.github/workflows/extended.yml`
+- One production module should have focused unit tests.
+- Every bug fix must add a regression test that fails before the fix and passes after it.
+- Tests must not depend on current wall-clock time, network availability, machine locale, or unspecified random state.
+- Test random behavior with explicit fixed seeds.
+- Do not weaken numerical tolerances merely to make CI pass.
+- Test both normal operation and boundary/error conditions.
+- Parser/formatter tests should use small representative fixtures rather than GB-sized logs.
+- Unit tests should normally complete in seconds.
 
-Purpose: expensive/full validation.
+### 7.2 Deterministic physical model tests
 
-Triggers:
+For numerical physics functions:
 
-```text
-workflow_dispatch
-scheduled run
-```
+1. Test a simple analytically checkable case where possible.
+2. Test against RTKLIB/reference calculations where RTKLIB owns the reference algorithm.
+3. Use explicitly justified absolute/relative tolerances.
+4. Include constellation-specific edge cases, especially GLONASS FDMA.
 
-Extended scope should include:
+### 7.3 State-machine tests
 
-- longer multi-GNSS runs;
-- all supported sampling rates 1/5/10/20/50 Hz;
-- all supported signal mappings;
-- HOT/WARM/COLD/REA scenario regression;
-- navigation update behavior;
-- deterministic same-seed repeat comparison;
-- 8-hour default-run smoke/regression when runtime cost is acceptable;
-- memory-growth/streaming validation;
-- optional sanitizer job on Linux.
+State-machine tests must check transitions and invariants, not only final values.
 
-Extended CI is not a substitute for fast PR CI. A PR must remain testable without waiting for an 8-hour-generation job.
+Examples:
 
-## 8. Unit test principles
+- lock time resets on signal loss;
+- ADR validity resets on power/signal loss as designed;
+- Receiver NAV is retained during REA;
+- Receiver NAV is empty at COLD startup;
+- EPH becomes available only after required NAV fragments;
+- HOT/WARM EPH is available immediately;
+- PSRPOS and PSRVEL validity can differ.
 
-### 8.1 General rules
+### 7.4 Output/golden tests
 
-- Every deterministic algorithm/module must have unit tests before or together with its implementation.
-- Test public behavior and important invariants, not private implementation trivia.
-- A bug fix must add a regression test that fails before the fix and passes after it.
-- Tests must be deterministic and independent of execution order.
-- Unit tests must not use current wall-clock time, online services, random unrecorded seeds, or machine-specific paths.
-- Do not loosen numerical tolerances merely to make a failing physics test pass. First determine the physical/numerical reason for the difference.
-- Tests should be small enough that developers run them locally before every PR.
+For NovAtel OEM7 and Unicore N4 formatters:
 
-### 8.2 Test framework
+- maintain small golden files under `tests/golden/`;
+- compare the complete serialized line/record where practical;
+- field formatting/precision/ordering is part of the test contract;
+- changes to golden output require explicit review and a reason;
+- golden files must never be regenerated silently merely because a test failed.
 
-- Use GoogleTest for C++ unit/integration tests.
-- Integrate tests through CTest.
-- Pin the GoogleTest revision/version just like other build dependencies.
-- Test-only code may use STL/features more freely than production hot-path code.
+## 8. Integration-test principles
 
-### 8.3 Required unit coverage categories
+Integration tests verify module boundaries and physical consistency.
 
-#### Time
+Required V1 integration coverage eventually includes:
 
-- 1/5/10/20/50 Hz exact tick intervals;
-- no cumulative floating-time drift;
-- GPST week crossover;
-- event effective at first epoch where `epoch_time >= event_time`.
+- GPS-only ideal static loopback;
+- multi-GNSS ideal static loopback;
+- all supported signals;
+- RTKLIB SPP recovery of the configured receiver position;
+- static velocity recovery near zero;
+- HOT/WARM/COLD startup;
+- REA signal off/on;
+- Truth NAV vs Receiver NAV isolation;
+- COLD EPH progressive acquisition;
+- EPH/ION runtime updates;
+- GPST week rollover;
+- 1/5/10/20/50 Hz;
+- deterministic same-seed repeatability.
 
-#### Signal definitions
+Normal CI uses short fixtures/durations. Long-duration versions of these tests belong in extended CI.
 
-- every supported constellation/signal maps to exactly one intended RINEX/RTKLIB/OEM definition;
-- GLONASS G1/G2 FCN-dependent wavelength;
-- no duplicate or conflicting mapping.
+## 9. Test data policy
 
-#### Satellite geometry
+- Keep only minimal necessary test data in Git.
+- Do not commit multi-GB IGS archives.
+- Every fixture should document its origin and any transformation applied.
+- Prefer synthetic minimal RINEX fixtures for parser boundary tests if they faithfully exercise the target format.
+- Real IGS snippets may be used when needed for reference/compatibility testing and redistribution is appropriate.
+- CI tests must not download test data from the internet during the test itself.
 
-- transmit-time iteration converges;
-- azimuth/elevation/range against trusted RTKLIB/reference cases;
-- 3 degree visibility mask boundary.
+## 10. Pull request and commit rules
 
-#### Measurement model
+- One PR should primarily solve one issue/work package.
+- Keep PRs reviewable; avoid one giant V1 implementation PR.
+- PR descriptions must include:
+  - what changed;
+  - why;
+  - tests run;
+  - any limitations/follow-up issues;
+  - Implementation Notes relevant to the issue.
+- Do not mix broad formatting/refactoring with unrelated GNSS behavior changes.
+- Update design/engineering documentation in the same PR when behavior or a frozen interface changes.
+- CI must pass before merge.
+- Do not bypass failing deterministic tests without root-cause analysis.
 
-- zero-noise PSR equation term-by-term;
-- Doppler/range-rate sign convention;
-- ADR continuity while tracking;
-- correct ionosphere sign between code and carrier;
-- TGD/ISC/BGD applied only to the intended signal.
+## 11. Review checklist
 
-#### Tracking
+Before merge, verify:
 
-- lock time increments only under continuous tracking;
-- loss of signal resets lock/ADR validity as specified;
-- HOT/WARM/COLD acquisition timing is deterministic for fixed seed/config;
-- REA recovery does not clear Receiver NAV.
-
-#### Navigation
-
-- Truth NAV and Receiver NAV never alias accidentally;
-- HOT/WARM restore cached EPH/ION;
-- COLD does not expose future/full Truth NAV before fragments complete;
-- IOD consistency checks;
-- RINEX NAV update causes correct Receiver NAV/log update.
-
-#### Output
-
-- exact OEM7/N4 record family names;
-- exact status/type transitions including `INSUFFICIENT_OBS/NONE`;
-- numeric formatting/field ordering;
-- CRC/checksum behavior where applicable;
-- golden output lines compared byte-for-byte where practical.
-
-## 9. Integration/acceptance test principles
-
-### Zero-noise static loopback
-
-Given the same broadcast NAV/corrections and static truth, simulated observations processed by RTKLIB must recover the truth within a tight numerical tolerance appropriate to the exact model path.
-
-This is the primary physics correctness oracle for V1.
-
-### Position/velocity independence
-
-PSRPOS and PSRVEL must be produced from the simulated measurements/Receiver NAV. Integration tests must catch any accidental direct use of receiver truth to fill solution outputs.
-
-### Startup modes
-
-Tests must verify state semantics, not only TTFF number:
-
-- HOT/WARM EPH available immediately from receiver cache;
-- COLD EPH progressively available through navigation-message collection;
-- TTFF occurs only once actual solution conditions are met.
-
-### REA
-
-During SIGNAL OFF:
-
-```text
-RANGEA count = 0
-PSRPOSA = INSUFFICIENT_OBS / NONE
-PSRVELA = INSUFFICIENT_OBS / NONE
-Receiver NAV retained
-GPST continuous
-```
-
-After SIGNAL ON, observations and solution must recover progressively according to tracking state.
-
-### Determinism
-
-Run the same short scenario twice with the same config/input/seed and compare hashes or exact output bytes. Run with a different seed and verify only intentionally stochastic timing/state fields change.
-
-### Cross-platform
-
-Numerical physics results should agree within defined floating-point tolerances between MSVC and GCC. Text-format golden tests should be designed to remain platform-independent (explicit line endings/locale/formatting).
-
-## 10. Test data policy
-
-- Keep CI fixtures minimal; do not commit GB-scale IGS/RINEX files.
-- Each fixture must document its source and purpose in `tests/data/README.md`.
-- Prefer the smallest RINEX excerpt that still exercises the intended condition.
-- Golden files are specifications and must not be regenerated automatically during CI.
-- Updating a golden file requires review of why the external format changed.
-
-## 11. Pull request rules
-
-Every implementation PR must include:
-
-- concise scope;
-- linked issue when applicable;
-- implementation notes describing important design choices;
-- tests added/updated;
-- local test command/results;
-- any format/config compatibility impact.
-
-A PR is not complete when only the new code works manually. The corresponding deterministic tests and documentation updates are part of the implementation.
-
-Keep PRs focused. Avoid combining unrelated formatter, physics, scenario, and CI refactors in one PR unless the dependency is unavoidable.
-
-## 12. Commit rules
-
-Use short English imperative/conventional-style commit subjects, for example:
-
-```text
-feat: add GPS LNAV cold-start scheduler
-test: add week-rollover timing coverage
-fix: preserve receiver nav during REA outage
-docs: define V1 output record rules
-ci: add Windows and Ubuntu test matrix
-```
-
-Do not use vague messages such as `update`, `fix bug`, or `changes`.
-
-## 13. Definition of done for V1 implementation work
-
-A module/change is done only when all applicable items are true:
-
-1. code follows the frozen directory/file/module ownership;
-2. public behavior is documented where necessary;
-3. unit tests cover deterministic behavior and boundaries;
-4. integration/regression tests cover cross-module behavior where applicable;
-5. local CMake build and CTest pass;
-6. Windows/MSVC CI passes;
-7. Ubuntu/GCC CI passes;
-8. no new project-code warnings;
-9. deterministic outputs remain reproducible;
-10. no 8-hour in-memory buffering or other obvious duration-proportional memory growth is introduced.
+- module ownership is respected;
+- no duplicate signal mapping was introduced;
+- Truth NAV and Receiver NAV remain separate;
+- no hidden random source was introduced;
+- units are explicit;
+- no full-run unbounded memory accumulation was introduced;
+- output writers only serialize;
+- tests cover the new behavior;
+- Windows and Linux builds remain green;
+- long tests have not leaked into normal PR CI.

--- a/include/gnss_sim/sim_config.h
+++ b/include/gnss_sim/sim_config.h
@@ -1,9 +1,63 @@
 #ifndef GNSS_SIM_SIM_CONFIG_H_
 #define GNSS_SIM_SIM_CONFIG_H_
 
+#include <cstdint>
+#include <string>
+
 namespace gnss_sim {
 
-struct SimConfig;
+enum class ScenarioType {
+    KS,
+    REA,
+    TTFF,
+};
+
+enum class StartupMode {
+    HOT,
+    WARM,
+    COLD,
+};
+
+struct ReceiverConfig {
+    double latitude_deg;
+    double longitude_deg;
+    double height_m;
+};
+
+struct TtffConfig {
+    StartupMode startup_mode;
+    std::int64_t power_on_ns;
+    std::int64_t power_off_ns;
+};
+
+struct ReaConfig {
+    std::int64_t signal_on_ns;
+    std::int64_t signal_off_ns;
+};
+
+struct SimConfig {
+    int schema_version;
+    ScenarioType scenario;
+    std::int64_t duration_ns;
+    int sampling_rate_hz;
+    double elevation_mask_deg;
+    bool output_eph;
+    bool output_ion;
+    bool measurement_noise_enabled;
+    bool multipath_enabled;
+    double receiver_clock_bias_m;
+    double receiver_clock_drift_mps;
+    ReceiverConfig receiver;
+    TtffConfig ttff;
+    ReaConfig rea;
+    std::uint64_t seed;
+};
+
+SimConfig default_sim_config();
+bool validate_sim_config(const SimConfig& config, std::string* error_message);
+bool load_sim_config_json(const char* file_path, SimConfig* config, std::string* error_message);
+const char* scenario_type_name(ScenarioType scenario);
+const char* startup_mode_name(StartupMode startup_mode);
 
 } // namespace gnss_sim
 

--- a/include/gnss_sim/sim_time.h
+++ b/include/gnss_sim/sim_time.h
@@ -3,9 +3,26 @@
 
 #include "gnss_sim/sim_types.h"
 
+#include <cstdint>
+
 namespace gnss_sim {
 
-// Time conversion and scheduling APIs are implemented by issue #3.
+constexpr std::int64_t NANOSECONDS_PER_SECOND = 1000000000LL;
+constexpr std::int64_t GPS_WEEK_SECONDS = 604800LL;
+constexpr std::int64_t GPS_WEEK_NANOSECONDS = GPS_WEEK_SECONDS * NANOSECONDS_PER_SECOND;
+
+bool normalize_sim_time(int gps_week, std::int64_t tow_ns, SimTime* out_time);
+bool sim_time_from_week_sow(int gps_week, double sow_sec, SimTime* out_time);
+double sim_time_sow_sec(const SimTime& time);
+int compare_sim_time(const SimTime& lhs, const SimTime& rhs);
+bool add_time_ns(const SimTime& time, std::int64_t delta_ns, SimTime* out_time);
+bool difference_time_ns(const SimTime& lhs, const SimTime& rhs, std::int64_t* difference_ns);
+bool sampling_interval_ns(int sampling_rate_hz, std::int64_t* interval_ns);
+bool epoch_time_at_index(const SimTime& start_time, int sampling_rate_hz, std::uint64_t epoch_index,
+                         SimTime* epoch_time);
+bool epoch_index_at_or_after(const SimTime& start_time, const SimTime& event_time, int sampling_rate_hz,
+                             std::uint64_t* epoch_index);
+bool epoch_count_for_duration(std::int64_t duration_ns, int sampling_rate_hz, std::uint64_t* epoch_count);
 
 } // namespace gnss_sim
 

--- a/src/core/deterministic_rng.cpp
+++ b/src/core/deterministic_rng.cpp
@@ -1,1 +1,54 @@
-// Deterministic PRNG implementation is introduced by issue #3.
+#include "core/deterministic_rng.h"
+
+namespace gnss_sim {
+namespace {
+
+constexpr std::uint64_t PCG32_MULTIPLIER = 6364136223846793005ULL;
+constexpr double TWO_POW_53 = 9007199254740992.0;
+
+} // namespace
+
+std::uint32_t rng_next_u32(DeterministicRng* rng) {
+    if (rng == nullptr) {
+        return 0U;
+    }
+
+    const std::uint64_t old_state = rng->state;
+    rng->state = old_state * PCG32_MULTIPLIER + rng->increment;
+
+    const std::uint32_t xorshifted = static_cast<std::uint32_t>(((old_state >> 18U) ^ old_state) >> 27U);
+    const std::uint32_t rotation = static_cast<std::uint32_t>(old_state >> 59U);
+    return static_cast<std::uint32_t>((xorshifted >> rotation) | (xorshifted << ((0U - rotation) & 31U)));
+}
+
+void seed_rng(DeterministicRng* rng, std::uint64_t seed, std::uint64_t sequence) {
+    if (rng == nullptr) {
+        return;
+    }
+
+    rng->state = 0U;
+    rng->increment = (sequence << 1U) | 1U;
+    static_cast<void>(rng_next_u32(rng));
+    rng->state += seed;
+    static_cast<void>(rng_next_u32(rng));
+}
+
+std::uint64_t rng_next_u64(DeterministicRng* rng) {
+    const std::uint64_t high = static_cast<std::uint64_t>(rng_next_u32(rng));
+    const std::uint64_t low = static_cast<std::uint64_t>(rng_next_u32(rng));
+    return (high << 32U) | low;
+}
+
+double rng_uniform_01(DeterministicRng* rng) {
+    const std::uint64_t random_53_bits = rng_next_u64(rng) >> 11U;
+    return static_cast<double>(random_53_bits) / TWO_POW_53;
+}
+
+double rng_uniform(DeterministicRng* rng, double minimum, double maximum) {
+    if (!(maximum > minimum)) {
+        return minimum;
+    }
+    return minimum + (maximum - minimum) * rng_uniform_01(rng);
+}
+
+} // namespace gnss_sim

--- a/src/core/deterministic_rng.h
+++ b/src/core/deterministic_rng.h
@@ -1,0 +1,21 @@
+#ifndef GNSS_SIM_SRC_CORE_DETERMINISTIC_RNG_H_
+#define GNSS_SIM_SRC_CORE_DETERMINISTIC_RNG_H_
+
+#include <cstdint>
+
+namespace gnss_sim {
+
+struct DeterministicRng {
+    std::uint64_t state;
+    std::uint64_t increment;
+};
+
+void seed_rng(DeterministicRng* rng, std::uint64_t seed, std::uint64_t sequence = 54U);
+std::uint32_t rng_next_u32(DeterministicRng* rng);
+std::uint64_t rng_next_u64(DeterministicRng* rng);
+double rng_uniform_01(DeterministicRng* rng);
+double rng_uniform(DeterministicRng* rng, double minimum, double maximum);
+
+} // namespace gnss_sim
+
+#endif // GNSS_SIM_SRC_CORE_DETERMINISTIC_RNG_H_

--- a/src/core/sim_config.cpp
+++ b/src/core/sim_config.cpp
@@ -1,1 +1,404 @@
-// Configuration implementation is introduced by issue #3.
+#include "gnss_sim/sim_config.h"
+
+#include "gnss_sim/sim_time.h"
+
+#include <cJSON.h>
+
+#include <cmath>
+#include <cstring>
+#include <fstream>
+#include <iterator>
+#include <limits>
+#include <string>
+
+namespace gnss_sim {
+namespace {
+
+constexpr double MAX_EXACT_JSON_INTEGER = 9007199254740991.0;
+
+void set_error(std::string* error_message, const std::string& message) {
+    if (error_message != nullptr) {
+        *error_message = message;
+    }
+}
+
+bool is_allowed_key(const char* key, const char* const* allowed_keys, std::size_t allowed_key_count) {
+    for (std::size_t index = 0; index < allowed_key_count; ++index) {
+        if (std::strcmp(key, allowed_keys[index]) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool validate_object_keys(const cJSON* object, const char* section_name, const char* const* allowed_keys,
+                          std::size_t allowed_key_count, std::string* error_message) {
+    if (!cJSON_IsObject(object)) {
+        set_error(error_message, std::string(section_name) + " must be a JSON object");
+        return false;
+    }
+
+    for (const cJSON* item = object->child; item != nullptr; item = item->next) {
+        if (item->string == nullptr || !is_allowed_key(item->string, allowed_keys, allowed_key_count)) {
+            set_error(error_message, std::string("unsupported key in ") + section_name + ": " +
+                                         (item->string == nullptr ? "<null>" : item->string));
+            return false;
+        }
+        for (const cJSON* previous = object->child; previous != item; previous = previous->next) {
+            if (previous->string != nullptr && std::strcmp(previous->string, item->string) == 0) {
+                set_error(error_message, std::string("duplicate key in ") + section_name + ": " + item->string);
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+bool read_optional_number(const cJSON* object, const char* key, double* value, std::string* error_message) {
+    const cJSON* item = cJSON_GetObjectItemCaseSensitive(object, key);
+    if (item == nullptr) {
+        return true;
+    }
+    if (!cJSON_IsNumber(item) || !std::isfinite(item->valuedouble)) {
+        set_error(error_message, std::string(key) + " must be a finite JSON number");
+        return false;
+    }
+    *value = item->valuedouble;
+    return true;
+}
+
+bool read_optional_int(const cJSON* object, const char* key, int* value, std::string* error_message) {
+    double number = static_cast<double>(*value);
+    if (!read_optional_number(object, key, &number, error_message)) {
+        return false;
+    }
+    if (cJSON_GetObjectItemCaseSensitive(object, key) == nullptr) {
+        return true;
+    }
+    if (std::floor(number) != number || number < static_cast<double>(std::numeric_limits<int>::min()) ||
+        number > static_cast<double>(std::numeric_limits<int>::max())) {
+        set_error(error_message, std::string(key) + " must be an integer in range");
+        return false;
+    }
+    *value = static_cast<int>(number);
+    return true;
+}
+
+bool read_optional_bool(const cJSON* object, const char* key, bool* value, std::string* error_message) {
+    const cJSON* item = cJSON_GetObjectItemCaseSensitive(object, key);
+    if (item == nullptr) {
+        return true;
+    }
+    if (!cJSON_IsBool(item)) {
+        set_error(error_message, std::string(key) + " must be a JSON boolean");
+        return false;
+    }
+    *value = cJSON_IsTrue(item) != 0;
+    return true;
+}
+
+bool read_optional_string(const cJSON* object, const char* key, const char** value, std::string* error_message) {
+    const cJSON* item = cJSON_GetObjectItemCaseSensitive(object, key);
+    if (item == nullptr) {
+        return true;
+    }
+    if (!cJSON_IsString(item) || item->valuestring == nullptr) {
+        set_error(error_message, std::string(key) + " must be a JSON string");
+        return false;
+    }
+    *value = item->valuestring;
+    return true;
+}
+
+bool seconds_to_ns(double seconds, const char* field_name, std::int64_t* value_ns, std::string* error_message) {
+    if (!std::isfinite(seconds) || seconds < 0.0) {
+        set_error(error_message, std::string(field_name) + " must be finite and non-negative");
+        return false;
+    }
+
+    const long double scaled =
+        static_cast<long double>(seconds) * static_cast<long double>(NANOSECONDS_PER_SECOND);
+    if (scaled > static_cast<long double>(std::numeric_limits<std::int64_t>::max())) {
+        set_error(error_message, std::string(field_name) + " is too large");
+        return false;
+    }
+    *value_ns = static_cast<std::int64_t>(std::llround(scaled));
+    return true;
+}
+
+bool parse_scenario(const char* value, ScenarioType* scenario, std::string* error_message) {
+    if (std::strcmp(value, "KS") == 0) {
+        *scenario = ScenarioType::KS;
+        return true;
+    }
+    if (std::strcmp(value, "REA") == 0) {
+        *scenario = ScenarioType::REA;
+        return true;
+    }
+    if (std::strcmp(value, "TTFF") == 0) {
+        *scenario = ScenarioType::TTFF;
+        return true;
+    }
+    set_error(error_message, std::string("unsupported scenario: ") + value);
+    return false;
+}
+
+bool parse_startup_mode(const char* value, StartupMode* startup_mode, std::string* error_message) {
+    if (std::strcmp(value, "HOT") == 0) {
+        *startup_mode = StartupMode::HOT;
+        return true;
+    }
+    if (std::strcmp(value, "WARM") == 0) {
+        *startup_mode = StartupMode::WARM;
+        return true;
+    }
+    if (std::strcmp(value, "COLD") == 0) {
+        *startup_mode = StartupMode::COLD;
+        return true;
+    }
+    set_error(error_message, std::string("unsupported TTFF startup mode: ") + value);
+    return false;
+}
+
+bool parse_receiver(const cJSON* root, SimConfig* config, std::string* error_message) {
+    const cJSON* receiver = cJSON_GetObjectItemCaseSensitive(root, "receiver");
+    if (receiver == nullptr) {
+        return true;
+    }
+    const char* const allowed_keys[] = {"latitude_deg", "longitude_deg", "height_m"};
+    if (!validate_object_keys(receiver, "receiver", allowed_keys, 3U, error_message)) {
+        return false;
+    }
+    return read_optional_number(receiver, "latitude_deg", &config->receiver.latitude_deg, error_message) &&
+           read_optional_number(receiver, "longitude_deg", &config->receiver.longitude_deg, error_message) &&
+           read_optional_number(receiver, "height_m", &config->receiver.height_m, error_message);
+}
+
+bool parse_ttff(const cJSON* root, SimConfig* config, std::string* error_message) {
+    const cJSON* ttff = cJSON_GetObjectItemCaseSensitive(root, "ttff");
+    if (ttff == nullptr) {
+        return true;
+    }
+    const char* const allowed_keys[] = {"startup_mode", "power_on_sec", "power_off_sec"};
+    if (!validate_object_keys(ttff, "ttff", allowed_keys, 3U, error_message)) {
+        return false;
+    }
+
+    const char* startup_mode = startup_mode_name(config->ttff.startup_mode);
+    if (!read_optional_string(ttff, "startup_mode", &startup_mode, error_message) ||
+        !parse_startup_mode(startup_mode, &config->ttff.startup_mode, error_message)) {
+        return false;
+    }
+
+    double power_on_sec = static_cast<double>(config->ttff.power_on_ns) / static_cast<double>(NANOSECONDS_PER_SECOND);
+    double power_off_sec =
+        static_cast<double>(config->ttff.power_off_ns) / static_cast<double>(NANOSECONDS_PER_SECOND);
+    return read_optional_number(ttff, "power_on_sec", &power_on_sec, error_message) &&
+           read_optional_number(ttff, "power_off_sec", &power_off_sec, error_message) &&
+           seconds_to_ns(power_on_sec, "ttff.power_on_sec", &config->ttff.power_on_ns, error_message) &&
+           seconds_to_ns(power_off_sec, "ttff.power_off_sec", &config->ttff.power_off_ns, error_message);
+}
+
+bool parse_rea(const cJSON* root, SimConfig* config, std::string* error_message) {
+    const cJSON* rea = cJSON_GetObjectItemCaseSensitive(root, "rea");
+    if (rea == nullptr) {
+        return true;
+    }
+    const char* const allowed_keys[] = {"signal_on_sec", "signal_off_sec"};
+    if (!validate_object_keys(rea, "rea", allowed_keys, 2U, error_message)) {
+        return false;
+    }
+
+    double signal_on_sec =
+        static_cast<double>(config->rea.signal_on_ns) / static_cast<double>(NANOSECONDS_PER_SECOND);
+    double signal_off_sec =
+        static_cast<double>(config->rea.signal_off_ns) / static_cast<double>(NANOSECONDS_PER_SECOND);
+    return read_optional_number(rea, "signal_on_sec", &signal_on_sec, error_message) &&
+           read_optional_number(rea, "signal_off_sec", &signal_off_sec, error_message) &&
+           seconds_to_ns(signal_on_sec, "rea.signal_on_sec", &config->rea.signal_on_ns, error_message) &&
+           seconds_to_ns(signal_off_sec, "rea.signal_off_sec", &config->rea.signal_off_ns, error_message);
+}
+
+bool parse_seed(const cJSON* root, SimConfig* config, std::string* error_message) {
+    const cJSON* seed = cJSON_GetObjectItemCaseSensitive(root, "seed");
+    if (seed == nullptr) {
+        return true;
+    }
+    if (!cJSON_IsNumber(seed) || !std::isfinite(seed->valuedouble) ||
+        std::floor(seed->valuedouble) != seed->valuedouble || seed->valuedouble < 0.0 ||
+        seed->valuedouble > MAX_EXACT_JSON_INTEGER) {
+        set_error(error_message, "seed must be an integer from 0 through 2^53-1");
+        return false;
+    }
+    config->seed = static_cast<std::uint64_t>(seed->valuedouble);
+    return true;
+}
+
+} // namespace
+
+SimConfig default_sim_config() {
+    SimConfig config{};
+    config.schema_version = 1;
+    config.scenario = ScenarioType::KS;
+    config.duration_ns = 28800LL * NANOSECONDS_PER_SECOND;
+    config.sampling_rate_hz = 10;
+    config.elevation_mask_deg = 3.0;
+    config.output_eph = true;
+    config.output_ion = true;
+    config.measurement_noise_enabled = false;
+    config.multipath_enabled = false;
+    config.receiver_clock_bias_m = 0.0;
+    config.receiver_clock_drift_mps = 0.0;
+    config.receiver = {20.0, 120.0, 100.0};
+    config.ttff = {StartupMode::HOT, 300LL * NANOSECONDS_PER_SECOND, 30LL * NANOSECONDS_PER_SECOND};
+    config.rea = {300LL * NANOSECONDS_PER_SECOND, 10LL * NANOSECONDS_PER_SECOND};
+    config.seed = 1U;
+    return config;
+}
+
+bool validate_sim_config(const SimConfig& config, std::string* error_message) {
+    std::int64_t interval_ns = 0;
+    if (config.schema_version != 1) {
+        set_error(error_message, "schema_version must be 1");
+        return false;
+    }
+    if (config.duration_ns <= 0) {
+        set_error(error_message, "duration_sec must be greater than zero");
+        return false;
+    }
+    if (!sampling_interval_ns(config.sampling_rate_hz, &interval_ns)) {
+        set_error(error_message, "sampling_rate_hz must be one of 1, 5, 10, 20, 50");
+        return false;
+    }
+    if (!std::isfinite(config.elevation_mask_deg) || config.elevation_mask_deg < 0.0 ||
+        config.elevation_mask_deg > 90.0) {
+        set_error(error_message, "elevation_mask_deg must be within [0, 90]");
+        return false;
+    }
+    if (config.measurement_noise_enabled) {
+        set_error(error_message, "measurement noise is not supported in V1");
+        return false;
+    }
+    if (config.multipath_enabled) {
+        set_error(error_message, "multipath is not supported in V1");
+        return false;
+    }
+    if (config.receiver_clock_bias_m != 0.0 || config.receiver_clock_drift_mps != 0.0) {
+        set_error(error_message, "receiver clock bias and drift must be zero in V1");
+        return false;
+    }
+    if (!std::isfinite(config.receiver.latitude_deg) || config.receiver.latitude_deg < -90.0 ||
+        config.receiver.latitude_deg > 90.0) {
+        set_error(error_message, "receiver.latitude_deg must be within [-90, 90]");
+        return false;
+    }
+    if (!std::isfinite(config.receiver.longitude_deg) || config.receiver.longitude_deg < -180.0 ||
+        config.receiver.longitude_deg > 180.0 || !std::isfinite(config.receiver.height_m)) {
+        set_error(error_message, "receiver longitude/height is invalid");
+        return false;
+    }
+    if (config.ttff.power_on_ns <= 0 || config.ttff.power_off_ns <= 0) {
+        set_error(error_message, "TTFF power on/off durations must be greater than zero");
+        return false;
+    }
+    if (config.rea.signal_on_ns <= 0 || config.rea.signal_off_ns <= 0) {
+        set_error(error_message, "REA signal on/off durations must be greater than zero");
+        return false;
+    }
+    return true;
+}
+
+bool load_sim_config_json(const char* file_path, SimConfig* config, std::string* error_message) {
+    if (file_path == nullptr || config == nullptr) {
+        set_error(error_message, "config path/output pointer must not be null");
+        return false;
+    }
+
+    std::ifstream input(file_path, std::ios::binary);
+    if (!input) {
+        set_error(error_message, std::string("failed to open config file: ") + file_path);
+        return false;
+    }
+    const std::string text((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
+    if (text.empty()) {
+        set_error(error_message, "config file is empty");
+        return false;
+    }
+
+    cJSON* root = cJSON_ParseWithLength(text.c_str(), text.size());
+    if (root == nullptr) {
+        const char* parse_error = cJSON_GetErrorPtr();
+        std::string message = "invalid JSON";
+        if (parse_error != nullptr) {
+            message += ": near ";
+            message += parse_error;
+        }
+        set_error(error_message, message);
+        return false;
+    }
+
+    const char* const allowed_keys[] = {"schema_version",          "scenario",          "duration_sec",
+                                        "sampling_rate_hz",       "elevation_mask_deg", "output_eph",
+                                        "output_ion",              "measurement_noise_enabled",
+                                        "multipath_enabled",       "receiver_clock_bias_m",
+                                        "receiver_clock_drift_mps", "receiver",          "ttff",
+                                        "rea",                     "seed"};
+
+    SimConfig parsed = default_sim_config();
+    bool success = validate_object_keys(root, "root", allowed_keys, 15U, error_message);
+
+    double duration_sec = static_cast<double>(parsed.duration_ns) / static_cast<double>(NANOSECONDS_PER_SECOND);
+    const char* scenario_name = scenario_type_name(parsed.scenario);
+    if (success) {
+        success = read_optional_int(root, "schema_version", &parsed.schema_version, error_message) &&
+                  read_optional_string(root, "scenario", &scenario_name, error_message) &&
+                  parse_scenario(scenario_name, &parsed.scenario, error_message) &&
+                  read_optional_number(root, "duration_sec", &duration_sec, error_message) &&
+                  seconds_to_ns(duration_sec, "duration_sec", &parsed.duration_ns, error_message) &&
+                  read_optional_int(root, "sampling_rate_hz", &parsed.sampling_rate_hz, error_message) &&
+                  read_optional_number(root, "elevation_mask_deg", &parsed.elevation_mask_deg, error_message) &&
+                  read_optional_bool(root, "output_eph", &parsed.output_eph, error_message) &&
+                  read_optional_bool(root, "output_ion", &parsed.output_ion, error_message) &&
+                  read_optional_bool(root, "measurement_noise_enabled", &parsed.measurement_noise_enabled, error_message) &&
+                  read_optional_bool(root, "multipath_enabled", &parsed.multipath_enabled, error_message) &&
+                  read_optional_number(root, "receiver_clock_bias_m", &parsed.receiver_clock_bias_m, error_message) &&
+                  read_optional_number(root, "receiver_clock_drift_mps", &parsed.receiver_clock_drift_mps, error_message) &&
+                  parse_receiver(root, &parsed, error_message) && parse_ttff(root, &parsed, error_message) &&
+                  parse_rea(root, &parsed, error_message) && parse_seed(root, &parsed, error_message) &&
+                  validate_sim_config(parsed, error_message);
+    }
+
+    cJSON_Delete(root);
+    if (!success) {
+        return false;
+    }
+
+    *config = parsed;
+    return true;
+}
+
+const char* scenario_type_name(ScenarioType scenario) {
+    switch (scenario) {
+    case ScenarioType::KS:
+        return "KS";
+    case ScenarioType::REA:
+        return "REA";
+    case ScenarioType::TTFF:
+        return "TTFF";
+    }
+    return "UNKNOWN";
+}
+
+const char* startup_mode_name(StartupMode startup_mode) {
+    switch (startup_mode) {
+    case StartupMode::HOT:
+        return "HOT";
+    case StartupMode::WARM:
+        return "WARM";
+    case StartupMode::COLD:
+        return "COLD";
+    }
+    return "UNKNOWN";
+}
+
+} // namespace gnss_sim

--- a/src/core/sim_config.cpp
+++ b/src/core/sim_config.cpp
@@ -3,7 +3,6 @@
 #include "gnss_sim/sim_time.h"
 
 #include <cJSON.h>
-
 #include <cmath>
 #include <cstring>
 #include <fstream>
@@ -116,8 +115,7 @@ bool seconds_to_ns(double seconds, const char* field_name, std::int64_t* value_n
         return false;
     }
 
-    const long double scaled =
-        static_cast<long double>(seconds) * static_cast<long double>(NANOSECONDS_PER_SECOND);
+    const long double scaled = static_cast<long double>(seconds) * static_cast<long double>(NANOSECONDS_PER_SECOND);
     if (scaled > static_cast<long double>(std::numeric_limits<std::int64_t>::max())) {
         set_error(error_message, std::string(field_name) + " is too large");
         return false;
@@ -191,8 +189,7 @@ bool parse_ttff(const cJSON* root, SimConfig* config, std::string* error_message
     }
 
     double power_on_sec = static_cast<double>(config->ttff.power_on_ns) / static_cast<double>(NANOSECONDS_PER_SECOND);
-    double power_off_sec =
-        static_cast<double>(config->ttff.power_off_ns) / static_cast<double>(NANOSECONDS_PER_SECOND);
+    double power_off_sec = static_cast<double>(config->ttff.power_off_ns) / static_cast<double>(NANOSECONDS_PER_SECOND);
     return read_optional_number(ttff, "power_on_sec", &power_on_sec, error_message) &&
            read_optional_number(ttff, "power_off_sec", &power_off_sec, error_message) &&
            seconds_to_ns(power_on_sec, "ttff.power_on_sec", &config->ttff.power_on_ns, error_message) &&
@@ -209,8 +206,7 @@ bool parse_rea(const cJSON* root, SimConfig* config, std::string* error_message)
         return false;
     }
 
-    double signal_on_sec =
-        static_cast<double>(config->rea.signal_on_ns) / static_cast<double>(NANOSECONDS_PER_SECOND);
+    double signal_on_sec = static_cast<double>(config->rea.signal_on_ns) / static_cast<double>(NANOSECONDS_PER_SECOND);
     double signal_off_sec =
         static_cast<double>(config->rea.signal_off_ns) / static_cast<double>(NANOSECONDS_PER_SECOND);
     return read_optional_number(rea, "signal_on_sec", &signal_on_sec, error_message) &&
@@ -337,12 +333,21 @@ bool load_sim_config_json(const char* file_path, SimConfig* config, std::string*
         return false;
     }
 
-    const char* const allowed_keys[] = {"schema_version",          "scenario",          "duration_sec",
-                                        "sampling_rate_hz",       "elevation_mask_deg", "output_eph",
-                                        "output_ion",              "measurement_noise_enabled",
-                                        "multipath_enabled",       "receiver_clock_bias_m",
-                                        "receiver_clock_drift_mps", "receiver",          "ttff",
-                                        "rea",                     "seed"};
+    const char* const allowed_keys[] = {"schema_version",
+                                        "scenario",
+                                        "duration_sec",
+                                        "sampling_rate_hz",
+                                        "elevation_mask_deg",
+                                        "output_eph",
+                                        "output_ion",
+                                        "measurement_noise_enabled",
+                                        "multipath_enabled",
+                                        "receiver_clock_bias_m",
+                                        "receiver_clock_drift_mps",
+                                        "receiver",
+                                        "ttff",
+                                        "rea",
+                                        "seed"};
 
     SimConfig parsed = default_sim_config();
     bool success = validate_object_keys(root, "root", allowed_keys, 15U, error_message);
@@ -350,22 +355,23 @@ bool load_sim_config_json(const char* file_path, SimConfig* config, std::string*
     double duration_sec = static_cast<double>(parsed.duration_ns) / static_cast<double>(NANOSECONDS_PER_SECOND);
     const char* scenario_name = scenario_type_name(parsed.scenario);
     if (success) {
-        success = read_optional_int(root, "schema_version", &parsed.schema_version, error_message) &&
-                  read_optional_string(root, "scenario", &scenario_name, error_message) &&
-                  parse_scenario(scenario_name, &parsed.scenario, error_message) &&
-                  read_optional_number(root, "duration_sec", &duration_sec, error_message) &&
-                  seconds_to_ns(duration_sec, "duration_sec", &parsed.duration_ns, error_message) &&
-                  read_optional_int(root, "sampling_rate_hz", &parsed.sampling_rate_hz, error_message) &&
-                  read_optional_number(root, "elevation_mask_deg", &parsed.elevation_mask_deg, error_message) &&
-                  read_optional_bool(root, "output_eph", &parsed.output_eph, error_message) &&
-                  read_optional_bool(root, "output_ion", &parsed.output_ion, error_message) &&
-                  read_optional_bool(root, "measurement_noise_enabled", &parsed.measurement_noise_enabled, error_message) &&
-                  read_optional_bool(root, "multipath_enabled", &parsed.multipath_enabled, error_message) &&
-                  read_optional_number(root, "receiver_clock_bias_m", &parsed.receiver_clock_bias_m, error_message) &&
-                  read_optional_number(root, "receiver_clock_drift_mps", &parsed.receiver_clock_drift_mps, error_message) &&
-                  parse_receiver(root, &parsed, error_message) && parse_ttff(root, &parsed, error_message) &&
-                  parse_rea(root, &parsed, error_message) && parse_seed(root, &parsed, error_message) &&
-                  validate_sim_config(parsed, error_message);
+        success =
+            read_optional_int(root, "schema_version", &parsed.schema_version, error_message) &&
+            read_optional_string(root, "scenario", &scenario_name, error_message) &&
+            parse_scenario(scenario_name, &parsed.scenario, error_message) &&
+            read_optional_number(root, "duration_sec", &duration_sec, error_message) &&
+            seconds_to_ns(duration_sec, "duration_sec", &parsed.duration_ns, error_message) &&
+            read_optional_int(root, "sampling_rate_hz", &parsed.sampling_rate_hz, error_message) &&
+            read_optional_number(root, "elevation_mask_deg", &parsed.elevation_mask_deg, error_message) &&
+            read_optional_bool(root, "output_eph", &parsed.output_eph, error_message) &&
+            read_optional_bool(root, "output_ion", &parsed.output_ion, error_message) &&
+            read_optional_bool(root, "measurement_noise_enabled", &parsed.measurement_noise_enabled, error_message) &&
+            read_optional_bool(root, "multipath_enabled", &parsed.multipath_enabled, error_message) &&
+            read_optional_number(root, "receiver_clock_bias_m", &parsed.receiver_clock_bias_m, error_message) &&
+            read_optional_number(root, "receiver_clock_drift_mps", &parsed.receiver_clock_drift_mps, error_message) &&
+            parse_receiver(root, &parsed, error_message) && parse_ttff(root, &parsed, error_message) &&
+            parse_rea(root, &parsed, error_message) && parse_seed(root, &parsed, error_message) &&
+            validate_sim_config(parsed, error_message);
     }
 
     cJSON_Delete(root);
@@ -379,24 +385,24 @@ bool load_sim_config_json(const char* file_path, SimConfig* config, std::string*
 
 const char* scenario_type_name(ScenarioType scenario) {
     switch (scenario) {
-    case ScenarioType::KS:
-        return "KS";
-    case ScenarioType::REA:
-        return "REA";
-    case ScenarioType::TTFF:
-        return "TTFF";
+        case ScenarioType::KS:
+            return "KS";
+        case ScenarioType::REA:
+            return "REA";
+        case ScenarioType::TTFF:
+            return "TTFF";
     }
     return "UNKNOWN";
 }
 
 const char* startup_mode_name(StartupMode startup_mode) {
     switch (startup_mode) {
-    case StartupMode::HOT:
-        return "HOT";
-    case StartupMode::WARM:
-        return "WARM";
-    case StartupMode::COLD:
-        return "COLD";
+        case StartupMode::HOT:
+            return "HOT";
+        case StartupMode::WARM:
+            return "WARM";
+        case StartupMode::COLD:
+            return "COLD";
     }
     return "UNKNOWN";
 }

--- a/src/core/sim_time.cpp
+++ b/src/core/sim_time.cpp
@@ -128,23 +128,23 @@ bool sampling_interval_ns(int sampling_rate_hz, std::int64_t* interval_ns) {
     }
 
     switch (sampling_rate_hz) {
-    case 1:
-        *interval_ns = 1000000000LL;
-        return true;
-    case 5:
-        *interval_ns = 200000000LL;
-        return true;
-    case 10:
-        *interval_ns = 100000000LL;
-        return true;
-    case 20:
-        *interval_ns = 50000000LL;
-        return true;
-    case 50:
-        *interval_ns = 20000000LL;
-        return true;
-    default:
-        return false;
+        case 1:
+            *interval_ns = 1000000000LL;
+            return true;
+        case 5:
+            *interval_ns = 200000000LL;
+            return true;
+        case 10:
+            *interval_ns = 100000000LL;
+            return true;
+        case 20:
+            *interval_ns = 50000000LL;
+            return true;
+        case 50:
+            *interval_ns = 20000000LL;
+            return true;
+        default:
+            return false;
     }
 }
 
@@ -155,7 +155,8 @@ bool epoch_time_at_index(const SimTime& start_time, int sampling_rate_hz, std::u
         return false;
     }
 
-    const std::uint64_t maximum_index = static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max() / interval_ns);
+    const std::uint64_t maximum_index =
+        static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max() / interval_ns);
     if (epoch_index > maximum_index) {
         return false;
     }

--- a/src/core/sim_time.cpp
+++ b/src/core/sim_time.cpp
@@ -1,1 +1,195 @@
-// Integer simulation time implementation is introduced by issue #3.
+#include "gnss_sim/sim_time.h"
+
+#include <cmath>
+#include <limits>
+
+namespace gnss_sim {
+namespace {
+
+bool checked_week_adjustment(int gps_week, std::int64_t week_adjustment, int* normalized_week) {
+    if (normalized_week == nullptr) {
+        return false;
+    }
+
+    const std::int64_t week = static_cast<std::int64_t>(gps_week) + week_adjustment;
+    if (week < 0 || week > static_cast<std::int64_t>(std::numeric_limits<int>::max())) {
+        return false;
+    }
+
+    *normalized_week = static_cast<int>(week);
+    return true;
+}
+
+bool valid_normalized_time(const SimTime& time) {
+    return time.gps_week >= 0 && time.tow_ns >= 0 && time.tow_ns < GPS_WEEK_NANOSECONDS;
+}
+
+} // namespace
+
+bool normalize_sim_time(int gps_week, std::int64_t tow_ns, SimTime* out_time) {
+    if (out_time == nullptr || gps_week < 0) {
+        return false;
+    }
+
+    std::int64_t week_adjustment = tow_ns / GPS_WEEK_NANOSECONDS;
+    std::int64_t normalized_tow_ns = tow_ns % GPS_WEEK_NANOSECONDS;
+    if (normalized_tow_ns < 0) {
+        normalized_tow_ns += GPS_WEEK_NANOSECONDS;
+        --week_adjustment;
+    }
+
+    int normalized_week = 0;
+    if (!checked_week_adjustment(gps_week, week_adjustment, &normalized_week)) {
+        return false;
+    }
+
+    out_time->gps_week = normalized_week;
+    out_time->tow_ns = normalized_tow_ns;
+    return true;
+}
+
+bool sim_time_from_week_sow(int gps_week, double sow_sec, SimTime* out_time) {
+    if (out_time == nullptr || gps_week < 0 || !std::isfinite(sow_sec)) {
+        return false;
+    }
+
+    const long double tow_ns_value =
+        static_cast<long double>(sow_sec) * static_cast<long double>(NANOSECONDS_PER_SECOND);
+    const long double minimum = static_cast<long double>(std::numeric_limits<std::int64_t>::min());
+    const long double maximum = static_cast<long double>(std::numeric_limits<std::int64_t>::max());
+    if (tow_ns_value < minimum || tow_ns_value > maximum) {
+        return false;
+    }
+
+    const std::int64_t tow_ns = static_cast<std::int64_t>(std::llround(tow_ns_value));
+    return normalize_sim_time(gps_week, tow_ns, out_time);
+}
+
+double sim_time_sow_sec(const SimTime& time) {
+    return static_cast<double>(time.tow_ns) / static_cast<double>(NANOSECONDS_PER_SECOND);
+}
+
+int compare_sim_time(const SimTime& lhs, const SimTime& rhs) {
+    if (lhs.gps_week < rhs.gps_week) {
+        return -1;
+    }
+    if (lhs.gps_week > rhs.gps_week) {
+        return 1;
+    }
+    if (lhs.tow_ns < rhs.tow_ns) {
+        return -1;
+    }
+    if (lhs.tow_ns > rhs.tow_ns) {
+        return 1;
+    }
+    return 0;
+}
+
+bool add_time_ns(const SimTime& time, std::int64_t delta_ns, SimTime* out_time) {
+    if (out_time == nullptr || !valid_normalized_time(time)) {
+        return false;
+    }
+
+    const std::int64_t whole_weeks = delta_ns / GPS_WEEK_NANOSECONDS;
+    const std::int64_t remainder_ns = delta_ns % GPS_WEEK_NANOSECONDS;
+    int adjusted_week = 0;
+    if (!checked_week_adjustment(time.gps_week, whole_weeks, &adjusted_week)) {
+        return false;
+    }
+
+    return normalize_sim_time(adjusted_week, time.tow_ns + remainder_ns, out_time);
+}
+
+bool difference_time_ns(const SimTime& lhs, const SimTime& rhs, std::int64_t* difference_ns) {
+    if (difference_ns == nullptr || !valid_normalized_time(lhs) || !valid_normalized_time(rhs)) {
+        return false;
+    }
+
+    const std::int64_t week_delta = static_cast<std::int64_t>(lhs.gps_week) - static_cast<std::int64_t>(rhs.gps_week);
+    const std::int64_t max_week_delta = std::numeric_limits<std::int64_t>::max() / GPS_WEEK_NANOSECONDS;
+    if (week_delta > max_week_delta || week_delta < -max_week_delta) {
+        return false;
+    }
+
+    const std::int64_t week_ns = week_delta * GPS_WEEK_NANOSECONDS;
+    const std::int64_t tow_delta = lhs.tow_ns - rhs.tow_ns;
+    if ((tow_delta > 0 && week_ns > std::numeric_limits<std::int64_t>::max() - tow_delta) ||
+        (tow_delta < 0 && week_ns < std::numeric_limits<std::int64_t>::min() - tow_delta)) {
+        return false;
+    }
+
+    *difference_ns = week_ns + tow_delta;
+    return true;
+}
+
+bool sampling_interval_ns(int sampling_rate_hz, std::int64_t* interval_ns) {
+    if (interval_ns == nullptr) {
+        return false;
+    }
+
+    switch (sampling_rate_hz) {
+    case 1:
+        *interval_ns = 1000000000LL;
+        return true;
+    case 5:
+        *interval_ns = 200000000LL;
+        return true;
+    case 10:
+        *interval_ns = 100000000LL;
+        return true;
+    case 20:
+        *interval_ns = 50000000LL;
+        return true;
+    case 50:
+        *interval_ns = 20000000LL;
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool epoch_time_at_index(const SimTime& start_time, int sampling_rate_hz, std::uint64_t epoch_index,
+                         SimTime* epoch_time) {
+    std::int64_t interval_ns = 0;
+    if (epoch_time == nullptr || !sampling_interval_ns(sampling_rate_hz, &interval_ns)) {
+        return false;
+    }
+
+    const std::uint64_t maximum_index = static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max() / interval_ns);
+    if (epoch_index > maximum_index) {
+        return false;
+    }
+
+    const std::int64_t delta_ns = static_cast<std::int64_t>(epoch_index) * interval_ns;
+    return add_time_ns(start_time, delta_ns, epoch_time);
+}
+
+bool epoch_index_at_or_after(const SimTime& start_time, const SimTime& event_time, int sampling_rate_hz,
+                             std::uint64_t* epoch_index) {
+    std::int64_t interval_ns = 0;
+    std::int64_t delta_ns = 0;
+    if (epoch_index == nullptr || !sampling_interval_ns(sampling_rate_hz, &interval_ns) ||
+        !difference_time_ns(event_time, start_time, &delta_ns)) {
+        return false;
+    }
+
+    if (delta_ns <= 0) {
+        *epoch_index = 0U;
+        return true;
+    }
+
+    *epoch_index = static_cast<std::uint64_t>((delta_ns - 1) / interval_ns + 1);
+    return true;
+}
+
+bool epoch_count_for_duration(std::int64_t duration_ns, int sampling_rate_hz, std::uint64_t* epoch_count) {
+    std::int64_t interval_ns = 0;
+    if (epoch_count == nullptr || duration_ns <= 0 || !sampling_interval_ns(sampling_rate_hz, &interval_ns)) {
+        return false;
+    }
+
+    *epoch_count = static_cast<std::uint64_t>((duration_ns - 1) / interval_ns + 1);
+    return true;
+}
+
+} // namespace gnss_sim

--- a/tests/unit/test_deterministic_rng.cpp
+++ b/tests/unit/test_deterministic_rng.cpp
@@ -8,8 +8,7 @@ TEST(DeterministicRng, Pcg32ReferenceSequence) {
     gnss_sim::DeterministicRng rng{};
     gnss_sim::seed_rng(&rng, 42U, 54U);
 
-    const std::uint32_t expected[] = {2707161783U, 2068313097U, 3122475824U,
-                                      2211639955U, 3215226955U, 3421331566U};
+    const std::uint32_t expected[] = {2707161783U, 2068313097U, 3122475824U, 2211639955U, 3215226955U, 3421331566U};
     for (const std::uint32_t value : expected) {
         EXPECT_EQ(gnss_sim::rng_next_u32(&rng), value);
     }

--- a/tests/unit/test_deterministic_rng.cpp
+++ b/tests/unit/test_deterministic_rng.cpp
@@ -1,0 +1,29 @@
+#include "core/deterministic_rng.h"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+TEST(DeterministicRng, Pcg32ReferenceSequence) {
+    gnss_sim::DeterministicRng rng{};
+    gnss_sim::seed_rng(&rng, 42U, 54U);
+
+    const std::uint32_t expected[] = {2707161783U, 2068313097U, 3122475824U,
+                                      2211639955U, 3215226955U, 3421331566U};
+    for (const std::uint32_t value : expected) {
+        EXPECT_EQ(gnss_sim::rng_next_u32(&rng), value);
+    }
+}
+
+TEST(DeterministicRng, SameSeedProducesSameUniformSequence) {
+    gnss_sim::DeterministicRng first{};
+    gnss_sim::DeterministicRng second{};
+    gnss_sim::seed_rng(&first, 123456U);
+    gnss_sim::seed_rng(&second, 123456U);
+
+    for (int index = 0; index < 100; ++index) {
+        EXPECT_DOUBLE_EQ(gnss_sim::rng_uniform_01(&first), gnss_sim::rng_uniform_01(&second));
+    }
+}
+
+} // namespace

--- a/tests/unit/test_sim_config.cpp
+++ b/tests/unit/test_sim_config.cpp
@@ -16,7 +16,7 @@ void write_test_config(const char* text) {
 }
 
 class SimConfigTest : public ::testing::Test {
-protected:
+  protected:
     void TearDown() override {
         static_cast<void>(std::remove(TEST_CONFIG_PATH));
     }

--- a/tests/unit/test_sim_config.cpp
+++ b/tests/unit/test_sim_config.cpp
@@ -1,0 +1,77 @@
+#include "gnss_sim/sim_config.h"
+#include "gnss_sim/sim_time.h"
+
+#include <cstdio>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <string>
+
+namespace {
+
+constexpr const char* TEST_CONFIG_PATH = "gnss_sim_test_config.json";
+
+void write_test_config(const char* text) {
+    std::ofstream output(TEST_CONFIG_PATH, std::ios::binary | std::ios::trunc);
+    output << text;
+}
+
+class SimConfigTest : public ::testing::Test {
+protected:
+    void TearDown() override {
+        static_cast<void>(std::remove(TEST_CONFIG_PATH));
+    }
+};
+
+TEST_F(SimConfigTest, FrozenDefaultsAreCentralized) {
+    const gnss_sim::SimConfig config = gnss_sim::default_sim_config();
+    EXPECT_EQ(config.duration_ns, 28800LL * gnss_sim::NANOSECONDS_PER_SECOND);
+    EXPECT_EQ(config.sampling_rate_hz, 10);
+    EXPECT_DOUBLE_EQ(config.elevation_mask_deg, 3.0);
+    EXPECT_TRUE(config.output_eph);
+    EXPECT_TRUE(config.output_ion);
+    EXPECT_FALSE(config.measurement_noise_enabled);
+    EXPECT_FALSE(config.multipath_enabled);
+    EXPECT_DOUBLE_EQ(config.receiver_clock_bias_m, 0.0);
+    EXPECT_DOUBLE_EQ(config.receiver_clock_drift_mps, 0.0);
+    EXPECT_EQ(config.ttff.startup_mode, gnss_sim::StartupMode::HOT);
+}
+
+TEST_F(SimConfigTest, LoadsValidOverridesWithoutLeakingJsonTypes) {
+    write_test_config(R"json({
+        "scenario": "TTFF",
+        "duration_sec": 60,
+        "sampling_rate_hz": 50,
+        "elevation_mask_deg": 3,
+        "receiver": {"latitude_deg": 21, "longitude_deg": 121, "height_m": 50},
+        "ttff": {"startup_mode": "COLD", "power_on_sec": 20, "power_off_sec": 5},
+        "seed": 42
+    })json");
+
+    gnss_sim::SimConfig config{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::load_sim_config_json(TEST_CONFIG_PATH, &config, &error_message)) << error_message;
+    EXPECT_EQ(config.scenario, gnss_sim::ScenarioType::TTFF);
+    EXPECT_EQ(config.duration_ns, 60LL * gnss_sim::NANOSECONDS_PER_SECOND);
+    EXPECT_EQ(config.sampling_rate_hz, 50);
+    EXPECT_EQ(config.ttff.startup_mode, gnss_sim::StartupMode::COLD);
+    EXPECT_EQ(config.seed, 42U);
+}
+
+TEST_F(SimConfigTest, RejectsUnknownKey) {
+    write_test_config(R"json({"sampling_rate_hz": 10, "samplng_rate_hz": 20})json");
+
+    gnss_sim::SimConfig config{};
+    std::string error_message;
+    EXPECT_FALSE(gnss_sim::load_sim_config_json(TEST_CONFIG_PATH, &config, &error_message));
+    EXPECT_NE(error_message.find("unsupported key"), std::string::npos);
+}
+
+TEST_F(SimConfigTest, RejectsUnsupportedRateAndV1Noise) {
+    write_test_config(R"json({"sampling_rate_hz": 2, "measurement_noise_enabled": true})json");
+
+    gnss_sim::SimConfig config{};
+    std::string error_message;
+    EXPECT_FALSE(gnss_sim::load_sim_config_json(TEST_CONFIG_PATH, &config, &error_message));
+}
+
+} // namespace

--- a/tests/unit/test_sim_time.cpp
+++ b/tests/unit/test_sim_time.cpp
@@ -1,20 +1,65 @@
-#include "gnss_sim/sim_types.h"
+#include "gnss_sim/sim_time.h"
 #include "gnss_sim/simulator.h"
 
+#include <cstdint>
 #include <cstring>
 #include <gtest/gtest.h>
 
 namespace {
 
-TEST(Bootstrap, SimTimeUsesIntegerNanoseconds) {
+TEST(SimTime, UsesIntegerNanosecondsAndPinnedRtklibRevision) {
     const gnss_sim::SimTime time{2300, 123456789LL};
     EXPECT_EQ(time.gps_week, 2300);
     EXPECT_EQ(time.tow_ns, 123456789LL);
-}
-
-TEST(Bootstrap, RtklibRevisionIsPinned) {
     EXPECT_STREQ(gnss_sim::rtklib_commit_sha(), "47bb6cf9935b510109d16f46baa35c648e56f1b5");
     EXPECT_EQ(std::strlen(gnss_sim::rtklib_commit_sha()), 40U);
+}
+
+TEST(SimTime, SupportsAllFrozenSamplingRatesExactly) {
+    struct RateCase {
+        int rate_hz;
+        std::int64_t interval_ns;
+    };
+    const RateCase cases[] = {{1, 1000000000LL}, {5, 200000000LL}, {10, 100000000LL},
+                              {20, 50000000LL},   {50, 20000000LL}};
+
+    for (const RateCase& test_case : cases) {
+        std::int64_t interval_ns = 0;
+        ASSERT_TRUE(gnss_sim::sampling_interval_ns(test_case.rate_hz, &interval_ns));
+        EXPECT_EQ(interval_ns, test_case.interval_ns);
+
+        std::uint64_t epoch_count = 0;
+        ASSERT_TRUE(gnss_sim::epoch_count_for_duration(gnss_sim::NANOSECONDS_PER_SECOND, test_case.rate_hz,
+                                                       &epoch_count));
+        EXPECT_EQ(epoch_count, static_cast<std::uint64_t>(test_case.rate_hz));
+    }
+}
+
+TEST(SimTime, CrossesGpsWeekWithoutFloatingAccumulation) {
+    const gnss_sim::SimTime start{2300, gnss_sim::GPS_WEEK_NANOSECONDS - 50000000LL};
+    gnss_sim::SimTime result{};
+    ASSERT_TRUE(gnss_sim::add_time_ns(start, 100000000LL, &result));
+    EXPECT_EQ(result.gps_week, 2301);
+    EXPECT_EQ(result.tow_ns, 50000000LL);
+}
+
+TEST(SimTime, EventAppliesAtFirstEpochAtOrAfterEventTime) {
+    const gnss_sim::SimTime start{2300, 0};
+    const gnss_sim::SimTime event{2300, 250000000LL};
+    std::uint64_t epoch_index = 0;
+    ASSERT_TRUE(gnss_sim::epoch_index_at_or_after(start, event, 10, &epoch_index));
+    EXPECT_EQ(epoch_index, 3U);
+
+    gnss_sim::SimTime epoch_time{};
+    ASSERT_TRUE(gnss_sim::epoch_time_at_index(start, 10, epoch_index, &epoch_time));
+    EXPECT_EQ(epoch_time.tow_ns, 300000000LL);
+}
+
+TEST(SimTime, NormalizesSecondOfWeekAcrossBoundary) {
+    gnss_sim::SimTime time{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, 604800.1, &time));
+    EXPECT_EQ(time.gps_week, 2301);
+    EXPECT_EQ(time.tow_ns, 100000000LL);
 }
 
 } // namespace

--- a/tests/unit/test_sim_time.cpp
+++ b/tests/unit/test_sim_time.cpp
@@ -20,8 +20,8 @@ TEST(SimTime, SupportsAllFrozenSamplingRatesExactly) {
         int rate_hz;
         std::int64_t interval_ns;
     };
-    const RateCase cases[] = {{1, 1000000000LL}, {5, 200000000LL}, {10, 100000000LL},
-                              {20, 50000000LL},   {50, 20000000LL}};
+    const RateCase cases[] = {
+        {1, 1000000000LL}, {5, 200000000LL}, {10, 100000000LL}, {20, 50000000LL}, {50, 20000000LL}};
 
     for (const RateCase& test_case : cases) {
         std::int64_t interval_ns = 0;
@@ -29,8 +29,8 @@ TEST(SimTime, SupportsAllFrozenSamplingRatesExactly) {
         EXPECT_EQ(interval_ns, test_case.interval_ns);
 
         std::uint64_t epoch_count = 0;
-        ASSERT_TRUE(gnss_sim::epoch_count_for_duration(gnss_sim::NANOSECONDS_PER_SECOND, test_case.rate_hz,
-                                                       &epoch_count));
+        ASSERT_TRUE(
+            gnss_sim::epoch_count_for_duration(gnss_sim::NANOSECONDS_PER_SECOND, test_case.rate_hz, &epoch_count));
         EXPECT_EQ(epoch_count, static_cast<std::uint64_t>(test_case.rate_hz));
     }
 }


### PR DESCRIPTION
Closes #3

## Summary

- implement integer-nanosecond GPST scheduling and week rollover;
- support exact 1/5/10/20/50 Hz intervals and deterministic event-to-epoch alignment;
- implement strict JSON V1 config loading and validation;
- centralize all currently frozen V1 defaults;
- implement PCG32-based deterministic PRNG with a cross-platform reference sequence;
- pin cJSON `v1.7.18` (`acc76239bee01d8e9c858ae2cab296704e52d916`) as the private config-parser dependency;
- add focused GoogleTest coverage for time, config, and deterministic RNG behavior;
- update engineering rules to record the cJSON boundary and `test_sim_config.cpp`.

## Implementation Notes

- Internal simulation time never advances through repeated floating-point SOW addition.
- Events take effect at the first epoch satisfying `epoch_time >= event_time`.
- V1 validation rejects measurement noise, multipath, and non-zero receiver clock bias/drift.
- JSON parser types are contained entirely in `sim_config.cpp`.
- The configured seed is limited to the exact JSON integer range (`0..2^53-1`) so cJSON's numeric representation cannot silently change it.
- PCG32 output is generated by project code rather than `std::rand()` or implementation-defined distributions.

## Tests

- exact interval/count tests for 1/5/10/20/50 Hz;
- GPST week rollover;
- event epoch alignment;
- strict config defaults/overrides/error handling;
- PCG32 reference sequence and same-seed repeatability on both toolchains.