### PR TITLE
Define authoritative V1 constellation and signal mappings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 include(CTest)
 include(cmake/CompilerWarnings.cmake)
 
-set(GNSS_SIM_RTKLIB_COMMIT "47bb6cf9935b510109d16f46baa35c648e56f1b5" CACHE STRING
+set(GNSS_SIM_RTKLIB_COMMIT "07e813b72c8667350c4e80293cb6679c519ef1a6" CACHE STRING
     "Pinned RTKLIB commit used by this simulator build")
 set(GNSS_SIM_CJSON_COMMIT "acc76239bee01d8e9c858ae2cab296704e52d916" CACHE STRING
     "Pinned cJSON commit used by this simulator build")
@@ -38,6 +38,7 @@ add_library(rtklib_pinned STATIC
     third_party/RTKLIB/src/rtcm3.c
     third_party/RTKLIB/src/rtcm3e.c
     third_party/RTKLIB/src/rtkcmn.c
+    third_party/RTKLIB/src/rtklib_obs_ext.c
     third_party/RTKLIB/src/sbas.c
 )
 add_library(gnss_sim::rtklib ALIAS rtklib_pinned)
@@ -69,6 +70,7 @@ add_library(gnss_sim_core STATIC
     src/core/sim_time.cpp
     src/core/simulator.cpp
     src/gnss/rtklib_adapter.cpp
+    src/gnss/signal_definitions.cpp
 )
 add_library(gnss_sim::core ALIAS gnss_sim_core)
 target_include_directories(gnss_sim_core
@@ -101,6 +103,7 @@ if(BUILD_TESTING)
     add_executable(gnss_sim_unit_tests
         tests/unit/test_deterministic_rng.cpp
         tests/unit/test_rtklib_adapter.cpp
+        tests/unit/test_signal_definitions.cpp
         tests/unit/test_sim_config.cpp
         tests/unit/test_sim_time.cpp
     )

--- a/src/gnss/rtklib_adapter.cpp
+++ b/src/gnss/rtklib_adapter.cpp
@@ -2,6 +2,7 @@
 
 extern "C" {
 #include <rtklib.h>
+#include <rtklib_obs_ext.h>
 }
 
 #include <cmath>
@@ -144,6 +145,20 @@ bool rtklib_satellite_id_to_number(const char* satellite_id, int* satellite_numb
         return false;
     }
     *satellite_number = satellite;
+    return true;
+}
+
+bool rtklib_observation_code(const char* rinex_signal_code, int* observation_code, int* frequency_index) {
+    if (rinex_signal_code == nullptr || observation_code == nullptr || frequency_index == nullptr) {
+        return false;
+    }
+    int frequency = 0;
+    const unsigned char code = obs2code_ext(rinex_signal_code, &frequency);
+    if (code == CODE_NONE || frequency <= 0) {
+        return false;
+    }
+    *observation_code = static_cast<int>(code);
+    *frequency_index = frequency;
     return true;
 }
 

--- a/src/gnss/rtklib_adapter.h
+++ b/src/gnss/rtklib_adapter.h
@@ -32,6 +32,7 @@ bool load_rinex_nav_file(RtklibNavStore* store, const char* file_path, std::stri
 bool get_rtklib_nav_counts(const RtklibNavStore* store, RtklibNavCounts* counts);
 
 bool rtklib_satellite_id_to_number(const char* satellite_id, int* satellite_number);
+bool rtklib_observation_code(const char* rinex_signal_code, int* observation_code, int* frequency_index);
 bool get_rtklib_satellite_state(const RtklibNavStore* store, int gps_week, double sow_sec, int satellite_number,
                                 RtklibSatelliteState* state, std::string* error_message);
 

--- a/src/gnss/signal_definitions.cpp
+++ b/src/gnss/signal_definitions.cpp
@@ -1,1 +1,161 @@
-// Authoritative signal definitions are introduced by issue #5.
+#include "gnss/signal_definitions.h"
+
+#include "gnss/rtklib_adapter.h"
+
+#include <cmath>
+#include <cstring>
+
+namespace gnss_sim {
+namespace {
+
+constexpr double kSpeedOfLightMps = 299792458.0;
+constexpr double kGlonassG1BaseHz = 1602.0e6;
+constexpr double kGlonassG1StepHz = 0.5625e6;
+constexpr double kGlonassG2BaseHz = 1246.0e6;
+constexpr double kGlonassG2StepHz = 0.4375e6;
+constexpr int kGlonassMinFcn = -7;
+constexpr int kGlonassMaxFcn = 6;
+
+// OEM7 signal types match the RANGE RINEX mapping table in the pinned RTKLIB
+// fork. RINEX codes resolve through RTKLIB, including its modern-BDS extension.
+constexpr SignalDefinition kSignalDefinitions[] = {
+    {GnssConstellation::kGps, SignalId::kGpsL1Ca, "GPS L1 C/A", "1C", CarrierFrequencyModel::kFixed, 1575.42e6,
+     NavMessageFamily::kGpsLnav, CodeBiasModel::kGpsL1Ca, 0},
+    {GnssConstellation::kGps, SignalId::kGpsL1C, "GPS L1C", "1L", CarrierFrequencyModel::kFixed, 1575.42e6,
+     NavMessageFamily::kGpsCnav2, CodeBiasModel::kGpsL1C, 16},
+    {GnssConstellation::kGps, SignalId::kGpsL2P, "GPS L2P", "2P", CarrierFrequencyModel::kFixed, 1227.60e6,
+     NavMessageFamily::kGpsLnav, CodeBiasModel::kGpsL2P, 5},
+    {GnssConstellation::kGps, SignalId::kGpsL2C, "GPS L2C", "2S", CarrierFrequencyModel::kFixed, 1227.60e6,
+     NavMessageFamily::kGpsCnav, CodeBiasModel::kGpsL2C, 17},
+    {GnssConstellation::kGps, SignalId::kGpsL5Q, "GPS L5Q", "5Q", CarrierFrequencyModel::kFixed, 1176.45e6,
+     NavMessageFamily::kGpsCnav, CodeBiasModel::kGpsL5Q, 14},
+
+    {GnssConstellation::kQzss, SignalId::kQzssL1Ca, "QZSS L1 C/A", "1C", CarrierFrequencyModel::kFixed,
+     1575.42e6, NavMessageFamily::kQzssLnav, CodeBiasModel::kQzssL1Ca, 0},
+    {GnssConstellation::kQzss, SignalId::kQzssL1C, "QZSS L1C", "1L", CarrierFrequencyModel::kFixed, 1575.42e6,
+     NavMessageFamily::kQzssCnav2, CodeBiasModel::kQzssL1C, 16},
+    {GnssConstellation::kQzss, SignalId::kQzssL2C, "QZSS L2C", "2S", CarrierFrequencyModel::kFixed, 1227.60e6,
+     NavMessageFamily::kQzssCnav, CodeBiasModel::kQzssL2C, 17},
+    {GnssConstellation::kQzss, SignalId::kQzssL5Q, "QZSS L5Q", "5Q", CarrierFrequencyModel::kFixed, 1176.45e6,
+     NavMessageFamily::kQzssCnav, CodeBiasModel::kQzssL5Q, 14},
+
+    {GnssConstellation::kGlonass, SignalId::kGlonassG1, "GLONASS G1", "1C", CarrierFrequencyModel::kGlonassFdmaG1,
+     kGlonassG1BaseHz, NavMessageFamily::kGlonassFdma, CodeBiasModel::kGlonassG1, 0},
+    {GnssConstellation::kGlonass, SignalId::kGlonassG2, "GLONASS G2", "2C", CarrierFrequencyModel::kGlonassFdmaG2,
+     kGlonassG2BaseHz, NavMessageFamily::kGlonassFdma, CodeBiasModel::kGlonassG2, 1},
+    {GnssConstellation::kGlonass, SignalId::kGlonassG3, "GLONASS G3", "3Q", CarrierFrequencyModel::kFixed,
+     1202.025e6, NavMessageFamily::kGlonassL3Oc, CodeBiasModel::kGlonassG3, 6},
+
+    {GnssConstellation::kGalileo, SignalId::kGalileoE1, "Galileo E1", "1C", CarrierFrequencyModel::kFixed,
+     1575.42e6, NavMessageFamily::kGalileoInav, CodeBiasModel::kGalileoE1, 2},
+    {GnssConstellation::kGalileo, SignalId::kGalileoE5A, "Galileo E5a", "5Q", CarrierFrequencyModel::kFixed,
+     1176.45e6, NavMessageFamily::kGalileoFnav, CodeBiasModel::kGalileoE5A, 12},
+    {GnssConstellation::kGalileo, SignalId::kGalileoE5B, "Galileo E5b", "7Q", CarrierFrequencyModel::kFixed,
+     1207.14e6, NavMessageFamily::kGalileoInav, CodeBiasModel::kGalileoE5B, 17},
+    {GnssConstellation::kGalileo, SignalId::kGalileoE6, "Galileo E6", "6B", CarrierFrequencyModel::kFixed,
+     1278.75e6, NavMessageFamily::kGalileoCnav, CodeBiasModel::kGalileoE6, 6},
+
+    {GnssConstellation::kBeidou, SignalId::kBeidouB1I, "BeiDou B1I", "2I", CarrierFrequencyModel::kFixed,
+     1561.098e6, NavMessageFamily::kBeidouD1D2, CodeBiasModel::kBeidouB1I, 0},
+    {GnssConstellation::kBeidou, SignalId::kBeidouB3I, "BeiDou B3I", "6I", CarrierFrequencyModel::kFixed,
+     1268.52e6, NavMessageFamily::kBeidouD1D2, CodeBiasModel::kBeidouB3I, 2},
+    {GnssConstellation::kBeidou, SignalId::kBeidouB1C, "BeiDou B1C", "1P", CarrierFrequencyModel::kFixed,
+     1575.42e6, NavMessageFamily::kBeidouBcnav1, CodeBiasModel::kBeidouB1C, 7},
+    {GnssConstellation::kBeidou, SignalId::kBeidouB2A, "BeiDou B2a", "5P", CarrierFrequencyModel::kFixed,
+     1176.45e6, NavMessageFamily::kBeidouBcnav2, CodeBiasModel::kBeidouB2A, 9},
+    {GnssConstellation::kBeidou, SignalId::kBeidouB2B, "BeiDou B2b", "7D", CarrierFrequencyModel::kFixed,
+     1207.14e6, NavMessageFamily::kBeidouBcnav3, CodeBiasModel::kBeidouB2B, 11},
+};
+
+constexpr std::size_t kSignalDefinitionCount = sizeof(kSignalDefinitions) / sizeof(kSignalDefinitions[0]);
+
+bool is_valid_glonass_fcn(int glonass_fcn) {
+    return glonass_fcn >= kGlonassMinFcn && glonass_fcn <= kGlonassMaxFcn;
+}
+
+} // namespace
+
+const SignalDefinition* signal_definitions(std::size_t* count) {
+    if (count != nullptr) {
+        *count = kSignalDefinitionCount;
+    }
+    return kSignalDefinitions;
+}
+
+const SignalDefinition* find_signal_definition(SignalId signal_id) {
+    for (const SignalDefinition& definition : kSignalDefinitions) {
+        if (definition.signal_id == signal_id) {
+            return &definition;
+        }
+    }
+    return nullptr;
+}
+
+const SignalDefinition* find_signal_definition_by_rinex(GnssConstellation constellation,
+                                                         const char* rinex_signal_code) {
+    if (rinex_signal_code == nullptr) {
+        return nullptr;
+    }
+    for (const SignalDefinition& definition : kSignalDefinitions) {
+        if (definition.constellation == constellation &&
+            std::strcmp(definition.rinex_signal_code, rinex_signal_code) == 0) {
+            return &definition;
+        }
+    }
+    return nullptr;
+}
+
+const SignalDefinition* find_signal_definition_by_oem7(GnssConstellation constellation,
+                                                        int novatel_oem7_signal_type) {
+    for (const SignalDefinition& definition : kSignalDefinitions) {
+        if (definition.constellation == constellation &&
+            definition.novatel_oem7_signal_type == novatel_oem7_signal_type) {
+            return &definition;
+        }
+    }
+    return nullptr;
+}
+
+bool signal_carrier_frequency_hz(const SignalDefinition& definition, int glonass_fcn, double* frequency_hz) {
+    if (frequency_hz == nullptr) {
+        return false;
+    }
+
+    switch (definition.carrier_model) {
+        case CarrierFrequencyModel::kFixed:
+            *frequency_hz = definition.nominal_frequency_hz;
+            return true;
+        case CarrierFrequencyModel::kGlonassFdmaG1:
+            if (!is_valid_glonass_fcn(glonass_fcn)) {
+                return false;
+            }
+            *frequency_hz = kGlonassG1BaseHz + static_cast<double>(glonass_fcn) * kGlonassG1StepHz;
+            return true;
+        case CarrierFrequencyModel::kGlonassFdmaG2:
+            if (!is_valid_glonass_fcn(glonass_fcn)) {
+                return false;
+            }
+            *frequency_hz = kGlonassG2BaseHz + static_cast<double>(glonass_fcn) * kGlonassG2StepHz;
+            return true;
+    }
+    return false;
+}
+
+bool signal_wavelength_m(const SignalDefinition& definition, int glonass_fcn, double* wavelength_m) {
+    if (wavelength_m == nullptr) {
+        return false;
+    }
+    double frequency_hz = 0.0;
+    if (!signal_carrier_frequency_hz(definition, glonass_fcn, &frequency_hz) || !std::isfinite(frequency_hz) ||
+        frequency_hz <= 0.0) {
+        return false;
+    }
+    *wavelength_m = kSpeedOfLightMps / frequency_hz;
+    return true;
+}
+
+bool signal_rtklib_observation_code(const SignalDefinition& definition, int* observation_code, int* frequency_index) {
+    return rtklib_observation_code(definition.rinex_signal_code, observation_code, frequency_index);
+}
+
+} // namespace gnss_sim

--- a/src/gnss/signal_definitions.cpp
+++ b/src/gnss/signal_definitions.cpp
@@ -30,8 +30,8 @@ constexpr SignalDefinition kSignalDefinitions[] = {
     {GnssConstellation::kGps, SignalId::kGpsL5Q, "GPS L5Q", "5Q", CarrierFrequencyModel::kFixed, 1176.45e6,
      NavMessageFamily::kGpsCnav, CodeBiasModel::kGpsL5Q, 14},
 
-    {GnssConstellation::kQzss, SignalId::kQzssL1Ca, "QZSS L1 C/A", "1C", CarrierFrequencyModel::kFixed,
-     1575.42e6, NavMessageFamily::kQzssLnav, CodeBiasModel::kQzssL1Ca, 0},
+    {GnssConstellation::kQzss, SignalId::kQzssL1Ca, "QZSS L1 C/A", "1C", CarrierFrequencyModel::kFixed, 1575.42e6,
+     NavMessageFamily::kQzssLnav, CodeBiasModel::kQzssL1Ca, 0},
     {GnssConstellation::kQzss, SignalId::kQzssL1C, "QZSS L1C", "1L", CarrierFrequencyModel::kFixed, 1575.42e6,
      NavMessageFamily::kQzssCnav2, CodeBiasModel::kQzssL1C, 16},
     {GnssConstellation::kQzss, SignalId::kQzssL2C, "QZSS L2C", "2S", CarrierFrequencyModel::kFixed, 1227.60e6,
@@ -43,28 +43,28 @@ constexpr SignalDefinition kSignalDefinitions[] = {
      kGlonassG1BaseHz, NavMessageFamily::kGlonassFdma, CodeBiasModel::kGlonassG1, 0},
     {GnssConstellation::kGlonass, SignalId::kGlonassG2, "GLONASS G2", "2C", CarrierFrequencyModel::kGlonassFdmaG2,
      kGlonassG2BaseHz, NavMessageFamily::kGlonassFdma, CodeBiasModel::kGlonassG2, 1},
-    {GnssConstellation::kGlonass, SignalId::kGlonassG3, "GLONASS G3", "3Q", CarrierFrequencyModel::kFixed,
-     1202.025e6, NavMessageFamily::kGlonassL3Oc, CodeBiasModel::kGlonassG3, 6},
+    {GnssConstellation::kGlonass, SignalId::kGlonassG3, "GLONASS G3", "3Q", CarrierFrequencyModel::kFixed, 1202.025e6,
+     NavMessageFamily::kGlonassL3Oc, CodeBiasModel::kGlonassG3, 6},
 
-    {GnssConstellation::kGalileo, SignalId::kGalileoE1, "Galileo E1", "1C", CarrierFrequencyModel::kFixed,
-     1575.42e6, NavMessageFamily::kGalileoInav, CodeBiasModel::kGalileoE1, 2},
-    {GnssConstellation::kGalileo, SignalId::kGalileoE5A, "Galileo E5a", "5Q", CarrierFrequencyModel::kFixed,
-     1176.45e6, NavMessageFamily::kGalileoFnav, CodeBiasModel::kGalileoE5A, 12},
-    {GnssConstellation::kGalileo, SignalId::kGalileoE5B, "Galileo E5b", "7Q", CarrierFrequencyModel::kFixed,
-     1207.14e6, NavMessageFamily::kGalileoInav, CodeBiasModel::kGalileoE5B, 17},
-    {GnssConstellation::kGalileo, SignalId::kGalileoE6, "Galileo E6", "6B", CarrierFrequencyModel::kFixed,
-     1278.75e6, NavMessageFamily::kGalileoCnav, CodeBiasModel::kGalileoE6, 6},
+    {GnssConstellation::kGalileo, SignalId::kGalileoE1, "Galileo E1", "1C", CarrierFrequencyModel::kFixed, 1575.42e6,
+     NavMessageFamily::kGalileoInav, CodeBiasModel::kGalileoE1, 2},
+    {GnssConstellation::kGalileo, SignalId::kGalileoE5A, "Galileo E5a", "5Q", CarrierFrequencyModel::kFixed, 1176.45e6,
+     NavMessageFamily::kGalileoFnav, CodeBiasModel::kGalileoE5A, 12},
+    {GnssConstellation::kGalileo, SignalId::kGalileoE5B, "Galileo E5b", "7Q", CarrierFrequencyModel::kFixed, 1207.14e6,
+     NavMessageFamily::kGalileoInav, CodeBiasModel::kGalileoE5B, 17},
+    {GnssConstellation::kGalileo, SignalId::kGalileoE6, "Galileo E6", "6B", CarrierFrequencyModel::kFixed, 1278.75e6,
+     NavMessageFamily::kGalileoCnav, CodeBiasModel::kGalileoE6, 6},
 
-    {GnssConstellation::kBeidou, SignalId::kBeidouB1I, "BeiDou B1I", "2I", CarrierFrequencyModel::kFixed,
-     1561.098e6, NavMessageFamily::kBeidouD1D2, CodeBiasModel::kBeidouB1I, 0},
-    {GnssConstellation::kBeidou, SignalId::kBeidouB3I, "BeiDou B3I", "6I", CarrierFrequencyModel::kFixed,
-     1268.52e6, NavMessageFamily::kBeidouD1D2, CodeBiasModel::kBeidouB3I, 2},
-    {GnssConstellation::kBeidou, SignalId::kBeidouB1C, "BeiDou B1C", "1P", CarrierFrequencyModel::kFixed,
-     1575.42e6, NavMessageFamily::kBeidouBcnav1, CodeBiasModel::kBeidouB1C, 7},
-    {GnssConstellation::kBeidou, SignalId::kBeidouB2A, "BeiDou B2a", "5P", CarrierFrequencyModel::kFixed,
-     1176.45e6, NavMessageFamily::kBeidouBcnav2, CodeBiasModel::kBeidouB2A, 9},
-    {GnssConstellation::kBeidou, SignalId::kBeidouB2B, "BeiDou B2b", "7D", CarrierFrequencyModel::kFixed,
-     1207.14e6, NavMessageFamily::kBeidouBcnav3, CodeBiasModel::kBeidouB2B, 11},
+    {GnssConstellation::kBeidou, SignalId::kBeidouB1I, "BeiDou B1I", "2I", CarrierFrequencyModel::kFixed, 1561.098e6,
+     NavMessageFamily::kBeidouD1D2, CodeBiasModel::kBeidouB1I, 0},
+    {GnssConstellation::kBeidou, SignalId::kBeidouB3I, "BeiDou B3I", "6I", CarrierFrequencyModel::kFixed, 1268.52e6,
+     NavMessageFamily::kBeidouD1D2, CodeBiasModel::kBeidouB3I, 2},
+    {GnssConstellation::kBeidou, SignalId::kBeidouB1C, "BeiDou B1C", "1P", CarrierFrequencyModel::kFixed, 1575.42e6,
+     NavMessageFamily::kBeidouBcnav1, CodeBiasModel::kBeidouB1C, 7},
+    {GnssConstellation::kBeidou, SignalId::kBeidouB2A, "BeiDou B2a", "5P", CarrierFrequencyModel::kFixed, 1176.45e6,
+     NavMessageFamily::kBeidouBcnav2, CodeBiasModel::kBeidouB2A, 9},
+    {GnssConstellation::kBeidou, SignalId::kBeidouB2B, "BeiDou B2b", "7D", CarrierFrequencyModel::kFixed, 1207.14e6,
+     NavMessageFamily::kBeidouBcnav3, CodeBiasModel::kBeidouB2B, 11},
 };
 
 constexpr std::size_t kSignalDefinitionCount = sizeof(kSignalDefinitions) / sizeof(kSignalDefinitions[0]);
@@ -92,7 +92,7 @@ const SignalDefinition* find_signal_definition(SignalId signal_id) {
 }
 
 const SignalDefinition* find_signal_definition_by_rinex(GnssConstellation constellation,
-                                                         const char* rinex_signal_code) {
+                                                        const char* rinex_signal_code) {
     if (rinex_signal_code == nullptr) {
         return nullptr;
     }
@@ -105,8 +105,7 @@ const SignalDefinition* find_signal_definition_by_rinex(GnssConstellation conste
     return nullptr;
 }
 
-const SignalDefinition* find_signal_definition_by_oem7(GnssConstellation constellation,
-                                                        int novatel_oem7_signal_type) {
+const SignalDefinition* find_signal_definition_by_oem7(GnssConstellation constellation, int novatel_oem7_signal_type) {
     for (const SignalDefinition& definition : kSignalDefinitions) {
         if (definition.constellation == constellation &&
             definition.novatel_oem7_signal_type == novatel_oem7_signal_type) {

--- a/src/gnss/signal_definitions.h
+++ b/src/gnss/signal_definitions.h
@@ -1,0 +1,115 @@
+#ifndef GNSS_SIM_SRC_GNSS_SIGNAL_DEFINITIONS_H_
+#define GNSS_SIM_SRC_GNSS_SIGNAL_DEFINITIONS_H_
+
+#include <cstddef>
+
+namespace gnss_sim {
+
+enum class GnssConstellation {
+    kGps,
+    kGlonass,
+    kGalileo,
+    kBeidou,
+    kQzss,
+};
+
+enum class SignalId {
+    kGpsL1Ca,
+    kGpsL1C,
+    kGpsL2P,
+    kGpsL2C,
+    kGpsL5Q,
+    kQzssL1Ca,
+    kQzssL1C,
+    kQzssL2C,
+    kQzssL5Q,
+    kGlonassG1,
+    kGlonassG2,
+    kGlonassG3,
+    kGalileoE1,
+    kGalileoE5A,
+    kGalileoE5B,
+    kGalileoE6,
+    kBeidouB1I,
+    kBeidouB3I,
+    kBeidouB1C,
+    kBeidouB2A,
+    kBeidouB2B,
+};
+
+enum class CarrierFrequencyModel {
+    kFixed,
+    kGlonassFdmaG1,
+    kGlonassFdmaG2,
+};
+
+enum class NavMessageFamily {
+    kGpsLnav,
+    kGpsCnav,
+    kGpsCnav2,
+    kQzssLnav,
+    kQzssCnav,
+    kQzssCnav2,
+    kGlonassFdma,
+    kGlonassL3Oc,
+    kGalileoInav,
+    kGalileoFnav,
+    kGalileoCnav,
+    kBeidouD1D2,
+    kBeidouBcnav1,
+    kBeidouBcnav2,
+    kBeidouBcnav3,
+};
+
+// Semantic selector for the signal-specific broadcast group-delay/code-bias
+// model. The measurement model resolves the selected semantic against the
+// actual RINEX NAV message (TGD, ISC, BGD, or GLONASS dtaun) rather than
+// exposing eph_t/geph_t slots outside the RTKLIB adapter boundary.
+enum class CodeBiasModel {
+    kGpsL1Ca,
+    kGpsL1C,
+    kGpsL2P,
+    kGpsL2C,
+    kGpsL5Q,
+    kQzssL1Ca,
+    kQzssL1C,
+    kQzssL2C,
+    kQzssL5Q,
+    kGlonassG1,
+    kGlonassG2,
+    kGlonassG3,
+    kGalileoE1,
+    kGalileoE5A,
+    kGalileoE5B,
+    kGalileoE6,
+    kBeidouB1I,
+    kBeidouB3I,
+    kBeidouB1C,
+    kBeidouB2A,
+    kBeidouB2B,
+};
+
+struct SignalDefinition {
+    GnssConstellation constellation;
+    SignalId signal_id;
+    const char* name;
+    const char* rinex_signal_code;
+    CarrierFrequencyModel carrier_model;
+    double nominal_frequency_hz;
+    NavMessageFamily nav_message_family;
+    CodeBiasModel code_bias_model;
+    int novatel_oem7_signal_type;
+};
+
+const SignalDefinition* signal_definitions(std::size_t* count);
+const SignalDefinition* find_signal_definition(SignalId signal_id);
+const SignalDefinition* find_signal_definition_by_rinex(GnssConstellation constellation, const char* rinex_signal_code);
+const SignalDefinition* find_signal_definition_by_oem7(GnssConstellation constellation, int novatel_oem7_signal_type);
+
+bool signal_carrier_frequency_hz(const SignalDefinition& definition, int glonass_fcn, double* frequency_hz);
+bool signal_wavelength_m(const SignalDefinition& definition, int glonass_fcn, double* wavelength_m);
+bool signal_rtklib_observation_code(const SignalDefinition& definition, int* observation_code, int* frequency_index);
+
+} // namespace gnss_sim
+
+#endif // GNSS_SIM_SRC_GNSS_SIGNAL_DEFINITIONS_H_

--- a/tests/unit/test_rtklib_adapter.cpp
+++ b/tests/unit/test_rtklib_adapter.cpp
@@ -66,7 +66,7 @@ TEST_F(RtklibAdapterTest, LoadsRepresentativeMixedNavigationFile) {
 }
 
 TEST(RtklibAdapterMetadata, ExposesExactPinnedRtklibCommit) {
-    EXPECT_STREQ(gnss_sim::rtklib_commit_sha(), "47bb6cf9935b510109d16f46baa35c648e56f1b5");
+    EXPECT_STREQ(gnss_sim::rtklib_commit_sha(), "07e813b72c8667350c4e80293cb6679c519ef1a6");
 }
 
 TEST_F(RtklibAdapterTest, SatelliteIdMappingCoversFrozenConstellations) {

--- a/tests/unit/test_signal_definitions.cpp
+++ b/tests/unit/test_signal_definitions.cpp
@@ -1,10 +1,9 @@
 #include "gnss/rtklib_adapter.h"
 #include "gnss/signal_definitions.h"
 
-#include <gtest/gtest.h>
-
 #include <cmath>
 #include <cstddef>
+#include <gtest/gtest.h>
 #include <iterator>
 #include <set>
 #include <string>
@@ -55,12 +54,11 @@ TEST(SignalDefinitions, CoversEveryFrozenV1SignalExactlyOnce) {
     for (std::size_t index = 0; index < count; ++index) {
         const gnss_sim::SignalDefinition& definition = definitions[index];
         EXPECT_TRUE(signal_ids.insert(static_cast<int>(definition.signal_id)).second);
-        EXPECT_TRUE(rinex_keys
-                        .insert({static_cast<int>(definition.constellation), std::string(definition.rinex_signal_code)})
-                        .second);
-        EXPECT_TRUE(oem7_keys
-                        .insert({static_cast<int>(definition.constellation), definition.novatel_oem7_signal_type})
-                        .second);
+        EXPECT_TRUE(
+            rinex_keys.insert({static_cast<int>(definition.constellation), std::string(definition.rinex_signal_code)})
+                .second);
+        EXPECT_TRUE(
+            oem7_keys.insert({static_cast<int>(definition.constellation), definition.novatel_oem7_signal_type}).second);
         EXPECT_NE(definition.name, nullptr);
         EXPECT_NE(definition.rinex_signal_code, nullptr);
     }

--- a/tests/unit/test_signal_definitions.cpp
+++ b/tests/unit/test_signal_definitions.cpp
@@ -1,9 +1,11 @@
+#include "gnss/rtklib_adapter.h"
 #include "gnss/signal_definitions.h"
 
 #include <gtest/gtest.h>
 
 #include <cmath>
 #include <cstddef>
+#include <iterator>
 #include <set>
 #include <string>
 #include <utility>

--- a/tests/unit/test_signal_definitions.cpp
+++ b/tests/unit/test_signal_definitions.cpp
@@ -1,0 +1,169 @@
+#include "gnss/signal_definitions.h"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstddef>
+#include <set>
+#include <string>
+#include <utility>
+
+namespace {
+
+struct ExpectedSignal {
+    gnss_sim::SignalId signal_id;
+    gnss_sim::GnssConstellation constellation;
+    const char* rinex_code;
+    int oem7_type;
+};
+
+constexpr ExpectedSignal kExpectedSignals[] = {
+    {gnss_sim::SignalId::kGpsL1Ca, gnss_sim::GnssConstellation::kGps, "1C", 0},
+    {gnss_sim::SignalId::kGpsL1C, gnss_sim::GnssConstellation::kGps, "1L", 16},
+    {gnss_sim::SignalId::kGpsL2P, gnss_sim::GnssConstellation::kGps, "2P", 5},
+    {gnss_sim::SignalId::kGpsL2C, gnss_sim::GnssConstellation::kGps, "2S", 17},
+    {gnss_sim::SignalId::kGpsL5Q, gnss_sim::GnssConstellation::kGps, "5Q", 14},
+    {gnss_sim::SignalId::kQzssL1Ca, gnss_sim::GnssConstellation::kQzss, "1C", 0},
+    {gnss_sim::SignalId::kQzssL1C, gnss_sim::GnssConstellation::kQzss, "1L", 16},
+    {gnss_sim::SignalId::kQzssL2C, gnss_sim::GnssConstellation::kQzss, "2S", 17},
+    {gnss_sim::SignalId::kQzssL5Q, gnss_sim::GnssConstellation::kQzss, "5Q", 14},
+    {gnss_sim::SignalId::kGlonassG1, gnss_sim::GnssConstellation::kGlonass, "1C", 0},
+    {gnss_sim::SignalId::kGlonassG2, gnss_sim::GnssConstellation::kGlonass, "2C", 1},
+    {gnss_sim::SignalId::kGlonassG3, gnss_sim::GnssConstellation::kGlonass, "3Q", 6},
+    {gnss_sim::SignalId::kGalileoE1, gnss_sim::GnssConstellation::kGalileo, "1C", 2},
+    {gnss_sim::SignalId::kGalileoE5A, gnss_sim::GnssConstellation::kGalileo, "5Q", 12},
+    {gnss_sim::SignalId::kGalileoE5B, gnss_sim::GnssConstellation::kGalileo, "7Q", 17},
+    {gnss_sim::SignalId::kGalileoE6, gnss_sim::GnssConstellation::kGalileo, "6B", 6},
+    {gnss_sim::SignalId::kBeidouB1I, gnss_sim::GnssConstellation::kBeidou, "2I", 0},
+    {gnss_sim::SignalId::kBeidouB3I, gnss_sim::GnssConstellation::kBeidou, "6I", 2},
+    {gnss_sim::SignalId::kBeidouB1C, gnss_sim::GnssConstellation::kBeidou, "1P", 7},
+    {gnss_sim::SignalId::kBeidouB2A, gnss_sim::GnssConstellation::kBeidou, "5P", 9},
+    {gnss_sim::SignalId::kBeidouB2B, gnss_sim::GnssConstellation::kBeidou, "7D", 11},
+};
+
+TEST(SignalDefinitions, CoversEveryFrozenV1SignalExactlyOnce) {
+    std::size_t count = 0;
+    const gnss_sim::SignalDefinition* definitions = gnss_sim::signal_definitions(&count);
+    ASSERT_NE(definitions, nullptr);
+    ASSERT_EQ(count, std::size(kExpectedSignals));
+
+    std::set<int> signal_ids;
+    std::set<std::pair<int, std::string>> rinex_keys;
+    std::set<std::pair<int, int>> oem7_keys;
+    for (std::size_t index = 0; index < count; ++index) {
+        const gnss_sim::SignalDefinition& definition = definitions[index];
+        EXPECT_TRUE(signal_ids.insert(static_cast<int>(definition.signal_id)).second);
+        EXPECT_TRUE(rinex_keys
+                        .insert({static_cast<int>(definition.constellation), std::string(definition.rinex_signal_code)})
+                        .second);
+        EXPECT_TRUE(oem7_keys
+                        .insert({static_cast<int>(definition.constellation), definition.novatel_oem7_signal_type})
+                        .second);
+        EXPECT_NE(definition.name, nullptr);
+        EXPECT_NE(definition.rinex_signal_code, nullptr);
+    }
+    EXPECT_EQ(signal_ids.size(), count);
+    EXPECT_EQ(rinex_keys.size(), count);
+    EXPECT_EQ(oem7_keys.size(), count);
+}
+
+TEST(SignalDefinitions, FrozenMappingsMatchExpectedValuesAndRoundTrip) {
+    for (const ExpectedSignal& expected : kExpectedSignals) {
+        const gnss_sim::SignalDefinition* definition = gnss_sim::find_signal_definition(expected.signal_id);
+        ASSERT_NE(definition, nullptr);
+        EXPECT_EQ(definition->constellation, expected.constellation);
+        EXPECT_STREQ(definition->rinex_signal_code, expected.rinex_code);
+        EXPECT_EQ(definition->novatel_oem7_signal_type, expected.oem7_type);
+        EXPECT_EQ(gnss_sim::find_signal_definition_by_rinex(expected.constellation, expected.rinex_code), definition);
+        EXPECT_EQ(gnss_sim::find_signal_definition_by_oem7(expected.constellation, expected.oem7_type), definition);
+
+        int rtklib_code = 0;
+        int frequency_index = 0;
+        EXPECT_TRUE(gnss_sim::signal_rtklib_observation_code(*definition, &rtklib_code, &frequency_index));
+        EXPECT_GT(rtklib_code, 0);
+        EXPECT_GT(frequency_index, 0);
+    }
+}
+
+TEST(SignalDefinitions, ModernBeidouCodesResolveThroughPinnedRtklib) {
+    const auto* b1c = gnss_sim::find_signal_definition(gnss_sim::SignalId::kBeidouB1C);
+    const auto* b2a = gnss_sim::find_signal_definition(gnss_sim::SignalId::kBeidouB2A);
+    const auto* b2b = gnss_sim::find_signal_definition(gnss_sim::SignalId::kBeidouB2B);
+    ASSERT_NE(b1c, nullptr);
+    ASSERT_NE(b2a, nullptr);
+    ASSERT_NE(b2b, nullptr);
+
+    int code = 0;
+    int frequency = 0;
+    ASSERT_TRUE(gnss_sim::signal_rtklib_observation_code(*b1c, &code, &frequency));
+    EXPECT_GT(code, 0);
+    EXPECT_EQ(frequency, 1);
+    ASSERT_TRUE(gnss_sim::signal_rtklib_observation_code(*b2a, &code, &frequency));
+    EXPECT_EQ(code, 49);
+    EXPECT_EQ(frequency, 3);
+    ASSERT_TRUE(gnss_sim::signal_rtklib_observation_code(*b2b, &code, &frequency));
+    EXPECT_EQ(code, 50);
+    EXPECT_EQ(frequency, 5);
+}
+
+TEST(SignalDefinitions, UnknownCombinationsFailExplicitly) {
+    EXPECT_EQ(gnss_sim::find_signal_definition_by_rinex(gnss_sim::GnssConstellation::kGps, "9Z"), nullptr);
+    EXPECT_EQ(gnss_sim::find_signal_definition_by_rinex(gnss_sim::GnssConstellation::kGps, nullptr), nullptr);
+    EXPECT_EQ(gnss_sim::find_signal_definition_by_oem7(gnss_sim::GnssConstellation::kGps, 999), nullptr);
+
+    int code = 0;
+    int frequency = 0;
+    EXPECT_FALSE(gnss_sim::rtklib_observation_code("9Z", &code, &frequency));
+}
+
+TEST(SignalDefinitions, GlonassG1AndG2UseFcnDependentFrequencyAndWavelength) {
+    const gnss_sim::SignalDefinition* g1 = gnss_sim::find_signal_definition(gnss_sim::SignalId::kGlonassG1);
+    const gnss_sim::SignalDefinition* g2 = gnss_sim::find_signal_definition(gnss_sim::SignalId::kGlonassG2);
+    ASSERT_NE(g1, nullptr);
+    ASSERT_NE(g2, nullptr);
+
+    double g1_minus7 = 0.0;
+    double g1_plus6 = 0.0;
+    double g2_minus7 = 0.0;
+    double g2_plus6 = 0.0;
+    ASSERT_TRUE(gnss_sim::signal_carrier_frequency_hz(*g1, -7, &g1_minus7));
+    ASSERT_TRUE(gnss_sim::signal_carrier_frequency_hz(*g1, 6, &g1_plus6));
+    ASSERT_TRUE(gnss_sim::signal_carrier_frequency_hz(*g2, -7, &g2_minus7));
+    ASSERT_TRUE(gnss_sim::signal_carrier_frequency_hz(*g2, 6, &g2_plus6));
+
+    EXPECT_NEAR(g1_minus7, 1598.0625e6, 1e-3);
+    EXPECT_NEAR(g1_plus6, 1605.375e6, 1e-3);
+    EXPECT_NEAR(g2_minus7, 1242.9375e6, 1e-3);
+    EXPECT_NEAR(g2_plus6, 1248.625e6, 1e-3);
+    EXPECT_FALSE(gnss_sim::signal_carrier_frequency_hz(*g1, -8, &g1_minus7));
+    EXPECT_FALSE(gnss_sim::signal_carrier_frequency_hz(*g2, 7, &g2_plus6));
+
+    double wavelength_minus7 = 0.0;
+    double wavelength_plus6 = 0.0;
+    ASSERT_TRUE(gnss_sim::signal_wavelength_m(*g1, -7, &wavelength_minus7));
+    ASSERT_TRUE(gnss_sim::signal_wavelength_m(*g1, 6, &wavelength_plus6));
+    EXPECT_NE(wavelength_minus7, wavelength_plus6);
+}
+
+TEST(SignalDefinitions, GlonassG3UsesFixedL3OcCarrier) {
+    const gnss_sim::SignalDefinition* g3 = gnss_sim::find_signal_definition(gnss_sim::SignalId::kGlonassG3);
+    ASSERT_NE(g3, nullptr);
+
+    double frequency_minus7 = 0.0;
+    double frequency_plus6 = 0.0;
+    ASSERT_TRUE(gnss_sim::signal_carrier_frequency_hz(*g3, -7, &frequency_minus7));
+    ASSERT_TRUE(gnss_sim::signal_carrier_frequency_hz(*g3, 6, &frequency_plus6));
+    EXPECT_DOUBLE_EQ(frequency_minus7, 1202.025e6);
+    EXPECT_DOUBLE_EQ(frequency_plus6, 1202.025e6);
+}
+
+TEST(SignalDefinitions, WavelengthMatchesSpeedOfLightOverCarrier) {
+    const gnss_sim::SignalDefinition* gps_l1 = gnss_sim::find_signal_definition(gnss_sim::SignalId::kGpsL1Ca);
+    ASSERT_NE(gps_l1, nullptr);
+
+    double wavelength_m = 0.0;
+    ASSERT_TRUE(gnss_sim::signal_wavelength_m(*gps_l1, 0, &wavelength_m));
+    EXPECT_NEAR(wavelength_m, 299792458.0 / 1575.42e6, 1e-15);
+}
+
+} // namespace

--- a/tests/unit/test_sim_time.cpp
+++ b/tests/unit/test_sim_time.cpp
@@ -11,7 +11,7 @@ TEST(SimTime, UsesIntegerNanosecondsAndPinnedRtklibRevision) {
     const gnss_sim::SimTime time{2300, 123456789LL};
     EXPECT_EQ(time.gps_week, 2300);
     EXPECT_EQ(time.tow_ns, 123456789LL);
-    EXPECT_STREQ(gnss_sim::rtklib_commit_sha(), "47bb6cf9935b510109d16f46baa35c648e56f1b5");
+    EXPECT_STREQ(gnss_sim::rtklib_commit_sha(), "07e813b72c8667350c4e80293cb6679c519ef1a6");
     EXPECT_EQ(std::strlen(gnss_sim::rtklib_commit_sha()), 40U);
 }
 


### PR DESCRIPTION
Closes #5.

## Summary
- add one authoritative `SignalDefinition` table for all 21 frozen V1 signals across GPS/QZSS/GLONASS/Galileo/BeiDou;
- centralize RINEX signal code, carrier model, NAV message family, code-bias semantic, and NovAtel OEM7 RANGE type;
- resolve RTKLIB observation codes through the RTKLIB adapter rather than duplicating code-number mappings;
- pin RTKLIB to `07e813b72c8667350c4e80293cb6679c519ef1a6`, which owns the required BDS B2a `5P` and B2b `7D` observation-code extensions;
- implement GLONASS G1/G2 FCN-dependent frequencies/wavelengths and fixed G3 carrier handling;
- reject unsupported lookups explicitly and cover every V1 entry, duplicate keys, RTKLIB resolution, OEM7 round trips, and GLONASS frequency behavior in unit tests.

## Implementation Notes
The simulator does not define private numeric observation codes for modern BDS signals. `rtklib_observation_code()` calls the pinned fork's `obs2code_ext()` API. This keeps RTKLIB as the owner of RINEX observation-code semantics while `signal_definitions.cpp` remains the simulator's single source of truth for signal-level behavior.

The `CodeBiasModel` values are semantic selectors, not raw `eph_t` array indexes. A later measurement-model issue will resolve each semantic against the selected RINEX NAV message (TGD/ISC/BGD or GLONASS `dtaun`) without leaking RTKLIB structures beyond the adapter.

CI must pass formatting plus Ubuntu/GCC and Windows/MSVC before merge.