### PR TITLE
Implement cold-start NAV scheduler for GPS, QZSS, and GLONASS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ add_library(gnss_sim_core STATIC
     src/core/sim_config.cpp
     src/core/sim_time.cpp
     src/core/simulator.cpp
+    src/gnss/nav_message_scheduler.cpp
     src/gnss/navigation_state.cpp
     src/gnss/rtklib_adapter.cpp
     src/gnss/satellite_engine.cpp
@@ -105,6 +106,7 @@ if(BUILD_TESTING)
 
     add_executable(gnss_sim_unit_tests
         tests/unit/test_deterministic_rng.cpp
+        tests/unit/test_nav_message_scheduler.cpp
         tests/unit/test_navigation_state.cpp
         tests/unit/test_receiver_truth.cpp
         tests/unit/test_rtklib_adapter.cpp

--- a/src/gnss/nav_message_scheduler.cpp
+++ b/src/gnss/nav_message_scheduler.cpp
@@ -1,1 +1,236 @@
-// Cold-start NAV scheduling is introduced by issues #8 and #9.
+#include "gnss/nav_message_scheduler.h"
+
+#include "gnss_sim/sim_time.h"
+
+#include <cstdint>
+
+namespace gnss_sim {
+namespace {
+
+constexpr std::uint32_t kFragment1 = 1U << 0;
+constexpr std::uint32_t kFragment2 = 1U << 1;
+constexpr std::uint32_t kFragment3 = 1U << 2;
+constexpr std::uint32_t kFragment4 = 1U << 3;
+
+void set_error(std::string* error_message, const char* message) {
+    if (error_message != nullptr) {
+        *error_message = message;
+    }
+}
+
+bool valid_sim_time(const SimTime& time) {
+    return time.gps_week >= 0 && time.tow_ns >= 0 && time.tow_ns < GPS_WEEK_NANOSECONDS;
+}
+
+bool set_fragment(const SimTime& acquisition_time, std::int64_t cycle_ns, std::int64_t slot_start_ns,
+                  std::int64_t duration_ns, int fragment_id, std::uint32_t mask_bit,
+                  NavAcquisitionFragment* fragment) {
+    if (fragment == nullptr || cycle_ns <= 0 || slot_start_ns < 0 || slot_start_ns >= cycle_ns || duration_ns <= 0) {
+        return false;
+    }
+
+    const std::int64_t cycle_phase_ns = acquisition_time.tow_ns % cycle_ns;
+    std::int64_t delta_to_slot_start_ns = slot_start_ns - cycle_phase_ns;
+    if (delta_to_slot_start_ns < 0) {
+        delta_to_slot_start_ns += cycle_ns;
+    }
+
+    SimTime completion_time{};
+    if (!add_time_ns(acquisition_time, delta_to_slot_start_ns + duration_ns, &completion_time)) {
+        return false;
+    }
+    fragment->fragment_id = fragment_id;
+    fragment->mask_bit = mask_bit;
+    fragment->completion_time = completion_time;
+    return true;
+}
+
+void update_availability_time(NavAcquisitionPlan* plan, const SimTime& completion_time) {
+    if (compare_sim_time(completion_time, plan->availability_time) > 0) {
+        plan->availability_time = completion_time;
+    }
+}
+
+bool add_periodic_fragment(const SimTime& acquisition_time, std::int64_t cycle_sec, std::int64_t slot_start_sec,
+                           std::int64_t duration_sec, int fragment_id, std::uint32_t mask_bit,
+                           NavAcquisitionPlan* plan) {
+    if (plan->fragment_count >= MAX_NAV_ACQUISITION_FRAGMENTS) {
+        return false;
+    }
+    NavAcquisitionFragment fragment{};
+    if (!set_fragment(acquisition_time, cycle_sec * NANOSECONDS_PER_SECOND, slot_start_sec * NANOSECONDS_PER_SECOND,
+                      duration_sec * NANOSECONDS_PER_SECOND, fragment_id, mask_bit, &fragment)) {
+        return false;
+    }
+    plan->fragments[plan->fragment_count++] = fragment;
+    update_availability_time(plan, fragment.completion_time);
+    plan->required_mask |= mask_bit;
+    return true;
+}
+
+bool build_lnav_plan(const SimTime& acquisition_time, NavAcquisitionPlan* plan) {
+    // GPS/QZSS legacy NAV repeats a 30 s frame made of five 6 s subframes.
+    // A complete broadcast ephemeris requires subframes 1, 2, and 3.
+    return add_periodic_fragment(acquisition_time, 30, 0, 6, 1, kFragment1, plan) &&
+           add_periodic_fragment(acquisition_time, 30, 6, 6, 2, kFragment2, plan) &&
+           add_periodic_fragment(acquisition_time, 30, 12, 6, 3, kFragment3, plan);
+}
+
+bool build_cnav_plan(const SimTime& acquisition_time, std::int64_t message_duration_sec, NavAcquisitionPlan* plan) {
+    // CNAV ephemeris requires MT10 + MT11 plus one clock-bearing MT30-37.
+    // V1 models the nominal TTFF-critical repeating sequence MT10, MT11, MT30.
+    const std::int64_t cycle_sec = 3 * message_duration_sec;
+    return add_periodic_fragment(acquisition_time, cycle_sec, 0, message_duration_sec, 10, kFragment1, plan) &&
+           add_periodic_fragment(acquisition_time, cycle_sec, message_duration_sec, message_duration_sec, 11,
+                                 kFragment2, plan) &&
+           add_periodic_fragment(acquisition_time, cycle_sec, 2 * message_duration_sec, message_duration_sec, 30,
+                                 kFragment3, plan);
+}
+
+bool build_cnav2_plan(const SimTime& acquisition_time, NavAcquisitionPlan* plan) {
+    // L1C CNAV-2 uses an 18 s frame; subframe 2 contains clock and ephemeris.
+    // Require a complete frame after acquisition rather than granting data from
+    // a frame that was already in progress when tracking began.
+    return add_periodic_fragment(acquisition_time, 18, 0, 18, 2, kFragment1, plan);
+}
+
+bool build_glonass_fdma_plan(const SimTime& acquisition_time, NavAcquisitionPlan* plan) {
+    // Legacy GLONASS FDMA has 15 two-second strings per 30 s frame.
+    // Immediate ephemeris/clock data occupy strings 1-4 and repeat every frame.
+    return add_periodic_fragment(acquisition_time, 30, 0, 2, 1, kFragment1, plan) &&
+           add_periodic_fragment(acquisition_time, 30, 2, 2, 2, kFragment2, plan) &&
+           add_periodic_fragment(acquisition_time, 30, 4, 2, 3, kFragment3, plan) &&
+           add_periodic_fragment(acquisition_time, 30, 6, 2, 4, kFragment4, plan);
+}
+
+bool build_glonass_l3oc_plan(const SimTime& acquisition_time, NavAcquisitionPlan* plan) {
+    // L3OC immediate orbit/clock data are string types 10, 11, and 12.
+    // Nominal L3OC strings are 3 s; model them at the start of an 18 s
+    // pseudoframe while leaving non-immediate string composition unspecified.
+    return add_periodic_fragment(acquisition_time, 18, 0, 3, 10, kFragment1, plan) &&
+           add_periodic_fragment(acquisition_time, 18, 3, 3, 11, kFragment2, plan) &&
+           add_periodic_fragment(acquisition_time, 18, 6, 3, 12, kFragment3, plan);
+}
+
+} // namespace
+
+bool build_cold_nav_acquisition_plan(SignalId signal_id, const SimTime& acquisition_time, int issue_data,
+                                     NavAcquisitionPlan* plan, std::string* error_message) {
+    if (plan == nullptr || !valid_sim_time(acquisition_time)) {
+        set_error(error_message, "cold NAV acquisition plan has invalid arguments");
+        return false;
+    }
+
+    const SignalDefinition* definition = find_signal_definition(signal_id);
+    if (definition == nullptr) {
+        set_error(error_message, "cold NAV acquisition uses an unknown signal");
+        return false;
+    }
+
+    NavAcquisitionPlan result{};
+    result.signal_id = signal_id;
+    result.family = definition->nav_message_family;
+    result.acquisition_time = acquisition_time;
+    result.availability_time = acquisition_time;
+    result.issue_data = issue_data;
+
+    bool ok = false;
+    switch (signal_id) {
+        case SignalId::kGpsL1Ca:
+        case SignalId::kGpsL2P:
+        case SignalId::kQzssL1Ca:
+            ok = build_lnav_plan(acquisition_time, &result);
+            break;
+        case SignalId::kGpsL2C:
+        case SignalId::kQzssL2C:
+            ok = build_cnav_plan(acquisition_time, 12, &result);
+            break;
+        case SignalId::kGpsL5Q:
+        case SignalId::kQzssL5Q:
+            ok = build_cnav_plan(acquisition_time, 6, &result);
+            break;
+        case SignalId::kGpsL1C:
+        case SignalId::kQzssL1C:
+            ok = build_cnav2_plan(acquisition_time, &result);
+            break;
+        case SignalId::kGlonassG1:
+        case SignalId::kGlonassG2:
+            ok = build_glonass_fdma_plan(acquisition_time, &result);
+            break;
+        case SignalId::kGlonassG3:
+            ok = build_glonass_l3oc_plan(acquisition_time, &result);
+            break;
+        default:
+            set_error(error_message, "signal family is not implemented by cold NAV scheduler issue #8");
+            return false;
+    }
+
+    if (!ok || result.fragment_count <= 0 || result.required_mask == 0U) {
+        set_error(error_message, "cannot build cold NAV acquisition fragment schedule");
+        return false;
+    }
+    *plan = result;
+    return true;
+}
+
+std::uint32_t nav_acquisition_received_mask(const NavAcquisitionPlan& plan, const SimTime& current_time) {
+    if (!valid_sim_time(current_time) || compare_sim_time(current_time, plan.acquisition_time) < 0) {
+        return 0U;
+    }
+    std::uint32_t mask = 0U;
+    for (int index = 0; index < plan.fragment_count; ++index) {
+        if (compare_sim_time(plan.fragments[index].completion_time, current_time) <= 0) {
+            mask |= plan.fragments[index].mask_bit;
+        }
+    }
+    return mask;
+}
+
+bool nav_acquisition_complete(const NavAcquisitionPlan& plan, const SimTime& current_time) {
+    const std::uint32_t received_mask = nav_acquisition_received_mask(plan, current_time);
+    return plan.required_mask != 0U && (received_mask & plan.required_mask) == plan.required_mask;
+}
+
+void reset_nav_fragment_collector(std::uint32_t required_mask, NavFragmentCollector* collector) {
+    if (collector == nullptr) {
+        return;
+    }
+    collector->required_mask = required_mask;
+    collector->received_mask = 0U;
+    collector->issue_data = 0;
+    collector->has_issue_data = false;
+}
+
+bool ingest_nav_fragment(NavFragmentCollector* collector, std::uint32_t fragment_mask_bit, int issue_data,
+                         bool* ephemeris_complete) {
+    if (collector == nullptr || ephemeris_complete == nullptr || collector->required_mask == 0U ||
+        fragment_mask_bit == 0U || (fragment_mask_bit & collector->required_mask) == 0U) {
+        return false;
+    }
+
+    if (!collector->has_issue_data || collector->issue_data != issue_data) {
+        collector->received_mask = 0U;
+        collector->issue_data = issue_data;
+        collector->has_issue_data = true;
+    }
+    collector->received_mask |= fragment_mask_bit;
+    *ephemeris_complete = (collector->received_mask & collector->required_mask) == collector->required_mask;
+    return true;
+}
+
+bool deliver_cold_nav_plan_if_complete(const NavAcquisitionPlan& plan, int truth_record_index,
+                                       const SimTime& current_time, NavigationState* navigation_state,
+                                       NavigationUpdateEvent* event, bool* emitted, std::string* error_message) {
+    if (navigation_state == nullptr || emitted == nullptr || truth_record_index < 0 || !valid_sim_time(current_time)) {
+        set_error(error_message, "cold NAV delivery request has invalid arguments");
+        return false;
+    }
+    *emitted = false;
+    if (!nav_acquisition_complete(plan, current_time)) {
+        return true;
+    }
+    return apply_truth_navigation_record(navigation_state, truth_record_index, plan.availability_time, event, emitted,
+                                         error_message);
+}
+
+} // namespace gnss_sim

--- a/src/gnss/nav_message_scheduler.cpp
+++ b/src/gnss/nav_message_scheduler.cpp
@@ -69,16 +69,12 @@ bool add_periodic_fragment(const SimTime& acquisition_time, std::int64_t cycle_s
 }
 
 bool build_lnav_plan(const SimTime& acquisition_time, NavAcquisitionPlan* plan) {
-    // GPS/QZSS legacy NAV repeats a 30 s frame made of five 6 s subframes.
-    // A complete broadcast ephemeris requires subframes 1, 2, and 3.
     return add_periodic_fragment(acquisition_time, 30, 0, 6, 1, kFragment1, plan) &&
            add_periodic_fragment(acquisition_time, 30, 6, 6, 2, kFragment2, plan) &&
            add_periodic_fragment(acquisition_time, 30, 12, 6, 3, kFragment3, plan);
 }
 
 bool build_cnav_plan(const SimTime& acquisition_time, std::int64_t message_duration_sec, NavAcquisitionPlan* plan) {
-    // CNAV ephemeris requires MT10 + MT11 plus one clock-bearing MT30-37.
-    // V1 models the nominal TTFF-critical repeating sequence MT10, MT11, MT30.
     const std::int64_t cycle_sec = 3 * message_duration_sec;
     return add_periodic_fragment(acquisition_time, cycle_sec, 0, message_duration_sec, 10, kFragment1, plan) &&
            add_periodic_fragment(acquisition_time, cycle_sec, message_duration_sec, message_duration_sec, 11,
@@ -88,15 +84,10 @@ bool build_cnav_plan(const SimTime& acquisition_time, std::int64_t message_durat
 }
 
 bool build_cnav2_plan(const SimTime& acquisition_time, NavAcquisitionPlan* plan) {
-    // L1C CNAV-2 uses an 18 s frame; subframe 2 contains clock and ephemeris.
-    // Require a complete frame after acquisition rather than granting data from
-    // a frame that was already in progress when tracking began.
     return add_periodic_fragment(acquisition_time, 18, 0, 18, 2, kFragment1, plan);
 }
 
 bool build_glonass_fdma_plan(const SimTime& acquisition_time, NavAcquisitionPlan* plan) {
-    // Legacy GLONASS FDMA has 15 two-second strings per 30 s frame.
-    // Immediate ephemeris/clock data occupy strings 1-4 and repeat every frame.
     return add_periodic_fragment(acquisition_time, 30, 0, 2, 1, kFragment1, plan) &&
            add_periodic_fragment(acquisition_time, 30, 2, 2, 2, kFragment2, plan) &&
            add_periodic_fragment(acquisition_time, 30, 4, 2, 3, kFragment3, plan) &&
@@ -104,9 +95,6 @@ bool build_glonass_fdma_plan(const SimTime& acquisition_time, NavAcquisitionPlan
 }
 
 bool build_glonass_l3oc_plan(const SimTime& acquisition_time, NavAcquisitionPlan* plan) {
-    // L3OC immediate orbit/clock data are string types 10, 11, and 12.
-    // Nominal L3OC strings are 3 s; model them at the start of an 18 s
-    // pseudoframe while leaving non-immediate string composition unspecified.
     return add_periodic_fragment(acquisition_time, 18, 0, 3, 10, kFragment1, plan) &&
            add_periodic_fragment(acquisition_time, 18, 3, 3, 11, kFragment2, plan) &&
            add_periodic_fragment(acquisition_time, 18, 6, 3, 12, kFragment3, plan);
@@ -229,6 +217,17 @@ bool deliver_cold_nav_plan_if_complete(const NavAcquisitionPlan& plan, int truth
     if (!nav_acquisition_complete(plan, current_time)) {
         return true;
     }
+
+    RtklibNavRecordInfo record_info{};
+    if (!rtklib_nav_record_info(truth_navigation_store(navigation_state), truth_record_index, &record_info)) {
+        set_error(error_message, "cold NAV plan references an invalid truth navigation record");
+        return false;
+    }
+    if (record_info.kind == RtklibNavRecordKind::kIonosphere || record_info.iode != plan.issue_data) {
+        set_error(error_message, "cold NAV fragment IOD does not match truth ephemeris record");
+        return false;
+    }
+
     return apply_truth_navigation_record(navigation_state, truth_record_index, plan.availability_time, event, emitted,
                                          error_message);
 }

--- a/src/gnss/nav_message_scheduler.cpp
+++ b/src/gnss/nav_message_scheduler.cpp
@@ -23,8 +23,7 @@ bool valid_sim_time(const SimTime& time) {
 }
 
 bool set_fragment(const SimTime& acquisition_time, std::int64_t cycle_ns, std::int64_t slot_start_ns,
-                  std::int64_t duration_ns, int fragment_id, std::uint32_t mask_bit,
-                  NavAcquisitionFragment* fragment) {
+                  std::int64_t duration_ns, int fragment_id, std::uint32_t mask_bit, NavAcquisitionFragment* fragment) {
     if (fragment == nullptr || cycle_ns <= 0 || slot_start_ns < 0 || slot_start_ns >= cycle_ns || duration_ns <= 0) {
         return false;
     }

--- a/src/gnss/nav_message_scheduler.h
+++ b/src/gnss/nav_message_scheduler.h
@@ -1,0 +1,54 @@
+#ifndef GNSS_SIM_SRC_GNSS_NAV_MESSAGE_SCHEDULER_H_
+#define GNSS_SIM_SRC_GNSS_NAV_MESSAGE_SCHEDULER_H_
+
+#include "gnss/navigation_state.h"
+#include "gnss/signal_definitions.h"
+#include "gnss_sim/sim_types.h"
+
+#include <cstdint>
+#include <string>
+
+namespace gnss_sim {
+
+constexpr int MAX_NAV_ACQUISITION_FRAGMENTS = 4;
+
+struct NavAcquisitionFragment {
+    int fragment_id;
+    std::uint32_t mask_bit;
+    SimTime completion_time;
+};
+
+struct NavAcquisitionPlan {
+    SignalId signal_id;
+    NavMessageFamily family;
+    SimTime acquisition_time;
+    SimTime availability_time;
+    int issue_data;
+    std::uint32_t required_mask;
+    int fragment_count;
+    NavAcquisitionFragment fragments[MAX_NAV_ACQUISITION_FRAGMENTS];
+};
+
+struct NavFragmentCollector {
+    std::uint32_t required_mask;
+    std::uint32_t received_mask;
+    int issue_data;
+    bool has_issue_data;
+};
+
+bool build_cold_nav_acquisition_plan(SignalId signal_id, const SimTime& acquisition_time, int issue_data,
+                                     NavAcquisitionPlan* plan, std::string* error_message);
+std::uint32_t nav_acquisition_received_mask(const NavAcquisitionPlan& plan, const SimTime& current_time);
+bool nav_acquisition_complete(const NavAcquisitionPlan& plan, const SimTime& current_time);
+
+void reset_nav_fragment_collector(std::uint32_t required_mask, NavFragmentCollector* collector);
+bool ingest_nav_fragment(NavFragmentCollector* collector, std::uint32_t fragment_mask_bit, int issue_data,
+                         bool* ephemeris_complete);
+
+bool deliver_cold_nav_plan_if_complete(const NavAcquisitionPlan& plan, int truth_record_index,
+                                       const SimTime& current_time, NavigationState* navigation_state,
+                                       NavigationUpdateEvent* event, bool* emitted, std::string* error_message);
+
+} // namespace gnss_sim
+
+#endif // GNSS_SIM_SRC_GNSS_NAV_MESSAGE_SCHEDULER_H_

--- a/tests/unit/test_nav_message_scheduler.cpp
+++ b/tests/unit/test_nav_message_scheduler.cpp
@@ -1,13 +1,11 @@
 #include "gnss/nav_message_scheduler.h"
-
 #include "gnss/navigation_state.h"
 #include "gnss/rtklib_adapter.h"
 #include "gnss/signal_definitions.h"
 #include "gnss_sim/sim_time.h"
 
-#include <gtest/gtest.h>
-
 #include <cstdint>
+#include <gtest/gtest.h>
 #include <string>
 
 namespace {
@@ -53,7 +51,7 @@ TEST(ColdNavSchedulerTiming, LegacyGpsAndQzssUseThirtySecondFramePhase) {
     gnss_sim::NavAcquisitionPlan plan{};
     std::string error_message;
     ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGpsL1Ca, acquisition_time, 21, &plan,
-                                                         &error_message));
+                                                          &error_message));
     EXPECT_NEAR(gnss_sim::sim_time_sow_sec(plan.availability_time), 180036.0, 1.0e-9);
     EXPECT_EQ(plan.fragment_count, 3);
     EXPECT_EQ(plan.fragments[0].fragment_id, 1);
@@ -75,9 +73,9 @@ TEST(ColdNavSchedulerTiming, CnavUsesSignalSpecificMessageRate) {
     gnss_sim::NavAcquisitionPlan l5_plan{};
     std::string error_message;
     ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGpsL2C, l2_acquisition, 21, &l2_plan,
-                                                         &error_message));
+                                                          &error_message));
     ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGpsL5Q, l5_acquisition, 21, &l5_plan,
-                                                         &error_message));
+                                                          &error_message));
     EXPECT_NEAR(gnss_sim::sim_time_sow_sec(l2_plan.availability_time), 180048.0, 1.0e-9);
     EXPECT_NEAR(gnss_sim::sim_time_sow_sec(l5_plan.availability_time), 180024.0, 1.0e-9);
     EXPECT_EQ(l2_plan.fragments[0].fragment_id, 10);
