### PR TITLE
Implement receiver truth and satellite geometry engine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,9 @@ add_library(gnss_sim_core STATIC
     src/core/sim_time.cpp
     src/core/simulator.cpp
     src/gnss/rtklib_adapter.cpp
+    src/gnss/satellite_engine.cpp
     src/gnss/signal_definitions.cpp
+    src/model/receiver_truth.cpp
 )
 add_library(gnss_sim::core ALIAS gnss_sim_core)
 target_include_directories(gnss_sim_core
@@ -102,7 +104,9 @@ if(BUILD_TESTING)
 
     add_executable(gnss_sim_unit_tests
         tests/unit/test_deterministic_rng.cpp
+        tests/unit/test_receiver_truth.cpp
         tests/unit/test_rtklib_adapter.cpp
+        tests/unit/test_satellite_engine.cpp
         tests/unit/test_signal_definitions.cpp
         tests/unit/test_sim_config.cpp
         tests/unit/test_sim_time.cpp

--- a/src/gnss/rtklib_adapter.cpp
+++ b/src/gnss/rtklib_adapter.cpp
@@ -35,6 +35,10 @@ bool valid_gps_time(int gps_week, double sow_sec) {
     return gps_week >= 0 && std::isfinite(sow_sec) && sow_sec >= 0.0 && sow_sec < 604800.0;
 }
 
+bool finite_vector3(const double vector[3]) {
+    return vector != nullptr && std::isfinite(vector[0]) && std::isfinite(vector[1]) && std::isfinite(vector[2]);
+}
+
 std::string rtklib_file_path(const char* file_path) {
     std::string path(file_path);
 #ifdef _WIN32
@@ -204,13 +208,8 @@ bool rtklib_llh_to_ecef(double latitude_deg, double longitude_deg, double height
 }
 
 bool rtklib_ecef_to_llh(const double ecef_m[3], double* latitude_deg, double* longitude_deg, double* height_m) {
-    if (ecef_m == nullptr || latitude_deg == nullptr || longitude_deg == nullptr || height_m == nullptr) {
+    if (!finite_vector3(ecef_m) || latitude_deg == nullptr || longitude_deg == nullptr || height_m == nullptr) {
         return false;
-    }
-    for (int index = 0; index < 3; ++index) {
-        if (!std::isfinite(ecef_m[index])) {
-            return false;
-        }
     }
 
     double position_rad_m[3]{};
@@ -219,6 +218,35 @@ bool rtklib_ecef_to_llh(const double ecef_m[3], double* latitude_deg, double* lo
     *longitude_deg = position_rad_m[1] * R2D;
     *height_m = position_rad_m[2];
     return true;
+}
+
+bool rtklib_geometric_distance(const double satellite_ecef_m[3], const double receiver_ecef_m[3], double* range_m,
+                               double line_of_sight_ecef[3]) {
+    if (!finite_vector3(satellite_ecef_m) || !finite_vector3(receiver_ecef_m) || range_m == nullptr ||
+        line_of_sight_ecef == nullptr) {
+        return false;
+    }
+    const double range = geodist(satellite_ecef_m, receiver_ecef_m, line_of_sight_ecef);
+    if (!std::isfinite(range) || range <= 0.0) {
+        return false;
+    }
+    *range_m = range;
+    return true;
+}
+
+bool rtklib_azimuth_elevation(const double receiver_ecef_m[3], const double line_of_sight_ecef[3],
+                              double* azimuth_rad, double* elevation_rad) {
+    if (!finite_vector3(receiver_ecef_m) || !finite_vector3(line_of_sight_ecef) || azimuth_rad == nullptr ||
+        elevation_rad == nullptr) {
+        return false;
+    }
+    double position_rad_m[3]{};
+    double azel[2]{};
+    ecef2pos(receiver_ecef_m, position_rad_m);
+    satazel(position_rad_m, line_of_sight_ecef, azel);
+    *azimuth_rad = azel[0];
+    *elevation_rad = azel[1];
+    return std::isfinite(*azimuth_rad) && std::isfinite(*elevation_rad);
 }
 
 } // namespace gnss_sim

--- a/src/gnss/rtklib_adapter.cpp
+++ b/src/gnss/rtklib_adapter.cpp
@@ -234,8 +234,8 @@ bool rtklib_geometric_distance(const double satellite_ecef_m[3], const double re
     return true;
 }
 
-bool rtklib_azimuth_elevation(const double receiver_ecef_m[3], const double line_of_sight_ecef[3],
-                              double* azimuth_rad, double* elevation_rad) {
+bool rtklib_azimuth_elevation(const double receiver_ecef_m[3], const double line_of_sight_ecef[3], double* azimuth_rad,
+                              double* elevation_rad) {
     if (!finite_vector3(receiver_ecef_m) || !finite_vector3(line_of_sight_ecef) || azimuth_rad == nullptr ||
         elevation_rad == nullptr) {
         return false;

--- a/src/gnss/rtklib_adapter.h
+++ b/src/gnss/rtklib_adapter.h
@@ -38,6 +38,10 @@ bool get_rtklib_satellite_state(const RtklibNavStore* store, int gps_week, doubl
 
 bool rtklib_llh_to_ecef(double latitude_deg, double longitude_deg, double height_m, double ecef_m[3]);
 bool rtklib_ecef_to_llh(const double ecef_m[3], double* latitude_deg, double* longitude_deg, double* height_m);
+bool rtklib_geometric_distance(const double satellite_ecef_m[3], const double receiver_ecef_m[3], double* range_m,
+                               double line_of_sight_ecef[3]);
+bool rtklib_azimuth_elevation(const double receiver_ecef_m[3], const double line_of_sight_ecef[3],
+                              double* azimuth_rad, double* elevation_rad);
 
 } // namespace gnss_sim
 

--- a/src/gnss/rtklib_adapter.h
+++ b/src/gnss/rtklib_adapter.h
@@ -40,8 +40,8 @@ bool rtklib_llh_to_ecef(double latitude_deg, double longitude_deg, double height
 bool rtklib_ecef_to_llh(const double ecef_m[3], double* latitude_deg, double* longitude_deg, double* height_m);
 bool rtklib_geometric_distance(const double satellite_ecef_m[3], const double receiver_ecef_m[3], double* range_m,
                                double line_of_sight_ecef[3]);
-bool rtklib_azimuth_elevation(const double receiver_ecef_m[3], const double line_of_sight_ecef[3],
-                              double* azimuth_rad, double* elevation_rad);
+bool rtklib_azimuth_elevation(const double receiver_ecef_m[3], const double line_of_sight_ecef[3], double* azimuth_rad,
+                              double* elevation_rad);
 
 } // namespace gnss_sim
 

--- a/src/gnss/satellite_engine.cpp
+++ b/src/gnss/satellite_engine.cpp
@@ -66,8 +66,8 @@ bool subtract_propagation_time(const SimTime& receive_time, double propagation_t
     }
 
     int week = receive_time.gps_week;
-    double sow_sec = static_cast<double>(receive_time.tow_ns) / static_cast<double>(NANOSECONDS_PER_SECOND) -
-                     propagation_time_sec;
+    double sow_sec =
+        static_cast<double>(receive_time.tow_ns) / static_cast<double>(NANOSECONDS_PER_SECOND) - propagation_time_sec;
     while (sow_sec < 0.0) {
         if (week == 0) {
             return false;
@@ -119,15 +119,15 @@ bool compute_satellite_geometry(const RtklibNavStore* nav_store, const ReceiverT
         }
 
         RtklibSatelliteState satellite_state{};
-        if (!get_rtklib_satellite_state(nav_store, transmit_week, transmit_sow_sec, satellite_number,
-                                        &satellite_state, error_message)) {
+        if (!get_rtklib_satellite_state(nav_store, transmit_week, transmit_sow_sec, satellite_number, &satellite_state,
+                                        error_message)) {
             return false;
         }
 
         double line_of_sight_ecef[3]{};
         double geometric_range_m = 0.0;
-        if (!rtklib_geometric_distance(satellite_state.position_ecef_m, receiver.position_ecef_m,
-                                       &geometric_range_m, line_of_sight_ecef)) {
+        if (!rtklib_geometric_distance(satellite_state.position_ecef_m, receiver.position_ecef_m, &geometric_range_m,
+                                       line_of_sight_ecef)) {
             set_error(error_message, "RTKLIB geometric-distance calculation failed");
             return false;
         }

--- a/src/gnss/satellite_engine.cpp
+++ b/src/gnss/satellite_engine.cpp
@@ -1,1 +1,187 @@
-// Satellite geometry implementation is introduced by issue #6.
+#include "gnss/satellite_engine.h"
+
+#include "gnss_sim/sim_time.h"
+
+#include <cmath>
+
+namespace gnss_sim {
+namespace {
+
+constexpr double kSpeedOfLightMps = 299792458.0;
+constexpr double kEarthRotationRateRadPerSec = 7.2921151467e-5;
+constexpr double kInitialPropagationTimeSec = 0.075;
+constexpr double kPropagationConvergenceSec = 1.0e-11;
+constexpr int kMaxPropagationIterations = 12;
+constexpr double kDegreesToRadians = 3.141592653589793238462643383279502884 / 180.0;
+
+void set_error(std::string* error_message, const char* message) {
+    if (error_message != nullptr) {
+        *error_message = message;
+    }
+}
+
+bool finite_vector3(const double value[3]) {
+    return value != nullptr && std::isfinite(value[0]) && std::isfinite(value[1]) && std::isfinite(value[2]);
+}
+
+bool compute_range_rate(const RtklibSatelliteState& satellite_state, const ReceiverTruth& receiver,
+                        const double line_of_sight_ecef[3], double* range_rate_mps) {
+    if (range_rate_mps == nullptr || !finite_vector3(satellite_state.position_ecef_m) ||
+        !finite_vector3(satellite_state.velocity_ecef_mps) || !finite_vector3(receiver.position_ecef_m) ||
+        !finite_vector3(receiver.velocity_ecef_mps) || !finite_vector3(line_of_sight_ecef)) {
+        return false;
+    }
+
+    double relative_velocity_ecef_mps[3]{};
+    for (int index = 0; index < 3; ++index) {
+        relative_velocity_ecef_mps[index] =
+            satellite_state.velocity_ecef_mps[index] - receiver.velocity_ecef_mps[index];
+    }
+
+    double rate_mps = 0.0;
+    for (int index = 0; index < 3; ++index) {
+        rate_mps += relative_velocity_ecef_mps[index] * line_of_sight_ecef[index];
+    }
+
+    // Match RTKLIB pntpos.c/resdop(): range rate includes the time derivative
+    // of geodist()'s first-order Earth-rotation correction.
+    rate_mps += kEarthRotationRateRadPerSec / kSpeedOfLightMps *
+                (satellite_state.velocity_ecef_mps[1] * receiver.position_ecef_m[0] +
+                 satellite_state.position_ecef_m[1] * receiver.velocity_ecef_mps[0] -
+                 satellite_state.velocity_ecef_mps[0] * receiver.position_ecef_m[1] -
+                 satellite_state.position_ecef_m[0] * receiver.velocity_ecef_mps[1]);
+
+    *range_rate_mps = rate_mps;
+    return std::isfinite(rate_mps);
+}
+
+} // namespace
+
+bool subtract_propagation_time(const SimTime& receive_time, double propagation_time_sec, int* transmit_gps_week,
+                               double* transmit_sow_sec) {
+    if (transmit_gps_week == nullptr || transmit_sow_sec == nullptr || receive_time.gps_week < 0 ||
+        receive_time.tow_ns < 0 || receive_time.tow_ns >= GPS_WEEK_NANOSECONDS ||
+        !std::isfinite(propagation_time_sec) || propagation_time_sec < 0.0) {
+        return false;
+    }
+
+    int week = receive_time.gps_week;
+    double sow_sec = static_cast<double>(receive_time.tow_ns) / static_cast<double>(NANOSECONDS_PER_SECOND) -
+                     propagation_time_sec;
+    while (sow_sec < 0.0) {
+        if (week == 0) {
+            return false;
+        }
+        --week;
+        sow_sec += static_cast<double>(GPS_WEEK_SECONDS);
+    }
+    while (sow_sec >= static_cast<double>(GPS_WEEK_SECONDS)) {
+        ++week;
+        sow_sec -= static_cast<double>(GPS_WEEK_SECONDS);
+    }
+
+    *transmit_gps_week = week;
+    *transmit_sow_sec = sow_sec;
+    return true;
+}
+
+bool elevation_passes_mask(double elevation_rad, double elevation_mask_deg) {
+    if (!std::isfinite(elevation_rad) || !std::isfinite(elevation_mask_deg) || elevation_mask_deg < -90.0 ||
+        elevation_mask_deg > 90.0) {
+        return false;
+    }
+    return elevation_rad >= elevation_mask_deg * kDegreesToRadians;
+}
+
+bool compute_satellite_geometry(const RtklibNavStore* nav_store, const ReceiverTruth& receiver,
+                                const SimTime& receive_time, int satellite_number, double elevation_mask_deg,
+                                SatelliteGeometry* geometry, std::string* error_message) {
+    if (nav_store == nullptr || geometry == nullptr || satellite_number <= 0 || receive_time.gps_week < 0 ||
+        receive_time.tow_ns < 0 || receive_time.tow_ns >= GPS_WEEK_NANOSECONDS ||
+        !finite_vector3(receiver.position_ecef_m) || !finite_vector3(receiver.velocity_ecef_mps) ||
+        !std::isfinite(elevation_mask_deg) || elevation_mask_deg < -90.0 || elevation_mask_deg > 90.0) {
+        set_error(error_message, "satellite-geometry request has invalid arguments");
+        return false;
+    }
+
+    SatelliteGeometry result{};
+    result.receive_time = receive_time;
+    result.satellite_number = satellite_number;
+
+    double propagation_time_sec = kInitialPropagationTimeSec;
+    bool converged = false;
+    for (int iteration = 0; iteration < kMaxPropagationIterations; ++iteration) {
+        int transmit_week = 0;
+        double transmit_sow_sec = 0.0;
+        if (!subtract_propagation_time(receive_time, propagation_time_sec, &transmit_week, &transmit_sow_sec)) {
+            set_error(error_message, "cannot derive satellite transmit time from receive time");
+            return false;
+        }
+
+        RtklibSatelliteState satellite_state{};
+        if (!get_rtklib_satellite_state(nav_store, transmit_week, transmit_sow_sec, satellite_number,
+                                        &satellite_state, error_message)) {
+            return false;
+        }
+
+        double line_of_sight_ecef[3]{};
+        double geometric_range_m = 0.0;
+        if (!rtklib_geometric_distance(satellite_state.position_ecef_m, receiver.position_ecef_m,
+                                       &geometric_range_m, line_of_sight_ecef)) {
+            set_error(error_message, "RTKLIB geometric-distance calculation failed");
+            return false;
+        }
+
+        const double next_propagation_time_sec = geometric_range_m / kSpeedOfLightMps;
+        if (!std::isfinite(next_propagation_time_sec) || next_propagation_time_sec <= 0.0) {
+            set_error(error_message, "computed propagation time is invalid");
+            return false;
+        }
+
+        result.transmit_gps_week = transmit_week;
+        result.transmit_sow_sec = transmit_sow_sec;
+        result.satellite_state = satellite_state;
+        result.geometric_range_m = geometric_range_m;
+        result.propagation_time_sec = next_propagation_time_sec;
+        result.iteration_count = iteration + 1;
+        for (int index = 0; index < 3; ++index) {
+            result.line_of_sight_ecef[index] = line_of_sight_ecef[index];
+        }
+
+        if (std::fabs(next_propagation_time_sec - propagation_time_sec) <= kPropagationConvergenceSec) {
+            converged = true;
+            break;
+        }
+        propagation_time_sec = next_propagation_time_sec;
+    }
+
+    if (!converged) {
+        set_error(error_message, "satellite transmit-time iteration did not converge");
+        return false;
+    }
+
+    // Re-evaluate the state at the converged propagation time so transmit_time,
+    // satellite_state, and geometric_range describe the same final iterate.
+    if (!subtract_propagation_time(receive_time, result.propagation_time_sec, &result.transmit_gps_week,
+                                   &result.transmit_sow_sec) ||
+        !get_rtklib_satellite_state(nav_store, result.transmit_gps_week, result.transmit_sow_sec, satellite_number,
+                                    &result.satellite_state, error_message) ||
+        !rtklib_geometric_distance(result.satellite_state.position_ecef_m, receiver.position_ecef_m,
+                                   &result.geometric_range_m, result.line_of_sight_ecef) ||
+        !rtklib_azimuth_elevation(receiver.position_ecef_m, result.line_of_sight_ecef, &result.azimuth_rad,
+                                  &result.elevation_rad) ||
+        !compute_range_rate(result.satellite_state, receiver, result.line_of_sight_ecef, &result.range_rate_mps)) {
+        set_error(error_message, "final satellite geometry evaluation failed");
+        return false;
+    }
+
+    result.propagation_time_sec = result.geometric_range_m / kSpeedOfLightMps;
+    result.healthy = result.satellite_state.health == 0;
+    result.above_elevation_mask = elevation_passes_mask(result.elevation_rad, elevation_mask_deg);
+    result.visible = result.healthy && result.above_elevation_mask;
+
+    *geometry = result;
+    return true;
+}
+
+} // namespace gnss_sim

--- a/src/gnss/satellite_engine.h
+++ b/src/gnss/satellite_engine.h
@@ -1,0 +1,39 @@
+#ifndef GNSS_SIM_SRC_GNSS_SATELLITE_ENGINE_H_
+#define GNSS_SIM_SRC_GNSS_SATELLITE_ENGINE_H_
+
+#include "gnss/rtklib_adapter.h"
+#include "gnss_sim/sim_types.h"
+#include "model/receiver_truth.h"
+
+#include <string>
+
+namespace gnss_sim {
+
+struct SatelliteGeometry {
+    SimTime receive_time;
+    int transmit_gps_week;
+    double transmit_sow_sec;
+    int satellite_number;
+    RtklibSatelliteState satellite_state;
+    double line_of_sight_ecef[3];
+    double geometric_range_m;
+    double range_rate_mps;
+    double propagation_time_sec;
+    double azimuth_rad;
+    double elevation_rad;
+    int iteration_count;
+    bool healthy;
+    bool above_elevation_mask;
+    bool visible;
+};
+
+bool subtract_propagation_time(const SimTime& receive_time, double propagation_time_sec, int* transmit_gps_week,
+                               double* transmit_sow_sec);
+bool elevation_passes_mask(double elevation_rad, double elevation_mask_deg);
+bool compute_satellite_geometry(const RtklibNavStore* nav_store, const ReceiverTruth& receiver,
+                                const SimTime& receive_time, int satellite_number, double elevation_mask_deg,
+                                SatelliteGeometry* geometry, std::string* error_message);
+
+} // namespace gnss_sim
+
+#endif // GNSS_SIM_SRC_GNSS_SATELLITE_ENGINE_H_

--- a/src/model/receiver_truth.cpp
+++ b/src/model/receiver_truth.cpp
@@ -1,1 +1,34 @@
-// Receiver truth implementation is introduced by issue #6.
+#include "model/receiver_truth.h"
+
+#include "gnss/rtklib_adapter.h"
+
+namespace gnss_sim {
+
+bool make_static_receiver_truth(const ReceiverConfig& receiver_config, ReceiverTruth* truth,
+                                std::string* error_message) {
+    if (truth == nullptr) {
+        if (error_message != nullptr) {
+            *error_message = "receiver truth output must not be null";
+        }
+        return false;
+    }
+
+    ReceiverTruth result{};
+    result.latitude_deg = receiver_config.latitude_deg;
+    result.longitude_deg = receiver_config.longitude_deg;
+    result.height_m = receiver_config.height_m;
+    if (!rtklib_llh_to_ecef(result.latitude_deg, result.longitude_deg, result.height_m, result.position_ecef_m)) {
+        if (error_message != nullptr) {
+            *error_message = "receiver LLH is invalid or cannot be converted to ECEF";
+        }
+        return false;
+    }
+
+    result.velocity_ecef_mps[0] = 0.0;
+    result.velocity_ecef_mps[1] = 0.0;
+    result.velocity_ecef_mps[2] = 0.0;
+    *truth = result;
+    return true;
+}
+
+} // namespace gnss_sim

--- a/src/model/receiver_truth.h
+++ b/src/model/receiver_truth.h
@@ -1,0 +1,23 @@
+#ifndef GNSS_SIM_SRC_MODEL_RECEIVER_TRUTH_H_
+#define GNSS_SIM_SRC_MODEL_RECEIVER_TRUTH_H_
+
+#include "gnss_sim/sim_config.h"
+
+#include <string>
+
+namespace gnss_sim {
+
+struct ReceiverTruth {
+    double latitude_deg;
+    double longitude_deg;
+    double height_m;
+    double position_ecef_m[3];
+    double velocity_ecef_mps[3];
+};
+
+bool make_static_receiver_truth(const ReceiverConfig& receiver_config, ReceiverTruth* truth,
+                                std::string* error_message);
+
+} // namespace gnss_sim
+
+#endif // GNSS_SIM_SRC_MODEL_RECEIVER_TRUTH_H_

--- a/tests/unit/test_receiver_truth.cpp
+++ b/tests/unit/test_receiver_truth.cpp
@@ -1,0 +1,48 @@
+#include "model/receiver_truth.h"
+
+#include "gnss/rtklib_adapter.h"
+#include "gnss_sim/sim_config.h"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <string>
+
+namespace {
+
+TEST(ReceiverTruth, DefaultStaticSiteRoundTripsThroughRtklib) {
+    const gnss_sim::SimConfig config = gnss_sim::default_sim_config();
+    gnss_sim::ReceiverTruth truth{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::make_static_receiver_truth(config.receiver, &truth, &error_message)) << error_message;
+
+    EXPECT_DOUBLE_EQ(truth.latitude_deg, 20.0);
+    EXPECT_DOUBLE_EQ(truth.longitude_deg, 120.0);
+    EXPECT_DOUBLE_EQ(truth.height_m, 100.0);
+    EXPECT_DOUBLE_EQ(truth.velocity_ecef_mps[0], 0.0);
+    EXPECT_DOUBLE_EQ(truth.velocity_ecef_mps[1], 0.0);
+    EXPECT_DOUBLE_EQ(truth.velocity_ecef_mps[2], 0.0);
+
+    double latitude_deg = 0.0;
+    double longitude_deg = 0.0;
+    double height_m = 0.0;
+    ASSERT_TRUE(gnss_sim::rtklib_ecef_to_llh(truth.position_ecef_m, &latitude_deg, &longitude_deg, &height_m));
+    EXPECT_NEAR(latitude_deg, 20.0, 1.0e-10);
+    EXPECT_NEAR(longitude_deg, 120.0, 1.0e-10);
+    EXPECT_NEAR(height_m, 100.0, 1.0e-6);
+}
+
+TEST(ReceiverTruth, RejectsInvalidCoordinatesAndNullOutput) {
+    gnss_sim::ReceiverConfig invalid{91.0, 120.0, 100.0};
+    gnss_sim::ReceiverTruth truth{};
+    std::string error_message;
+    EXPECT_FALSE(gnss_sim::make_static_receiver_truth(invalid, &truth, &error_message));
+    EXPECT_FALSE(error_message.empty());
+
+    const gnss_sim::ReceiverConfig valid{20.0, 120.0, 100.0};
+    error_message.clear();
+    EXPECT_FALSE(gnss_sim::make_static_receiver_truth(valid, nullptr, &error_message));
+    EXPECT_FALSE(error_message.empty());
+}
+
+} // namespace

--- a/tests/unit/test_receiver_truth.cpp
+++ b/tests/unit/test_receiver_truth.cpp
@@ -1,11 +1,9 @@
-#include "model/receiver_truth.h"
-
 #include "gnss/rtklib_adapter.h"
 #include "gnss_sim/sim_config.h"
-
-#include <gtest/gtest.h>
+#include "model/receiver_truth.h"
 
 #include <cmath>
+#include <gtest/gtest.h>
 #include <string>
 
 namespace {

--- a/tests/unit/test_satellite_engine.cpp
+++ b/tests/unit/test_satellite_engine.cpp
@@ -1,6 +1,5 @@
-#include "gnss/satellite_engine.h"
-
 #include "gnss/rtklib_adapter.h"
+#include "gnss/satellite_engine.h"
 #include "gnss_sim/sim_config.h"
 #include "gnss_sim/sim_time.h"
 #include "model/receiver_truth.h"
@@ -51,8 +50,7 @@ class SatelliteEngineTest : public ::testing::Test {
             << error_message;
 
         const gnss_sim::SimConfig config = gnss_sim::default_sim_config();
-        ASSERT_TRUE(gnss_sim::make_static_receiver_truth(config.receiver, &receiver_, &error_message))
-            << error_message;
+        ASSERT_TRUE(gnss_sim::make_static_receiver_truth(config.receiver, &receiver_, &error_message)) << error_message;
     }
 
     void TearDown() override {
@@ -165,10 +163,8 @@ TEST_F(SatelliteEngineTest, GeometryMatchesDirectRtklibReferenceAtConvergedTrans
     }
     reference_range_rate_mps +=
         OMGE / kSpeedOfLightMps *
-        (reference_state[4] * receiver_.position_ecef_m[0] +
-         reference_state[1] * receiver_.velocity_ecef_mps[0] -
-         reference_state[3] * receiver_.position_ecef_m[1] -
-         reference_state[0] * receiver_.velocity_ecef_mps[1]);
+        (reference_state[4] * receiver_.position_ecef_m[0] + reference_state[1] * receiver_.velocity_ecef_mps[0] -
+         reference_state[3] * receiver_.position_ecef_m[1] - reference_state[0] * receiver_.velocity_ecef_mps[1]);
 
     for (int index = 0; index < 3; ++index) {
         EXPECT_NEAR(geometry.satellite_state.position_ecef_m[index], reference_state[index], 1.0e-6);

--- a/tests/unit/test_satellite_engine.cpp
+++ b/tests/unit/test_satellite_engine.cpp
@@ -1,0 +1,214 @@
+#include "gnss/satellite_engine.h"
+
+#include "gnss/rtklib_adapter.h"
+#include "gnss_sim/sim_config.h"
+#include "gnss_sim/sim_time.h"
+#include "model/receiver_truth.h"
+
+#include <gtest/gtest.h>
+
+extern "C" {
+#include <rtklib.h>
+}
+
+#ifdef lock
+#undef lock
+#endif
+#ifdef unlock
+#undef unlock
+#endif
+
+#include <cmath>
+#include <string>
+
+namespace {
+
+constexpr double kSpeedOfLightMps = 299792458.0;
+
+std::string test_nav_path() {
+    return std::string(GNSS_SIM_TEST_DATA_DIR) + "/mixed_nav_2019.rnx";
+}
+
+std::string rtklib_reference_nav_path() {
+    std::string path = test_nav_path();
+#ifdef _WIN32
+    for (char& character : path) {
+        if (character == '/') {
+            character = '\\';
+        }
+    }
+#endif
+    return path;
+}
+
+class SatelliteEngineTest : public ::testing::Test {
+  protected:
+    void SetUp() override {
+        nav_store_ = gnss_sim::create_rtklib_nav_store();
+        ASSERT_NE(nav_store_, nullptr);
+        std::string error_message;
+        ASSERT_TRUE(gnss_sim::load_rinex_nav_file(nav_store_, test_nav_path().c_str(), &error_message))
+            << error_message;
+
+        const gnss_sim::SimConfig config = gnss_sim::default_sim_config();
+        ASSERT_TRUE(gnss_sim::make_static_receiver_truth(config.receiver, &receiver_, &error_message))
+            << error_message;
+    }
+
+    void TearDown() override {
+        gnss_sim::destroy_rtklib_nav_store(nav_store_);
+    }
+
+    gnss_sim::RtklibNavStore* nav_store_ = nullptr;
+    gnss_sim::ReceiverTruth receiver_{};
+};
+
+TEST(SatelliteEngineTime, PropagationSubtractionCrossesGpsWeek) {
+    const gnss_sim::SimTime receive_time{2300, 50000000LL};
+    int transmit_week = 0;
+    double transmit_sow_sec = 0.0;
+    ASSERT_TRUE(gnss_sim::subtract_propagation_time(receive_time, 0.075, &transmit_week, &transmit_sow_sec));
+    EXPECT_EQ(transmit_week, 2299);
+    EXPECT_NEAR(transmit_sow_sec, 604799.975, 1.0e-12);
+}
+
+TEST(SatelliteEngineMask, ExactlyOnAndAroundThreeDegreesAreDeterministic) {
+    const double three_deg_rad = 3.0 * D2R;
+    EXPECT_TRUE(gnss_sim::elevation_passes_mask(three_deg_rad, 3.0));
+    EXPECT_FALSE(gnss_sim::elevation_passes_mask(three_deg_rad - 1.0e-12, 3.0));
+    EXPECT_TRUE(gnss_sim::elevation_passes_mask(three_deg_rad + 1.0e-12, 3.0));
+}
+
+TEST_F(SatelliteEngineTest, TransmitTimeConvergesForRepresentativeSatellitesInEveryConstellation) {
+    struct Case {
+        const char* satellite_id;
+        int gps_week;
+        double receive_sow_sec;
+    };
+    const Case cases[] = {
+        {"G01", 2041, 176400.0}, {"E01", 2041, 176400.0}, {"C01", 2041, 176400.0},
+        {"J01", 2041, 176400.0}, {"R26", 2041, 258300.0},
+    };
+
+    for (const Case& test_case : cases) {
+        SCOPED_TRACE(test_case.satellite_id);
+        int satellite_number = 0;
+        ASSERT_TRUE(gnss_sim::rtklib_satellite_id_to_number(test_case.satellite_id, &satellite_number));
+
+        gnss_sim::SimTime receive_time{};
+        ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(test_case.gps_week, test_case.receive_sow_sec, &receive_time));
+        gnss_sim::SatelliteGeometry geometry{};
+        std::string error_message;
+        ASSERT_TRUE(gnss_sim::compute_satellite_geometry(nav_store_, receiver_, receive_time, satellite_number, 3.0,
+                                                         &geometry, &error_message))
+            << error_message;
+
+        EXPECT_GE(geometry.iteration_count, 1);
+        EXPECT_LE(geometry.iteration_count, 12);
+        EXPECT_GT(geometry.propagation_time_sec, 0.04);
+        EXPECT_LT(geometry.propagation_time_sec, 0.20);
+        EXPECT_GT(geometry.geometric_range_m, 1.0e7);
+        EXPECT_LT(geometry.geometric_range_m, 6.0e7);
+        EXPECT_TRUE(std::isfinite(geometry.range_rate_mps));
+        EXPECT_TRUE(std::isfinite(geometry.azimuth_rad));
+        EXPECT_TRUE(std::isfinite(geometry.elevation_rad));
+        EXPECT_EQ(geometry.visible, geometry.healthy && geometry.above_elevation_mask);
+
+        const double receive_sow = gnss_sim::sim_time_sow_sec(receive_time);
+        if (geometry.transmit_gps_week == receive_time.gps_week) {
+            EXPECT_LT(geometry.transmit_sow_sec, receive_sow);
+        }
+    }
+}
+
+TEST_F(SatelliteEngineTest, GeometryMatchesDirectRtklibReferenceAtConvergedTransmitTime) {
+    int satellite_number = 0;
+    ASSERT_TRUE(gnss_sim::rtklib_satellite_id_to_number("G01", &satellite_number));
+    gnss_sim::SimTime receive_time{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2041, 180000.0, &receive_time));
+
+    gnss_sim::SatelliteGeometry geometry{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::compute_satellite_geometry(nav_store_, receiver_, receive_time, satellite_number, 3.0,
+                                                     &geometry, &error_message))
+        << error_message;
+
+    nav_t reference_nav{};
+    obs_t reference_obs{};
+    sta_t reference_station{};
+    const std::string reference_path = rtklib_reference_nav_path();
+    ASSERT_NE(readrnx(reference_path.c_str(), 1, "", &reference_obs, &reference_nav, &reference_station), 0);
+    freeobs(&reference_obs);
+    uniqnav(&reference_nav);
+
+    const gtime_t transmit_time = gpst2time(geometry.transmit_gps_week, geometry.transmit_sow_sec);
+    double reference_state[6]{};
+    double reference_clock[2]{};
+    double reference_variance_m2 = 0.0;
+    int reference_health = 0;
+    ASSERT_NE(satpos(transmit_time, transmit_time, satellite_number, EPHOPT_BRDC, &reference_nav, reference_state,
+                     reference_clock, &reference_variance_m2, &reference_health),
+              0);
+
+    double reference_los[3]{};
+    const double reference_range_m = geodist(reference_state, receiver_.position_ecef_m, reference_los);
+    ASSERT_GT(reference_range_m, 0.0);
+    double receiver_pos[3]{};
+    double reference_azel[2]{};
+    ecef2pos(receiver_.position_ecef_m, receiver_pos);
+    satazel(receiver_pos, reference_los, reference_azel);
+
+    double reference_range_rate_mps = 0.0;
+    for (int index = 0; index < 3; ++index) {
+        reference_range_rate_mps +=
+            (reference_state[index + 3] - receiver_.velocity_ecef_mps[index]) * reference_los[index];
+    }
+    reference_range_rate_mps +=
+        OMGE / kSpeedOfLightMps *
+        (reference_state[4] * receiver_.position_ecef_m[0] +
+         reference_state[1] * receiver_.velocity_ecef_mps[0] -
+         reference_state[3] * receiver_.position_ecef_m[1] -
+         reference_state[0] * receiver_.velocity_ecef_mps[1]);
+
+    for (int index = 0; index < 3; ++index) {
+        EXPECT_NEAR(geometry.satellite_state.position_ecef_m[index], reference_state[index], 1.0e-6);
+        EXPECT_NEAR(geometry.satellite_state.velocity_ecef_mps[index], reference_state[index + 3], 1.0e-9);
+        EXPECT_NEAR(geometry.line_of_sight_ecef[index], reference_los[index], 1.0e-14);
+    }
+    EXPECT_NEAR(geometry.satellite_state.clock_bias_sec, reference_clock[0], 1.0e-15);
+    EXPECT_NEAR(geometry.satellite_state.clock_drift_sec_per_sec, reference_clock[1], 1.0e-18);
+    EXPECT_EQ(geometry.satellite_state.health, reference_health);
+    EXPECT_NEAR(geometry.geometric_range_m, reference_range_m, 1.0e-6);
+    EXPECT_NEAR(geometry.azimuth_rad, reference_azel[0], 1.0e-14);
+    EXPECT_NEAR(geometry.elevation_rad, reference_azel[1], 1.0e-14);
+    EXPECT_NEAR(geometry.range_rate_mps, reference_range_rate_mps, 1.0e-9);
+    EXPECT_NEAR(geometry.propagation_time_sec, geometry.geometric_range_m / kSpeedOfLightMps, 1.0e-15);
+
+    freenav(&reference_nav, 0xFF);
+}
+
+TEST_F(SatelliteEngineTest, SatelliteStateIsEvaluatedAtTransmitRatherThanReceiveTime) {
+    int satellite_number = 0;
+    ASSERT_TRUE(gnss_sim::rtklib_satellite_id_to_number("G01", &satellite_number));
+    gnss_sim::SimTime receive_time{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2041, 180000.0, &receive_time));
+
+    gnss_sim::SatelliteGeometry geometry{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::compute_satellite_geometry(nav_store_, receiver_, receive_time, satellite_number, 3.0,
+                                                     &geometry, &error_message))
+        << error_message;
+
+    gnss_sim::RtklibSatelliteState receive_state{};
+    ASSERT_TRUE(gnss_sim::get_rtklib_satellite_state(nav_store_, receive_time.gps_week,
+                                                     gnss_sim::sim_time_sow_sec(receive_time), satellite_number,
+                                                     &receive_state, &error_message));
+
+    const double position_delta_m =
+        std::hypot(std::hypot(geometry.satellite_state.position_ecef_m[0] - receive_state.position_ecef_m[0],
+                              geometry.satellite_state.position_ecef_m[1] - receive_state.position_ecef_m[1]),
+                   geometry.satellite_state.position_ecef_m[2] - receive_state.position_ecef_m[2]);
+    EXPECT_GT(position_delta_m, 10.0);
+}
+
+} // namespace


### PR DESCRIPTION
Closes #6.

## Summary
- add canonical static receiver truth from configured LLH through the RTKLIB adapter;
- solve satellite transmit time iteratively from generated geometric range rather than from an existing pseudorange;
- compute broadcast satellite state at transmit time, RTKLIB-consistent `geodist()` range/LOS and `satazel()` azimuth/elevation;
- compute range rate with the same first-order Earth-rotation derivative used by RTKLIB `resdop()`;
- apply health plus configurable elevation-mask visibility semantics;
- cover GPS/GLO/GAL/BDS/QZSS representative ephemerides, independent direct-RTKLIB geometry checks, exactly-on/around 3 deg mask behavior, cross-week transmit-time subtraction, and static receiver LLH/ECEF round trips.

## Implementation Notes
The generator never calls an API that derives transmission time from pseudorange. The fixed-point iteration starts from 75 ms and converges on `geodist/c`; a final state is recomputed at the converged transmit time. Satellite state and RTKLIB structures remain behind the adapter boundary, while `SatelliteGeometry` exposes only simulator-owned POD data.

Range-rate Earth-rotation handling mirrors the current pinned RTKLIB `pntpos.c/resdop()` expression so later Doppler loopback can share the same convention.

CI must pass formatting plus Ubuntu/GCC and Windows/MSVC before merge.