@@ -94,7 +92,7 @@ TEST(ColdNavSchedulerTiming, Cnav2RequiresCompleteEighteenSecondFrame) {
     gnss_sim::NavAcquisitionPlan plan{};
     std::string error_message;
     ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGpsL1C, acquisition_time, 21, &plan,
-                                                         &error_message));
+                                                          &error_message));
     EXPECT_NEAR(gnss_sim::sim_time_sow_sec(plan.availability_time), 180036.0, 1.0e-9);
     EXPECT_EQ(plan.fragment_count, 1);
 }
@@ -108,7 +106,7 @@ TEST(ColdNavSchedulerTiming, GlonassFdmaCollectsStringsOneThroughFourWithoutThir
     gnss_sim::NavAcquisitionPlan plan{};
     std::string error_message;
     ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGlonassG1, acquisition_time, 5, &plan,
-                                                         &error_message));
+                                                          &error_message));
     EXPECT_NEAR(gnss_sim::sim_time_sow_sec(plan.availability_time), 180032.0, 1.0e-9);
     EXPECT_LT(gnss_sim::sim_time_sow_sec(plan.availability_time) - 180000.001, 33.0);
     EXPECT_EQ(plan.fragment_count, 4);
@@ -122,7 +120,7 @@ TEST(ColdNavSchedulerTiming, GlonassL3OcCollectsThreeImmediateStrings) {
     gnss_sim::NavAcquisitionPlan plan{};
     std::string error_message;
     ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGlonassG3, acquisition_time, 5, &plan,
-                                                         &error_message));
+                                                          &error_message));
     EXPECT_NEAR(gnss_sim::sim_time_sow_sec(plan.availability_time), 180021.0, 1.0e-9);
     EXPECT_EQ(plan.fragments[0].fragment_id, 10);
     EXPECT_EQ(plan.fragments[1].fragment_id, 11);
@@ -135,7 +133,7 @@ TEST(ColdNavSchedulerTiming, WeekBoundaryIsHandledWithIntegerSimTime) {
     gnss_sim::NavAcquisitionPlan plan{};
     std::string error_message;
     ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGpsL1Ca, acquisition_time, 21, &plan,
-                                                         &error_message));
+                                                          &error_message));
     EXPECT_EQ(plan.availability_time.gps_week, 2301);
     EXPECT_NEAR(gnss_sim::sim_time_sow_sec(plan.availability_time), 18.0, 1.0e-9);
 }
@@ -167,7 +165,7 @@ TEST(ColdNavSchedulerMask, FragmentsAppearOnlyAfterTheirCompleteMessageBoundary)
     gnss_sim::NavAcquisitionPlan plan{};
     std::string error_message;
     ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGpsL1Ca, acquisition_time, 21, &plan,
-                                                         &error_message));
+                                                          &error_message));
 
     gnss_sim::SimTime at_six{};
     gnss_sim::SimTime before_eighteen{};
@@ -187,8 +185,8 @@ TEST(ColdNavSchedulerIntegration, ColdReceiverNavGrowsOneCompletedAcquisitionAtA
 
     gnss_sim::SimTime startup_time{};
     ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2041, 180000.0, &startup_time));
-    ASSERT_TRUE(gnss_sim::initialize_receiver_navigation(state, gnss_sim::StartupMode::COLD, startup_time,
-                                                        &error_message))
+    ASSERT_TRUE(
+        gnss_sim::initialize_receiver_navigation(state, gnss_sim::StartupMode::COLD, startup_time, &error_message))
         << error_message;
 
     int gps_satellite = 0;
@@ -208,15 +206,15 @@ TEST(ColdNavSchedulerIntegration, ColdReceiverNavGrowsOneCompletedAcquisitionAtA
     gnss_sim::NavAcquisitionPlan gps_plan{};
     gnss_sim::NavAcquisitionPlan glo_plan{};
     ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGpsL1Ca, startup_time, gps_info.iode,
-                                                         &gps_plan, &error_message));
+                                                          &gps_plan, &error_message));
     gnss_sim::SimTime glo_acquisition{};
     ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2041, 180020.001, &glo_acquisition));
     ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGlonassG1, glo_acquisition,
-                                                         glo_info.iode, &glo_plan, &error_message));
+                                                          glo_info.iode, &glo_plan, &error_message));
 
     bool emitted = false;
     ASSERT_TRUE(gnss_sim::deliver_cold_nav_plan_if_complete(gps_plan, gps_record, gps_plan.availability_time, state,
-                                                           nullptr, &emitted, &error_message))
+                                                            nullptr, &emitted, &error_message))
         << error_message;
     EXPECT_TRUE(emitted);
 
@@ -227,11 +225,11 @@ TEST(ColdNavSchedulerIntegration, ColdReceiverNavGrowsOneCompletedAcquisitionAtA
 
     emitted = true;
     ASSERT_TRUE(gnss_sim::deliver_cold_nav_plan_if_complete(glo_plan, glo_record, gps_plan.availability_time, state,
-                                                           nullptr, &emitted, &error_message));
+                                                            nullptr, &emitted, &error_message));
     EXPECT_FALSE(emitted);
 
     ASSERT_TRUE(gnss_sim::deliver_cold_nav_plan_if_complete(glo_plan, glo_record, glo_plan.availability_time, state,
-                                                           nullptr, &emitted, &error_message))
+                                                            nullptr, &emitted, &error_message))
         << error_message;
     EXPECT_TRUE(emitted);
     ASSERT_TRUE(gnss_sim::get_rtklib_nav_counts(gnss_sim::receiver_navigation_store(state), &counts));
@@ -240,7 +238,7 @@ TEST(ColdNavSchedulerIntegration, ColdReceiverNavGrowsOneCompletedAcquisitionAtA
 
     emitted = true;
     ASSERT_TRUE(gnss_sim::deliver_cold_nav_plan_if_complete(glo_plan, glo_record, glo_plan.availability_time, state,
-                                                           nullptr, &emitted, &error_message));
+                                                            nullptr, &emitted, &error_message));
     EXPECT_FALSE(emitted);
     gnss_sim::destroy_navigation_state(state);
 }
@@ -252,15 +250,15 @@ TEST(ColdNavSchedulerIntegration, PlanCannotDeliverDifferentIssueOfData) {
     ASSERT_TRUE(gnss_sim::load_truth_navigation(state, update_nav_path().c_str(), &error_message)) << error_message;
     gnss_sim::SimTime startup_time{};
     ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2041, 179000.0, &startup_time));
-    ASSERT_TRUE(gnss_sim::initialize_receiver_navigation(state, gnss_sim::StartupMode::COLD, startup_time,
-                                                        &error_message));
+    ASSERT_TRUE(
+        gnss_sim::initialize_receiver_navigation(state, gnss_sim::StartupMode::COLD, startup_time, &error_message));
 
     gnss_sim::NavAcquisitionPlan wrong_plan{};
-    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGpsL1Ca, startup_time, 999,
-                                                         &wrong_plan, &error_message));
+    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGpsL1Ca, startup_time, 999, &wrong_plan,
+                                                          &error_message));
     bool emitted = false;
     EXPECT_FALSE(gnss_sim::deliver_cold_nav_plan_if_complete(wrong_plan, 0, wrong_plan.availability_time, state,
-                                                            nullptr, &emitted, &error_message));
+                                                             nullptr, &emitted, &error_message));
     EXPECT_FALSE(emitted);
     gnss_sim::destroy_navigation_state(state);
 }

--- a/tests/unit/test_nav_message_scheduler.cpp
+++ b/tests/unit/test_nav_message_scheduler.cpp
@@ -1,0 +1,268 @@
+#include "gnss/nav_message_scheduler.h"
+
+#include "gnss/navigation_state.h"
+#include "gnss/rtklib_adapter.h"
+#include "gnss/signal_definitions.h"
+#include "gnss_sim/sim_time.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+
+namespace {
+
+std::string mixed_nav_path() {
+    return std::string(GNSS_SIM_TEST_DATA_DIR) + "/mixed_nav_2019.rnx";
+}
+
+std::string update_nav_path() {
+    return std::string(GNSS_SIM_TEST_DATA_DIR) + "/nav_updates_2019.rnx";
+}
+
+void expect_availability(gnss_sim::SignalId signal_id, double acquisition_sow_sec, double expected_sow_sec) {
+    gnss_sim::SimTime acquisition_time{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, acquisition_sow_sec, &acquisition_time));
+    gnss_sim::NavAcquisitionPlan plan{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(signal_id, acquisition_time, 21, &plan, &error_message))
+        << error_message;
+    EXPECT_EQ(plan.availability_time.gps_week, 2300);
+    EXPECT_NEAR(gnss_sim::sim_time_sow_sec(plan.availability_time), expected_sow_sec, 1.0e-9);
+    EXPECT_TRUE(gnss_sim::nav_acquisition_complete(plan, plan.availability_time));
+}
+
+int find_truth_record(const gnss_sim::NavigationState* state, int satellite_number) {
+    for (int index = 0; index < gnss_sim::navigation_truth_record_count(state); ++index) {
+        gnss_sim::RtklibNavRecordInfo info{};
+        if (gnss_sim::rtklib_nav_record_info(gnss_sim::truth_navigation_store(state), index, &info) &&
+            info.satellite_number == satellite_number) {
+            return index;
+        }
+    }
+    return -1;
+}
+
+TEST(ColdNavSchedulerTiming, LegacyGpsAndQzssUseThirtySecondFramePhase) {
+    expect_availability(gnss_sim::SignalId::kGpsL1Ca, 180000.0, 180018.0);
+    expect_availability(gnss_sim::SignalId::kGpsL2P, 180000.0, 180018.0);
+    expect_availability(gnss_sim::SignalId::kQzssL1Ca, 180000.0, 180018.0);
+
+    gnss_sim::SimTime acquisition_time{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, 180000.001, &acquisition_time));
+    gnss_sim::NavAcquisitionPlan plan{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGpsL1Ca, acquisition_time, 21, &plan,
+                                                         &error_message));
+    EXPECT_NEAR(gnss_sim::sim_time_sow_sec(plan.availability_time), 180036.0, 1.0e-9);
+    EXPECT_EQ(plan.fragment_count, 3);
+    EXPECT_EQ(plan.fragments[0].fragment_id, 1);
+    EXPECT_EQ(plan.fragments[1].fragment_id, 2);
+    EXPECT_EQ(plan.fragments[2].fragment_id, 3);
+}
+
+TEST(ColdNavSchedulerTiming, CnavUsesSignalSpecificMessageRate) {
+    expect_availability(gnss_sim::SignalId::kGpsL2C, 180000.0, 180036.0);
+    expect_availability(gnss_sim::SignalId::kQzssL2C, 180000.0, 180036.0);
+    expect_availability(gnss_sim::SignalId::kGpsL5Q, 180000.0, 180018.0);
+    expect_availability(gnss_sim::SignalId::kQzssL5Q, 180000.0, 180018.0);
+
+    gnss_sim::SimTime l2_acquisition{};
+    gnss_sim::SimTime l5_acquisition{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, 180000.001, &l2_acquisition));
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, 180000.001, &l5_acquisition));
+    gnss_sim::NavAcquisitionPlan l2_plan{};
+    gnss_sim::NavAcquisitionPlan l5_plan{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGpsL2C, l2_acquisition, 21, &l2_plan,
+                                                         &error_message));
+    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGpsL5Q, l5_acquisition, 21, &l5_plan,
+                                                         &error_message));
+    EXPECT_NEAR(gnss_sim::sim_time_sow_sec(l2_plan.availability_time), 180048.0, 1.0e-9);
+    EXPECT_NEAR(gnss_sim::sim_time_sow_sec(l5_plan.availability_time), 180024.0, 1.0e-9);
+    EXPECT_EQ(l2_plan.fragments[0].fragment_id, 10);
+    EXPECT_EQ(l2_plan.fragments[1].fragment_id, 11);
+    EXPECT_EQ(l2_plan.fragments[2].fragment_id, 30);
+}
+
+TEST(ColdNavSchedulerTiming, Cnav2RequiresCompleteEighteenSecondFrame) {
+    expect_availability(gnss_sim::SignalId::kGpsL1C, 180000.0, 180018.0);
+    expect_availability(gnss_sim::SignalId::kQzssL1C, 180000.0, 180018.0);
+
+    gnss_sim::SimTime acquisition_time{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, 180000.001, &acquisition_time));
+    gnss_sim::NavAcquisitionPlan plan{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGpsL1C, acquisition_time, 21, &plan,
+                                                         &error_message));
+    EXPECT_NEAR(gnss_sim::sim_time_sow_sec(plan.availability_time), 180036.0, 1.0e-9);
+    EXPECT_EQ(plan.fragment_count, 1);
+}
+
+TEST(ColdNavSchedulerTiming, GlonassFdmaCollectsStringsOneThroughFourWithoutThirtyMinuteWait) {
+    expect_availability(gnss_sim::SignalId::kGlonassG1, 180000.0, 180008.0);
+    expect_availability(gnss_sim::SignalId::kGlonassG2, 180000.0, 180008.0);
+
+    gnss_sim::SimTime acquisition_time{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, 180000.001, &acquisition_time));
+    gnss_sim::NavAcquisitionPlan plan{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGlonassG1, acquisition_time, 5, &plan,
+                                                         &error_message));
+    EXPECT_NEAR(gnss_sim::sim_time_sow_sec(plan.availability_time), 180032.0, 1.0e-9);
+    EXPECT_LT(gnss_sim::sim_time_sow_sec(plan.availability_time) - 180000.001, 33.0);
+    EXPECT_EQ(plan.fragment_count, 4);
+}
+
+TEST(ColdNavSchedulerTiming, GlonassL3OcCollectsThreeImmediateStrings) {
+    expect_availability(gnss_sim::SignalId::kGlonassG3, 180000.0, 180009.0);
+
+    gnss_sim::SimTime acquisition_time{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, 180000.001, &acquisition_time));
+    gnss_sim::NavAcquisitionPlan plan{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGlonassG3, acquisition_time, 5, &plan,
+                                                         &error_message));
+    EXPECT_NEAR(gnss_sim::sim_time_sow_sec(plan.availability_time), 180021.0, 1.0e-9);
+    EXPECT_EQ(plan.fragments[0].fragment_id, 10);
+    EXPECT_EQ(plan.fragments[1].fragment_id, 11);
+    EXPECT_EQ(plan.fragments[2].fragment_id, 12);
+}
+
+TEST(ColdNavSchedulerTiming, WeekBoundaryIsHandledWithIntegerSimTime) {
+    gnss_sim::SimTime acquisition_time{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, 604799.0, &acquisition_time));
+    gnss_sim::NavAcquisitionPlan plan{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGpsL1Ca, acquisition_time, 21, &plan,
+                                                         &error_message));
+    EXPECT_EQ(plan.availability_time.gps_week, 2301);
+    EXPECT_NEAR(gnss_sim::sim_time_sow_sec(plan.availability_time), 18.0, 1.0e-9);
+}
+
+TEST(ColdNavSchedulerCollector, IssueChangeResetsPartialFragmentSet) {
+    gnss_sim::NavFragmentCollector collector{};
+    gnss_sim::reset_nav_fragment_collector(0x7U, &collector);
+    bool complete = false;
+    ASSERT_TRUE(gnss_sim::ingest_nav_fragment(&collector, 0x1U, 21, &complete));
+    EXPECT_FALSE(complete);
+    ASSERT_TRUE(gnss_sim::ingest_nav_fragment(&collector, 0x2U, 21, &complete));
+    EXPECT_FALSE(complete);
+    EXPECT_EQ(collector.received_mask, 0x3U);
+
+    ASSERT_TRUE(gnss_sim::ingest_nav_fragment(&collector, 0x4U, 22, &complete));
+    EXPECT_FALSE(complete);
+    EXPECT_EQ(collector.issue_data, 22);
+    EXPECT_EQ(collector.received_mask, 0x4U);
+
+    ASSERT_TRUE(gnss_sim::ingest_nav_fragment(&collector, 0x1U, 22, &complete));
+    ASSERT_TRUE(gnss_sim::ingest_nav_fragment(&collector, 0x2U, 22, &complete));
+    EXPECT_TRUE(complete);
+    EXPECT_EQ(collector.received_mask, 0x7U);
+}
+
+TEST(ColdNavSchedulerMask, FragmentsAppearOnlyAfterTheirCompleteMessageBoundary) {
+    gnss_sim::SimTime acquisition_time{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, 180000.0, &acquisition_time));
+    gnss_sim::NavAcquisitionPlan plan{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGpsL1Ca, acquisition_time, 21, &plan,
+                                                         &error_message));
+
+    gnss_sim::SimTime at_six{};
+    gnss_sim::SimTime before_eighteen{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, 180006.0, &at_six));
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, 180017.999, &before_eighteen));
+    EXPECT_EQ(gnss_sim::nav_acquisition_received_mask(plan, at_six), 0x1U);
+    EXPECT_EQ(gnss_sim::nav_acquisition_received_mask(plan, before_eighteen), 0x3U);
+    EXPECT_FALSE(gnss_sim::nav_acquisition_complete(plan, before_eighteen));
+    EXPECT_TRUE(gnss_sim::nav_acquisition_complete(plan, plan.availability_time));
+}
+
+TEST(ColdNavSchedulerIntegration, ColdReceiverNavGrowsOneCompletedAcquisitionAtATime) {
+    gnss_sim::NavigationState* state = gnss_sim::create_navigation_state();
+    ASSERT_NE(state, nullptr);
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::load_truth_navigation(state, mixed_nav_path().c_str(), &error_message)) << error_message;
+
+    gnss_sim::SimTime startup_time{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2041, 180000.0, &startup_time));
+    ASSERT_TRUE(gnss_sim::initialize_receiver_navigation(state, gnss_sim::StartupMode::COLD, startup_time,
+                                                        &error_message))
+        << error_message;
+
+    int gps_satellite = 0;
+    int glo_satellite = 0;
+    ASSERT_TRUE(gnss_sim::rtklib_satellite_id_to_number("G01", &gps_satellite));
+    ASSERT_TRUE(gnss_sim::rtklib_satellite_id_to_number("R26", &glo_satellite));
+    const int gps_record = find_truth_record(state, gps_satellite);
+    const int glo_record = find_truth_record(state, glo_satellite);
+    ASSERT_GE(gps_record, 0);
+    ASSERT_GE(glo_record, 0);
+
+    gnss_sim::RtklibNavRecordInfo gps_info{};
+    gnss_sim::RtklibNavRecordInfo glo_info{};
+    ASSERT_TRUE(gnss_sim::rtklib_nav_record_info(gnss_sim::truth_navigation_store(state), gps_record, &gps_info));
+    ASSERT_TRUE(gnss_sim::rtklib_nav_record_info(gnss_sim::truth_navigation_store(state), glo_record, &glo_info));
+
+    gnss_sim::NavAcquisitionPlan gps_plan{};
+    gnss_sim::NavAcquisitionPlan glo_plan{};
+    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGpsL1Ca, startup_time, gps_info.iode,
+                                                         &gps_plan, &error_message));
+    gnss_sim::SimTime glo_acquisition{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2041, 180020.001, &glo_acquisition));
+    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGlonassG1, glo_acquisition,
+                                                         glo_info.iode, &glo_plan, &error_message));
+
+    bool emitted = false;
+    ASSERT_TRUE(gnss_sim::deliver_cold_nav_plan_if_complete(gps_plan, gps_record, gps_plan.availability_time, state,
+                                                           nullptr, &emitted, &error_message))
+        << error_message;
+    EXPECT_TRUE(emitted);
+
+    gnss_sim::RtklibNavCounts counts{};
+    ASSERT_TRUE(gnss_sim::get_rtklib_nav_counts(gnss_sim::receiver_navigation_store(state), &counts));
+    EXPECT_EQ(counts.gps_eph_count, 1);
+    EXPECT_EQ(counts.glo_eph_count, 0);
+
+    emitted = true;
+    ASSERT_TRUE(gnss_sim::deliver_cold_nav_plan_if_complete(glo_plan, glo_record, gps_plan.availability_time, state,
+                                                           nullptr, &emitted, &error_message));
+    EXPECT_FALSE(emitted);
+
+    ASSERT_TRUE(gnss_sim::deliver_cold_nav_plan_if_complete(glo_plan, glo_record, glo_plan.availability_time, state,
+                                                           nullptr, &emitted, &error_message))
+        << error_message;
+    EXPECT_TRUE(emitted);
+    ASSERT_TRUE(gnss_sim::get_rtklib_nav_counts(gnss_sim::receiver_navigation_store(state), &counts));
+    EXPECT_EQ(counts.gps_eph_count, 1);
+    EXPECT_EQ(counts.glo_eph_count, 1);
+
+    emitted = true;
+    ASSERT_TRUE(gnss_sim::deliver_cold_nav_plan_if_complete(glo_plan, glo_record, glo_plan.availability_time, state,
+                                                           nullptr, &emitted, &error_message));
+    EXPECT_FALSE(emitted);
+    gnss_sim::destroy_navigation_state(state);
+}
+
+TEST(ColdNavSchedulerIntegration, PlanCannotDeliverDifferentIssueOfData) {
+    gnss_sim::NavigationState* state = gnss_sim::create_navigation_state();
+    ASSERT_NE(state, nullptr);
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::load_truth_navigation(state, update_nav_path().c_str(), &error_message)) << error_message;
+    gnss_sim::SimTime startup_time{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2041, 179000.0, &startup_time));
+    ASSERT_TRUE(gnss_sim::initialize_receiver_navigation(state, gnss_sim::StartupMode::COLD, startup_time,
+                                                        &error_message));
+
+    gnss_sim::NavAcquisitionPlan wrong_plan{};
+    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGpsL1Ca, startup_time, 999,
+                                                         &wrong_plan, &error_message));
+    bool emitted = false;
+    EXPECT_FALSE(gnss_sim::deliver_cold_nav_plan_if_complete(wrong_plan, 0, wrong_plan.availability_time, state,
+                                                            nullptr, &emitted, &error_message));
+    EXPECT_FALSE(emitted);
+    gnss_sim::destroy_navigation_state(state);
+}
+
+} // namespace


### PR DESCRIPTION
Closes #8.

## Summary
- add deterministic cold-start NAV acquisition plans for GPS/QZSS LNAV, CNAV, and CNAV-2 plus GLONASS FDMA and L3OC;
- derive fragment completion from actual frame/message phase instead of arbitrary per-satellite EPH delay;
- model GPS/QZSS LNAV SF1/SF2/SF3, CNAV MT10/MT11/clock-bearing MT30, CNAV-2 18 s frames, GLONASS FDMA strings 1-4, and GLONASS L3OC immediate strings 10-12;
- use signal-specific CNAV rates: 12 s/message on L2C and 6 s/message on L5;
- preserve integer SimTime and GPST week rollover;
- add IOD-consistent fragment collection: a changed IOD resets a partial set;
- reject delivery when collected IOD does not match the selected Truth NAV record;
- deliver completed acquisitions into the physically isolated Receiver NAV through #7's NavigationState API;
- cover best/worst/edge phase, week crossover, partial masks, repeated delivery, and stepwise Receiver NAV growth.

## Implementation Notes
V1 remains above the bit level. A fragment means a complete subframe/string/message required for ephemeris usability. Acquisition begun inside an already-running fragment cannot use that partial fragment; the receiver waits for the next complete occurrence. This produces phase-dependent TTFF without stochastic EPH delays.

GPS/QZSS CNAV uses the TTFF-critical MT10 + MT11 + clock-bearing message set. The nominal scheduler uses MT30 as the clock-bearing representative, while the collector semantics remain IOD-based so later work can substitute observed/ICD-compliant MT30-37 sequences without changing Receiver NAV delivery.

GLONASS FDMA explicitly models the 30 s frame / 2 s string organization and immediate strings 1-4, so cold start does not incorrectly wait for the ~30 min ephemeris content-update interval. GLONASS G3/L3OC uses the three immediate orbit/clock strings 10-12 with 3 s nominal strings.

CI must pass formatting plus Ubuntu/GCC and Windows/MSVC before merge.