### PR TITLE
Implement cold-start NAV scheduler for Galileo and BeiDou

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ if(BUILD_TESTING)
     add_executable(gnss_sim_unit_tests
         tests/unit/test_deterministic_rng.cpp
         tests/unit/test_nav_message_scheduler.cpp
+        tests/unit/test_nav_message_scheduler_gal_bds.cpp
         tests/unit/test_navigation_state.cpp
         tests/unit/test_receiver_truth.cpp
         tests/unit/test_rtklib_adapter.cpp

--- a/src/gnss/nav_message_scheduler.cpp
+++ b/src/gnss/nav_message_scheduler.cpp
@@ -7,10 +7,7 @@
 namespace gnss_sim {
 namespace {
 
-constexpr std::uint32_t kFragment1 = 1U << 0;
-constexpr std::uint32_t kFragment2 = 1U << 1;
-constexpr std::uint32_t kFragment3 = 1U << 2;
-constexpr std::uint32_t kFragment4 = 1U << 3;
+constexpr std::int64_t kBdtFromGpstOffsetNs = -14LL * NANOSECONDS_PER_SECOND;
 
 void set_error(std::string* error_message, const char* message) {
     if (error_message != nullptr) {
@@ -22,13 +19,22 @@ bool valid_sim_time(const SimTime& time) {
     return time.gps_week >= 0 && time.tow_ns >= 0 && time.tow_ns < GPS_WEEK_NANOSECONDS;
 }
 
+std::int64_t positive_mod(std::int64_t value, std::int64_t modulus) {
+    std::int64_t result = value % modulus;
+    if (result < 0) {
+        result += modulus;
+    }
+    return result;
+}
+
 bool set_fragment(const SimTime& acquisition_time, std::int64_t cycle_ns, std::int64_t slot_start_ns,
-                  std::int64_t duration_ns, int fragment_id, std::uint32_t mask_bit, NavAcquisitionFragment* fragment) {
+                  std::int64_t duration_ns, std::int64_t phase_offset_ns, int fragment_id,
+                  std::uint32_t mask_bit, NavAcquisitionFragment* fragment) {
     if (fragment == nullptr || cycle_ns <= 0 || slot_start_ns < 0 || slot_start_ns >= cycle_ns || duration_ns <= 0) {
         return false;
     }
 
-    const std::int64_t cycle_phase_ns = acquisition_time.tow_ns % cycle_ns;
+    const std::int64_t cycle_phase_ns = positive_mod(acquisition_time.tow_ns + phase_offset_ns, cycle_ns);
     std::int64_t delta_to_slot_start_ns = slot_start_ns - cycle_phase_ns;
     if (delta_to_slot_start_ns < 0) {
         delta_to_slot_start_ns += cycle_ns;
@@ -50,15 +56,17 @@ void update_availability_time(NavAcquisitionPlan* plan, const SimTime& completio
     }
 }
 
-bool add_periodic_fragment(const SimTime& acquisition_time, std::int64_t cycle_sec, std::int64_t slot_start_sec,
-                           std::int64_t duration_sec, int fragment_id, std::uint32_t mask_bit,
-                           NavAcquisitionPlan* plan) {
-    if (plan->fragment_count >= MAX_NAV_ACQUISITION_FRAGMENTS) {
+bool add_periodic_fragment_ns(const SimTime& acquisition_time, std::int64_t cycle_ns, std::int64_t slot_start_ns,
+                              std::int64_t duration_ns, std::int64_t phase_offset_ns, int fragment_id,
+                              NavAcquisitionPlan* plan) {
+    if (plan == nullptr || plan->fragment_count < 0 || plan->fragment_count >= MAX_NAV_ACQUISITION_FRAGMENTS ||
+        plan->fragment_count >= 32) {
         return false;
     }
+    const std::uint32_t mask_bit = 1U << plan->fragment_count;
     NavAcquisitionFragment fragment{};
-    if (!set_fragment(acquisition_time, cycle_sec * NANOSECONDS_PER_SECOND, slot_start_sec * NANOSECONDS_PER_SECOND,
-                      duration_sec * NANOSECONDS_PER_SECOND, fragment_id, mask_bit, &fragment)) {
+    if (!set_fragment(acquisition_time, cycle_ns, slot_start_ns, duration_ns, phase_offset_ns, fragment_id, mask_bit,
+                      &fragment)) {
         return false;
     }
     plan->fragments[plan->fragment_count++] = fragment;
@@ -67,42 +75,135 @@ bool add_periodic_fragment(const SimTime& acquisition_time, std::int64_t cycle_s
     return true;
 }
 
+bool add_periodic_fragment(const SimTime& acquisition_time, std::int64_t cycle_sec, std::int64_t slot_start_sec,
+                           std::int64_t duration_sec, int fragment_id, NavAcquisitionPlan* plan,
+                           std::int64_t phase_offset_ns = 0) {
+    return add_periodic_fragment_ns(acquisition_time, cycle_sec * NANOSECONDS_PER_SECOND,
+                                    slot_start_sec * NANOSECONDS_PER_SECOND,
+                                    duration_sec * NANOSECONDS_PER_SECOND, phase_offset_ns, fragment_id, plan);
+}
+
 bool build_lnav_plan(const SimTime& acquisition_time, NavAcquisitionPlan* plan) {
-    return add_periodic_fragment(acquisition_time, 30, 0, 6, 1, kFragment1, plan) &&
-           add_periodic_fragment(acquisition_time, 30, 6, 6, 2, kFragment2, plan) &&
-           add_periodic_fragment(acquisition_time, 30, 12, 6, 3, kFragment3, plan);
+    return add_periodic_fragment(acquisition_time, 30, 0, 6, 1, plan) &&
+           add_periodic_fragment(acquisition_time, 30, 6, 6, 2, plan) &&
+           add_periodic_fragment(acquisition_time, 30, 12, 6, 3, plan);
 }
 
 bool build_cnav_plan(const SimTime& acquisition_time, std::int64_t message_duration_sec, NavAcquisitionPlan* plan) {
     const std::int64_t cycle_sec = 3 * message_duration_sec;
-    return add_periodic_fragment(acquisition_time, cycle_sec, 0, message_duration_sec, 10, kFragment1, plan) &&
-           add_periodic_fragment(acquisition_time, cycle_sec, message_duration_sec, message_duration_sec, 11,
-                                 kFragment2, plan) &&
+    return add_periodic_fragment(acquisition_time, cycle_sec, 0, message_duration_sec, 10, plan) &&
+           add_periodic_fragment(acquisition_time, cycle_sec, message_duration_sec, message_duration_sec, 11, plan) &&
            add_periodic_fragment(acquisition_time, cycle_sec, 2 * message_duration_sec, message_duration_sec, 30,
-                                 kFragment3, plan);
+                                 plan);
 }
 
 bool build_cnav2_plan(const SimTime& acquisition_time, NavAcquisitionPlan* plan) {
-    return add_periodic_fragment(acquisition_time, 18, 0, 18, 2, kFragment1, plan);
+    return add_periodic_fragment(acquisition_time, 18, 0, 18, 2, plan);
 }
 
 bool build_glonass_fdma_plan(const SimTime& acquisition_time, NavAcquisitionPlan* plan) {
-    return add_periodic_fragment(acquisition_time, 30, 0, 2, 1, kFragment1, plan) &&
-           add_periodic_fragment(acquisition_time, 30, 2, 2, 2, kFragment2, plan) &&
-           add_periodic_fragment(acquisition_time, 30, 4, 2, 3, kFragment3, plan) &&
-           add_periodic_fragment(acquisition_time, 30, 6, 2, 4, kFragment4, plan);
+    return add_periodic_fragment(acquisition_time, 30, 0, 2, 1, plan) &&
+           add_periodic_fragment(acquisition_time, 30, 2, 2, 2, plan) &&
+           add_periodic_fragment(acquisition_time, 30, 4, 2, 3, plan) &&
+           add_periodic_fragment(acquisition_time, 30, 6, 2, 4, plan);
 }
 
 bool build_glonass_l3oc_plan(const SimTime& acquisition_time, NavAcquisitionPlan* plan) {
-    return add_periodic_fragment(acquisition_time, 18, 0, 3, 10, kFragment1, plan) &&
-           add_periodic_fragment(acquisition_time, 18, 3, 3, 11, kFragment2, plan) &&
-           add_periodic_fragment(acquisition_time, 18, 6, 3, 12, kFragment3, plan);
+    return add_periodic_fragment(acquisition_time, 18, 0, 3, 10, plan) &&
+           add_periodic_fragment(acquisition_time, 18, 3, 3, 11, plan) &&
+           add_periodic_fragment(acquisition_time, 18, 6, 3, 12, plan);
+}
+
+bool build_galileo_inav_e1_plan(const SimTime& acquisition_time, NavAcquisitionPlan* plan) {
+    // Current nominal I/NAV E1-B subframe: WT2 completes at T0+3 s,
+    // WT4 at +5 s, WT1 at +23 s, and WT3 at +25 s. RedCED is
+    // deliberately not treated as a normal RTKLIB broadcast ephemeris.
+    return add_periodic_fragment(acquisition_time, 30, 1, 2, 2, plan) &&
+           add_periodic_fragment(acquisition_time, 30, 3, 2, 4, plan) &&
+           add_periodic_fragment(acquisition_time, 30, 21, 2, 1, plan) &&
+           add_periodic_fragment(acquisition_time, 30, 23, 2, 3, plan);
+}
+
+bool build_galileo_inav_e5b_plan(const SimTime& acquisition_time, NavAcquisitionPlan* plan) {
+    // Current nominal I/NAV E5b-I subframe: WT1, WT3, WT2, WT4 occupy
+    // complete two-second pages beginning at T0+0,+2,+20,+22 s.
+    return add_periodic_fragment(acquisition_time, 30, 0, 2, 1, plan) &&
+           add_periodic_fragment(acquisition_time, 30, 2, 2, 3, plan) &&
+           add_periodic_fragment(acquisition_time, 30, 20, 2, 2, plan) &&
+           add_periodic_fragment(acquisition_time, 30, 22, 2, 4, plan);
+}
+
+bool build_galileo_fnav_plan(const SimTime& acquisition_time, NavAcquisitionPlan* plan) {
+    // E5a-I F/NAV has 10 s pages in a 50 s subframe. Page 1 contains
+    // clock/BGD and pages 2-4 contain the three ephemeris parts.
+    return add_periodic_fragment(acquisition_time, 50, 0, 10, 1, plan) &&
+           add_periodic_fragment(acquisition_time, 50, 10, 10, 2, plan) &&
+           add_periodic_fragment(acquisition_time, 50, 20, 10, 3, plan) &&
+           add_periodic_fragment(acquisition_time, 50, 30, 10, 4, plan);
+}
+
+bool build_beidou_d1_plan(const SimTime& acquisition_time, NavAcquisitionPlan* plan) {
+    // BDS D1 basic navigation data occupy subframes 1-3 of a 30 s frame.
+    // Frame phase is defined in BDT; BDT = GPST - 14 s.
+    return add_periodic_fragment(acquisition_time, 30, 0, 6, 1, plan, kBdtFromGpstOffsetNs) &&
+           add_periodic_fragment(acquisition_time, 30, 6, 6, 2, plan, kBdtFromGpstOffsetNs) &&
+           add_periodic_fragment(acquisition_time, 30, 12, 6, 3, plan, kBdtFromGpstOffsetNs);
+}
+
+bool build_beidou_d2_plan(const SimTime& acquisition_time, NavAcquisitionPlan* plan) {
+    // GEO D2 basic navigation data are subcommutated over pages 1-10 of
+    // subframe 1 across ten consecutive 3 s frames. Each subframe is 0.6 s.
+    constexpr std::int64_t kCycleNs = 30LL * NANOSECONDS_PER_SECOND;
+    constexpr std::int64_t kFrameNs = 3LL * NANOSECONDS_PER_SECOND;
+    constexpr std::int64_t kSubframeNs = 600000000LL;
+    for (int page = 1; page <= 10; ++page) {
+        if (!add_periodic_fragment_ns(acquisition_time, kCycleNs, (page - 1) * kFrameNs, kSubframeNs,
+                                      kBdtFromGpstOffsetNs, page, plan)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool build_beidou_bcnav1_plan(const SimTime& acquisition_time, NavAcquisitionPlan* plan) {
+    // B1C B-CNAV1 is an 18 s frame. Subframe 2 contains the complete
+    // ephemeris, clock and group-delay data; V1 conservatively requires one
+    // complete frame after acquisition so partial frame sync is never reused.
+    return add_periodic_fragment(acquisition_time, 18, 0, 18, 2, plan, kBdtFromGpstOffsetNs);
+}
+
+bool build_beidou_bcnav2_plan(const SimTime& acquisition_time, NavAcquisitionPlan* plan) {
+    // B2a B-CNAV2 uses 3 s frames. MT10 and MT11 carry ephemeris I/II and
+    // are continuously paired; MT30 carries clock/TGD/ISC. Broadcast order is
+    // dynamically adjustable, so V1 freezes the deterministic nominal
+    // TTFF-critical schedule MT10 -> MT11 -> MT30.
+    return add_periodic_fragment(acquisition_time, 9, 0, 3, 10, plan, kBdtFromGpstOffsetNs) &&
+           add_periodic_fragment(acquisition_time, 9, 3, 3, 11, plan, kBdtFromGpstOffsetNs) &&
+           add_periodic_fragment(acquisition_time, 9, 6, 3, 30, plan, kBdtFromGpstOffsetNs);
+}
+
+bool build_beidou_bcnav3_plan(const SimTime& acquisition_time, NavAcquisitionPlan* plan) {
+    // B2b B-CNAV3 uses 1 s frames. MT10 contains ephemeris I+II while MT30
+    // carries clock and TGD. Use a deterministic nominal two-frame schedule.
+    return add_periodic_fragment(acquisition_time, 2, 0, 1, 10, plan, kBdtFromGpstOffsetNs) &&
+           add_periodic_fragment(acquisition_time, 2, 1, 1, 30, plan, kBdtFromGpstOffsetNs);
+}
+
+bool variant_is_default(NavScheduleVariant variant) {
+    return variant == NavScheduleVariant::kDefault;
 }
 
 } // namespace
 
 bool build_cold_nav_acquisition_plan(SignalId signal_id, const SimTime& acquisition_time, int issue_data,
                                      NavAcquisitionPlan* plan, std::string* error_message) {
+    return build_cold_nav_acquisition_plan_with_variant(signal_id, NavScheduleVariant::kDefault, acquisition_time,
+                                                        issue_data, plan, error_message);
+}
+
+bool build_cold_nav_acquisition_plan_with_variant(SignalId signal_id, NavScheduleVariant variant,
+                                                  const SimTime& acquisition_time, int issue_data,
+                                                  NavAcquisitionPlan* plan, std::string* error_message) {
     if (plan == nullptr || !valid_sim_time(acquisition_time)) {
         set_error(error_message, "cold NAV acquisition plan has invalid arguments");
         return false;
@@ -117,6 +218,7 @@ bool build_cold_nav_acquisition_plan(SignalId signal_id, const SimTime& acquisit
     NavAcquisitionPlan result{};
     result.signal_id = signal_id;
     result.family = definition->nav_message_family;
+    result.variant = variant;
     result.acquisition_time = acquisition_time;
     result.availability_time = acquisition_time;
     result.issue_data = issue_data;
@@ -126,30 +228,106 @@ bool build_cold_nav_acquisition_plan(SignalId signal_id, const SimTime& acquisit
         case SignalId::kGpsL1Ca:
         case SignalId::kGpsL2P:
         case SignalId::kQzssL1Ca:
+            if (!variant_is_default(variant)) {
+                set_error(error_message, "NAV schedule variant is invalid for GPS/QZSS LNAV");
+                return false;
+            }
             ok = build_lnav_plan(acquisition_time, &result);
             break;
         case SignalId::kGpsL2C:
         case SignalId::kQzssL2C:
+            if (!variant_is_default(variant)) {
+                set_error(error_message, "NAV schedule variant is invalid for GPS/QZSS CNAV");
+                return false;
+            }
             ok = build_cnav_plan(acquisition_time, 12, &result);
             break;
         case SignalId::kGpsL5Q:
         case SignalId::kQzssL5Q:
+            if (!variant_is_default(variant)) {
+                set_error(error_message, "NAV schedule variant is invalid for GPS/QZSS CNAV");
+                return false;
+            }
             ok = build_cnav_plan(acquisition_time, 6, &result);
             break;
         case SignalId::kGpsL1C:
         case SignalId::kQzssL1C:
+            if (!variant_is_default(variant)) {
+                set_error(error_message, "NAV schedule variant is invalid for GPS/QZSS CNAV-2");
+                return false;
+            }
             ok = build_cnav2_plan(acquisition_time, &result);
             break;
         case SignalId::kGlonassG1:
         case SignalId::kGlonassG2:
+            if (!variant_is_default(variant)) {
+                set_error(error_message, "NAV schedule variant is invalid for GLONASS FDMA");
+                return false;
+            }
             ok = build_glonass_fdma_plan(acquisition_time, &result);
             break;
         case SignalId::kGlonassG3:
+            if (!variant_is_default(variant)) {
+                set_error(error_message, "NAV schedule variant is invalid for GLONASS L3OC");
+                return false;
+            }
             ok = build_glonass_l3oc_plan(acquisition_time, &result);
             break;
-        default:
-            set_error(error_message, "signal family is not implemented by cold NAV scheduler issue #8");
+        case SignalId::kGalileoE1:
+            if (!variant_is_default(variant)) {
+                set_error(error_message, "NAV schedule variant is invalid for Galileo I/NAV");
+                return false;
+            }
+            ok = build_galileo_inav_e1_plan(acquisition_time, &result);
+            break;
+        case SignalId::kGalileoE5B:
+            if (!variant_is_default(variant)) {
+                set_error(error_message, "NAV schedule variant is invalid for Galileo I/NAV");
+                return false;
+            }
+            ok = build_galileo_inav_e5b_plan(acquisition_time, &result);
+            break;
+        case SignalId::kGalileoE5A:
+            if (!variant_is_default(variant)) {
+                set_error(error_message, "NAV schedule variant is invalid for Galileo F/NAV");
+                return false;
+            }
+            ok = build_galileo_fnav_plan(acquisition_time, &result);
+            break;
+        case SignalId::kGalileoE6:
+            set_error(error_message,
+                      "Galileo E6 C/NAV/HAS does not provide the normal broadcast ephemeris used by Receiver NAV");
             return false;
+        case SignalId::kBeidouB1I:
+        case SignalId::kBeidouB3I:
+            if (variant == NavScheduleVariant::kDefault || variant == NavScheduleVariant::kBeidouD1) {
+                result.variant = NavScheduleVariant::kBeidouD1;
+                ok = build_beidou_d1_plan(acquisition_time, &result);
+            } else if (variant == NavScheduleVariant::kBeidouD2) {
+                ok = build_beidou_d2_plan(acquisition_time, &result);
+            }
+            break;
+        case SignalId::kBeidouB1C:
+            if (!variant_is_default(variant)) {
+                set_error(error_message, "NAV schedule variant is invalid for BeiDou B-CNAV1");
+                return false;
+            }
+            ok = build_beidou_bcnav1_plan(acquisition_time, &result);
+            break;
+        case SignalId::kBeidouB2A:
+            if (!variant_is_default(variant)) {
+                set_error(error_message, "NAV schedule variant is invalid for BeiDou B-CNAV2");
+                return false;
+            }
+            ok = build_beidou_bcnav2_plan(acquisition_time, &result);
+            break;
+        case SignalId::kBeidouB2B:
+            if (!variant_is_default(variant)) {
+                set_error(error_message, "NAV schedule variant is invalid for BeiDou B-CNAV3");
+                return false;
+            }
+            ok = build_beidou_bcnav3_plan(acquisition_time, &result);
+            break;
     }
 
     if (!ok || result.fragment_count <= 0 || result.required_mask == 0U) {

--- a/src/gnss/nav_message_scheduler.cpp
+++ b/src/gnss/nav_message_scheduler.cpp
@@ -28,8 +28,8 @@ std::int64_t positive_mod(std::int64_t value, std::int64_t modulus) {
 }
 
 bool set_fragment(const SimTime& acquisition_time, std::int64_t cycle_ns, std::int64_t slot_start_ns,
-                  std::int64_t duration_ns, std::int64_t phase_offset_ns, int fragment_id,
-                  std::uint32_t mask_bit, NavAcquisitionFragment* fragment) {
+                  std::int64_t duration_ns, std::int64_t phase_offset_ns, int fragment_id, std::uint32_t mask_bit,
+                  NavAcquisitionFragment* fragment) {
     if (fragment == nullptr || cycle_ns <= 0 || slot_start_ns < 0 || slot_start_ns >= cycle_ns || duration_ns <= 0) {
         return false;
     }
@@ -79,8 +79,8 @@ bool add_periodic_fragment(const SimTime& acquisition_time, std::int64_t cycle_s
                            std::int64_t duration_sec, int fragment_id, NavAcquisitionPlan* plan,
                            std::int64_t phase_offset_ns = 0) {
     return add_periodic_fragment_ns(acquisition_time, cycle_sec * NANOSECONDS_PER_SECOND,
-                                    slot_start_sec * NANOSECONDS_PER_SECOND,
-                                    duration_sec * NANOSECONDS_PER_SECOND, phase_offset_ns, fragment_id, plan);
+                                    slot_start_sec * NANOSECONDS_PER_SECOND, duration_sec * NANOSECONDS_PER_SECOND,
+                                    phase_offset_ns, fragment_id, plan);
 }
 
 bool build_lnav_plan(const SimTime& acquisition_time, NavAcquisitionPlan* plan) {
@@ -93,8 +93,7 @@ bool build_cnav_plan(const SimTime& acquisition_time, std::int64_t message_durat
     const std::int64_t cycle_sec = 3 * message_duration_sec;
     return add_periodic_fragment(acquisition_time, cycle_sec, 0, message_duration_sec, 10, plan) &&
            add_periodic_fragment(acquisition_time, cycle_sec, message_duration_sec, message_duration_sec, 11, plan) &&
-           add_periodic_fragment(acquisition_time, cycle_sec, 2 * message_duration_sec, message_duration_sec, 30,
-                                 plan);
+           add_periodic_fragment(acquisition_time, cycle_sec, 2 * message_duration_sec, message_duration_sec, 30, plan);
 }
 
 bool build_cnav2_plan(const SimTime& acquisition_time, NavAcquisitionPlan* plan) {

--- a/src/gnss/nav_message_scheduler.h
+++ b/src/gnss/nav_message_scheduler.h
@@ -10,7 +10,13 @@
 
 namespace gnss_sim {
 
-constexpr int MAX_NAV_ACQUISITION_FRAGMENTS = 4;
+constexpr int MAX_NAV_ACQUISITION_FRAGMENTS = 12;
+
+enum class NavScheduleVariant {
+    kDefault,
+    kBeidouD1,
+    kBeidouD2,
+};
 
 struct NavAcquisitionFragment {
     int fragment_id;
@@ -21,6 +27,7 @@ struct NavAcquisitionFragment {
 struct NavAcquisitionPlan {
     SignalId signal_id;
     NavMessageFamily family;
+    NavScheduleVariant variant;
     SimTime acquisition_time;
     SimTime availability_time;
     int issue_data;
@@ -38,6 +45,9 @@ struct NavFragmentCollector {
 
 bool build_cold_nav_acquisition_plan(SignalId signal_id, const SimTime& acquisition_time, int issue_data,
                                      NavAcquisitionPlan* plan, std::string* error_message);
+bool build_cold_nav_acquisition_plan_with_variant(SignalId signal_id, NavScheduleVariant variant,
+                                                  const SimTime& acquisition_time, int issue_data,
+                                                  NavAcquisitionPlan* plan, std::string* error_message);
 std::uint32_t nav_acquisition_received_mask(const NavAcquisitionPlan& plan, const SimTime& current_time);
 bool nav_acquisition_complete(const NavAcquisitionPlan& plan, const SimTime& current_time);
 

--- a/tests/unit/test_nav_message_scheduler_gal_bds.cpp
+++ b/tests/unit/test_nav_message_scheduler_gal_bds.cpp
@@ -63,9 +63,9 @@ TEST(ColdNavGalileo, InavUsesSignalSpecificNominalWordSwapSchedule) {
     gnss_sim::NavAcquisitionPlan e5b_plan{};
     std::string error_message;
     ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGalileoE1, e1_after_word2_start, 7,
-                                                         &e1_plan, &error_message));
+                                                          &e1_plan, &error_message));
     ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGalileoE5B, e5b_after_word1_start, 7,
-                                                         &e5b_plan, &error_message));
+                                                          &e5b_plan, &error_message));
     EXPECT_NEAR(gnss_sim::sim_time_sow_sec(e1_plan.availability_time), 180033.0, 1.0e-9);
     EXPECT_NEAR(gnss_sim::sim_time_sow_sec(e5b_plan.availability_time), 180032.0, 1.0e-9);
     EXPECT_EQ(e1_plan.fragment_count, 4);
@@ -80,7 +80,7 @@ TEST(ColdNavGalileo, FnavRequiresClockPageAndThreeEphemerisPages) {
     gnss_sim::NavAcquisitionPlan plan{};
     std::string error_message;
     ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGalileoE5A, acquisition_time, 7, &plan,
-                                                         &error_message));
+                                                          &error_message));
     EXPECT_NEAR(gnss_sim::sim_time_sow_sec(plan.availability_time), 180060.0, 1.0e-9);
     ASSERT_EQ(plan.fragment_count, 4);
     EXPECT_EQ(plan.fragments[0].fragment_id, 1);
@@ -95,28 +95,28 @@ TEST(ColdNavGalileo, E6HasNoNormalBroadcastEphemerisAcquisitionPlan) {
     gnss_sim::NavAcquisitionPlan plan{};
     std::string error_message;
     EXPECT_FALSE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGalileoE6, acquisition_time, 7, &plan,
-                                                          &error_message));
+                                                           &error_message));
     EXPECT_NE(error_message.find("does not provide the normal broadcast ephemeris"), std::string::npos);
 }
 
 TEST(ColdNavBeidou, D1AndD2AreDistinctAndUseBdtPhase) {
     // GPST 180014 corresponds to BDT 180000, exactly on a BDT frame boundary.
-    expect_bds_variant_availability(gnss_sim::SignalId::kBeidouB1I, gnss_sim::NavScheduleVariant::kBeidouD1,
-                                    180014.0, 180032.0, 3);
-    expect_bds_variant_availability(gnss_sim::SignalId::kBeidouB1I, gnss_sim::NavScheduleVariant::kBeidouD2,
-                                    180014.0, 180041.6, 10);
-    expect_bds_variant_availability(gnss_sim::SignalId::kBeidouB3I, gnss_sim::NavScheduleVariant::kBeidouD1,
-                                    180014.0, 180032.0, 3);
-    expect_bds_variant_availability(gnss_sim::SignalId::kBeidouB3I, gnss_sim::NavScheduleVariant::kBeidouD2,
-                                    180014.0, 180041.6, 10);
+    expect_bds_variant_availability(gnss_sim::SignalId::kBeidouB1I, gnss_sim::NavScheduleVariant::kBeidouD1, 180014.0,
+                                    180032.0, 3);
+    expect_bds_variant_availability(gnss_sim::SignalId::kBeidouB1I, gnss_sim::NavScheduleVariant::kBeidouD2, 180014.0,
+                                    180041.6, 10);
+    expect_bds_variant_availability(gnss_sim::SignalId::kBeidouB3I, gnss_sim::NavScheduleVariant::kBeidouD1, 180014.0,
+                                    180032.0, 3);
+    expect_bds_variant_availability(gnss_sim::SignalId::kBeidouB3I, gnss_sim::NavScheduleVariant::kBeidouD2, 180014.0,
+                                    180041.6, 10);
 
     gnss_sim::SimTime just_after_page1{};
     ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, 180014.001, &just_after_page1));
     gnss_sim::NavAcquisitionPlan d2_plan{};
     std::string error_message;
-    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan_with_variant(
-        gnss_sim::SignalId::kBeidouB1I, gnss_sim::NavScheduleVariant::kBeidouD2, just_after_page1, 7, &d2_plan,
-        &error_message));
+    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan_with_variant(gnss_sim::SignalId::kBeidouB1I,
+                                                                       gnss_sim::NavScheduleVariant::kBeidouD2,
+                                                                       just_after_page1, 7, &d2_plan, &error_message));
     EXPECT_NEAR(gnss_sim::sim_time_sow_sec(d2_plan.availability_time), 180044.6, 1.0e-9);
 }
 
@@ -126,7 +126,7 @@ TEST(ColdNavBeidou, DefaultLegacyVariantIsD1) {
     gnss_sim::NavAcquisitionPlan plan{};
     std::string error_message;
     ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kBeidouB1I, acquisition_time, 7, &plan,
-                                                         &error_message));
+                                                          &error_message));
     EXPECT_EQ(plan.variant, gnss_sim::NavScheduleVariant::kBeidouD1);
     EXPECT_EQ(plan.fragment_count, 3);
 }
@@ -144,11 +144,11 @@ TEST(ColdNavBeidou, ModernFamiliesUseDifferentFrameAndMessageRules) {
     gnss_sim::NavAcquisitionPlan b2a_plan{};
     gnss_sim::NavAcquisitionPlan b2b_plan{};
     ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kBeidouB1C, acquisition_time, 7,
-                                                         &b1c_plan, &error_message));
+                                                          &b1c_plan, &error_message));
     ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kBeidouB2A, acquisition_time, 7,
-                                                         &b2a_plan, &error_message));
+                                                          &b2a_plan, &error_message));
     ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kBeidouB2B, acquisition_time, 7,
-                                                         &b2b_plan, &error_message));
+                                                          &b2b_plan, &error_message));
     EXPECT_NEAR(gnss_sim::sim_time_sow_sec(b1c_plan.availability_time), 180050.0, 1.0e-9);
     EXPECT_NEAR(gnss_sim::sim_time_sow_sec(b2a_plan.availability_time), 180026.0, 1.0e-9);
     EXPECT_NEAR(gnss_sim::sim_time_sow_sec(b2b_plan.availability_time), 180017.0, 1.0e-9);
@@ -166,9 +166,9 @@ TEST(ColdNavBeidou, D1CrossesGpsWeekWhileKeepingBdtFramePhase) {
     ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, 604784.0, &acquisition_time));
     gnss_sim::NavAcquisitionPlan plan{};
     std::string error_message;
-    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan_with_variant(
-        gnss_sim::SignalId::kBeidouB1I, gnss_sim::NavScheduleVariant::kBeidouD1, acquisition_time, 7, &plan,
-        &error_message));
+    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan_with_variant(gnss_sim::SignalId::kBeidouB1I,
+                                                                       gnss_sim::NavScheduleVariant::kBeidouD1,
+                                                                       acquisition_time, 7, &plan, &error_message));
     EXPECT_EQ(plan.availability_time.gps_week, 2301);
     EXPECT_NEAR(gnss_sim::sim_time_sow_sec(plan.availability_time), 2.0, 1.0e-9);
 }
@@ -178,9 +178,9 @@ TEST(ColdNavBeidou, VariantCannotBeAppliedToUnrelatedConstellation) {
     ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, 180000.0, &acquisition_time));
     gnss_sim::NavAcquisitionPlan plan{};
     std::string error_message;
-    EXPECT_FALSE(gnss_sim::build_cold_nav_acquisition_plan_with_variant(
-        gnss_sim::SignalId::kGpsL1Ca, gnss_sim::NavScheduleVariant::kBeidouD2, acquisition_time, 7, &plan,
-        &error_message));
+    EXPECT_FALSE(gnss_sim::build_cold_nav_acquisition_plan_with_variant(gnss_sim::SignalId::kGpsL1Ca,
+                                                                        gnss_sim::NavScheduleVariant::kBeidouD2,
+                                                                        acquisition_time, 7, &plan, &error_message));
     EXPECT_FALSE(error_message.empty());
 }
 
@@ -210,8 +210,8 @@ TEST(ColdNavGalileoBeidouIntegration, ReceiverNavGrowsOnlyAfterEachConstellation
     ASSERT_TRUE(gnss_sim::rtklib_nav_record_info(gnss_sim::truth_navigation_store(state), bds_record, &bds_info));
 
     gnss_sim::NavAcquisitionPlan gal_plan{};
-    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGalileoE1, startup_time,
-                                                         gal_info.iode, &gal_plan, &error_message));
+    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGalileoE1, startup_time, gal_info.iode,
+                                                          &gal_plan, &error_message));
     gnss_sim::SimTime bds_acquisition{};
     ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2041, 180014.0, &bds_acquisition));
     gnss_sim::NavAcquisitionPlan bds_plan{};
@@ -221,7 +221,7 @@ TEST(ColdNavGalileoBeidouIntegration, ReceiverNavGrowsOnlyAfterEachConstellation
 
     bool emitted = false;
     ASSERT_TRUE(gnss_sim::deliver_cold_nav_plan_if_complete(gal_plan, gal_record, gal_plan.availability_time, state,
-                                                           nullptr, &emitted, &error_message));
+                                                            nullptr, &emitted, &error_message));
     EXPECT_TRUE(emitted);
     gnss_sim::RtklibNavCounts counts{};
     ASSERT_TRUE(gnss_sim::get_rtklib_nav_counts(gnss_sim::receiver_navigation_store(state), &counts));
@@ -230,10 +230,10 @@ TEST(ColdNavGalileoBeidouIntegration, ReceiverNavGrowsOnlyAfterEachConstellation
 
     emitted = true;
     ASSERT_TRUE(gnss_sim::deliver_cold_nav_plan_if_complete(bds_plan, bds_record, gal_plan.availability_time, state,
-                                                           nullptr, &emitted, &error_message));
+                                                            nullptr, &emitted, &error_message));
     EXPECT_FALSE(emitted);
     ASSERT_TRUE(gnss_sim::deliver_cold_nav_plan_if_complete(bds_plan, bds_record, bds_plan.availability_time, state,
-                                                           nullptr, &emitted, &error_message));
+                                                            nullptr, &emitted, &error_message));
     EXPECT_TRUE(emitted);
     ASSERT_TRUE(gnss_sim::get_rtklib_nav_counts(gnss_sim::receiver_navigation_store(state), &counts));
     EXPECT_EQ(counts.gal_eph_count, 1);

--- a/tests/unit/test_nav_message_scheduler_gal_bds.cpp
+++ b/tests/unit/test_nav_message_scheduler_gal_bds.cpp
@@ -1,0 +1,245 @@
+#include "gnss/nav_message_scheduler.h"
+#include "gnss/navigation_state.h"
+#include "gnss/rtklib_adapter.h"
+#include "gnss_sim/sim_time.h"
+
+#include <gtest/gtest.h>
+#include <string>
+
+namespace {
+
+std::string mixed_nav_path() {
+    return std::string(GNSS_SIM_TEST_DATA_DIR) + "/mixed_nav_2019.rnx";
+}
+
+void expect_availability(gnss_sim::SignalId signal_id, double acquisition_sow_sec, double expected_sow_sec) {
+    gnss_sim::SimTime acquisition_time{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, acquisition_sow_sec, &acquisition_time));
+    gnss_sim::NavAcquisitionPlan plan{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(signal_id, acquisition_time, 7, &plan, &error_message))
+        << error_message;
+    EXPECT_EQ(plan.availability_time.gps_week, 2300);
+    EXPECT_NEAR(gnss_sim::sim_time_sow_sec(plan.availability_time), expected_sow_sec, 1.0e-9);
+    EXPECT_TRUE(gnss_sim::nav_acquisition_complete(plan, plan.availability_time));
+}
+
+void expect_bds_variant_availability(gnss_sim::SignalId signal_id, gnss_sim::NavScheduleVariant variant,
+                                     double acquisition_sow_sec, double expected_sow_sec, int expected_fragments) {
+    gnss_sim::SimTime acquisition_time{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, acquisition_sow_sec, &acquisition_time));
+    gnss_sim::NavAcquisitionPlan plan{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan_with_variant(signal_id, variant, acquisition_time, 7, &plan,
+                                                                       &error_message))
+        << error_message;
+    EXPECT_EQ(plan.availability_time.gps_week, 2300);
+    EXPECT_NEAR(gnss_sim::sim_time_sow_sec(plan.availability_time), expected_sow_sec, 1.0e-9);
+    EXPECT_EQ(plan.fragment_count, expected_fragments);
+    EXPECT_TRUE(gnss_sim::nav_acquisition_complete(plan, plan.availability_time));
+}
+
+int find_truth_record(const gnss_sim::NavigationState* state, int satellite_number) {
+    for (int index = 0; index < gnss_sim::navigation_truth_record_count(state); ++index) {
+        gnss_sim::RtklibNavRecordInfo info{};
+        if (gnss_sim::rtklib_nav_record_info(gnss_sim::truth_navigation_store(state), index, &info) &&
+            info.satellite_number == satellite_number) {
+            return index;
+        }
+    }
+    return -1;
+}
+
+TEST(ColdNavGalileo, InavUsesSignalSpecificNominalWordSwapSchedule) {
+    expect_availability(gnss_sim::SignalId::kGalileoE1, 180000.0, 180025.0);
+    expect_availability(gnss_sim::SignalId::kGalileoE5B, 180000.0, 180024.0);
+
+    gnss_sim::SimTime e1_after_word2_start{};
+    gnss_sim::SimTime e5b_after_word1_start{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, 180001.001, &e1_after_word2_start));
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, 180000.001, &e5b_after_word1_start));
+
+    gnss_sim::NavAcquisitionPlan e1_plan{};
+    gnss_sim::NavAcquisitionPlan e5b_plan{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGalileoE1, e1_after_word2_start, 7,
+                                                         &e1_plan, &error_message));
+    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGalileoE5B, e5b_after_word1_start, 7,
+                                                         &e5b_plan, &error_message));
+    EXPECT_NEAR(gnss_sim::sim_time_sow_sec(e1_plan.availability_time), 180033.0, 1.0e-9);
+    EXPECT_NEAR(gnss_sim::sim_time_sow_sec(e5b_plan.availability_time), 180032.0, 1.0e-9);
+    EXPECT_EQ(e1_plan.fragment_count, 4);
+    EXPECT_EQ(e5b_plan.fragment_count, 4);
+}
+
+TEST(ColdNavGalileo, FnavRequiresClockPageAndThreeEphemerisPages) {
+    expect_availability(gnss_sim::SignalId::kGalileoE5A, 180000.0, 180040.0);
+
+    gnss_sim::SimTime acquisition_time{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, 180000.001, &acquisition_time));
+    gnss_sim::NavAcquisitionPlan plan{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGalileoE5A, acquisition_time, 7, &plan,
+                                                         &error_message));
+    EXPECT_NEAR(gnss_sim::sim_time_sow_sec(plan.availability_time), 180060.0, 1.0e-9);
+    ASSERT_EQ(plan.fragment_count, 4);
+    EXPECT_EQ(plan.fragments[0].fragment_id, 1);
+    EXPECT_EQ(plan.fragments[1].fragment_id, 2);
+    EXPECT_EQ(plan.fragments[2].fragment_id, 3);
+    EXPECT_EQ(plan.fragments[3].fragment_id, 4);
+}
+
+TEST(ColdNavGalileo, E6HasNoNormalBroadcastEphemerisAcquisitionPlan) {
+    gnss_sim::SimTime acquisition_time{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, 180000.0, &acquisition_time));
+    gnss_sim::NavAcquisitionPlan plan{};
+    std::string error_message;
+    EXPECT_FALSE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGalileoE6, acquisition_time, 7, &plan,
+                                                          &error_message));
+    EXPECT_NE(error_message.find("does not provide the normal broadcast ephemeris"), std::string::npos);
+}
+
+TEST(ColdNavBeidou, D1AndD2AreDistinctAndUseBdtPhase) {
+    // GPST 180014 corresponds to BDT 180000, exactly on a BDT frame boundary.
+    expect_bds_variant_availability(gnss_sim::SignalId::kBeidouB1I, gnss_sim::NavScheduleVariant::kBeidouD1,
+                                    180014.0, 180032.0, 3);
+    expect_bds_variant_availability(gnss_sim::SignalId::kBeidouB1I, gnss_sim::NavScheduleVariant::kBeidouD2,
+                                    180014.0, 180041.6, 10);
+    expect_bds_variant_availability(gnss_sim::SignalId::kBeidouB3I, gnss_sim::NavScheduleVariant::kBeidouD1,
+                                    180014.0, 180032.0, 3);
+    expect_bds_variant_availability(gnss_sim::SignalId::kBeidouB3I, gnss_sim::NavScheduleVariant::kBeidouD2,
+                                    180014.0, 180041.6, 10);
+
+    gnss_sim::SimTime just_after_page1{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, 180014.001, &just_after_page1));
+    gnss_sim::NavAcquisitionPlan d2_plan{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan_with_variant(
+        gnss_sim::SignalId::kBeidouB1I, gnss_sim::NavScheduleVariant::kBeidouD2, just_after_page1, 7, &d2_plan,
+        &error_message));
+    EXPECT_NEAR(gnss_sim::sim_time_sow_sec(d2_plan.availability_time), 180044.6, 1.0e-9);
+}
+
+TEST(ColdNavBeidou, DefaultLegacyVariantIsD1) {
+    gnss_sim::SimTime acquisition_time{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, 180014.0, &acquisition_time));
+    gnss_sim::NavAcquisitionPlan plan{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kBeidouB1I, acquisition_time, 7, &plan,
+                                                         &error_message));
+    EXPECT_EQ(plan.variant, gnss_sim::NavScheduleVariant::kBeidouD1);
+    EXPECT_EQ(plan.fragment_count, 3);
+}
+
+TEST(ColdNavBeidou, ModernFamiliesUseDifferentFrameAndMessageRules) {
+    expect_availability(gnss_sim::SignalId::kBeidouB1C, 180014.0, 180032.0);
+    expect_availability(gnss_sim::SignalId::kBeidouB2A, 180014.0, 180023.0);
+    expect_availability(gnss_sim::SignalId::kBeidouB2B, 180014.0, 180016.0);
+
+    gnss_sim::SimTime acquisition_time{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, 180014.001, &acquisition_time));
+    std::string error_message;
+
+    gnss_sim::NavAcquisitionPlan b1c_plan{};
+    gnss_sim::NavAcquisitionPlan b2a_plan{};
+    gnss_sim::NavAcquisitionPlan b2b_plan{};
+    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kBeidouB1C, acquisition_time, 7,
+                                                         &b1c_plan, &error_message));
+    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kBeidouB2A, acquisition_time, 7,
+                                                         &b2a_plan, &error_message));
+    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kBeidouB2B, acquisition_time, 7,
+                                                         &b2b_plan, &error_message));
+    EXPECT_NEAR(gnss_sim::sim_time_sow_sec(b1c_plan.availability_time), 180050.0, 1.0e-9);
+    EXPECT_NEAR(gnss_sim::sim_time_sow_sec(b2a_plan.availability_time), 180026.0, 1.0e-9);
+    EXPECT_NEAR(gnss_sim::sim_time_sow_sec(b2b_plan.availability_time), 180017.0, 1.0e-9);
+    EXPECT_EQ(b2a_plan.fragments[0].fragment_id, 10);
+    EXPECT_EQ(b2a_plan.fragments[1].fragment_id, 11);
+    EXPECT_EQ(b2a_plan.fragments[2].fragment_id, 30);
+    EXPECT_EQ(b2b_plan.fragments[0].fragment_id, 10);
+    EXPECT_EQ(b2b_plan.fragments[1].fragment_id, 30);
+}
+
+TEST(ColdNavBeidou, D1CrossesGpsWeekWhileKeepingBdtFramePhase) {
+    // BDT 604770 is the last complete D1 frame start of the BDT week;
+    // it corresponds to GPST week 2300 SOW 604784.
+    gnss_sim::SimTime acquisition_time{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, 604784.0, &acquisition_time));
+    gnss_sim::NavAcquisitionPlan plan{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan_with_variant(
+        gnss_sim::SignalId::kBeidouB1I, gnss_sim::NavScheduleVariant::kBeidouD1, acquisition_time, 7, &plan,
+        &error_message));
+    EXPECT_EQ(plan.availability_time.gps_week, 2301);
+    EXPECT_NEAR(gnss_sim::sim_time_sow_sec(plan.availability_time), 2.0, 1.0e-9);
+}
+
+TEST(ColdNavBeidou, VariantCannotBeAppliedToUnrelatedConstellation) {
+    gnss_sim::SimTime acquisition_time{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, 180000.0, &acquisition_time));
+    gnss_sim::NavAcquisitionPlan plan{};
+    std::string error_message;
+    EXPECT_FALSE(gnss_sim::build_cold_nav_acquisition_plan_with_variant(
+        gnss_sim::SignalId::kGpsL1Ca, gnss_sim::NavScheduleVariant::kBeidouD2, acquisition_time, 7, &plan,
+        &error_message));
+    EXPECT_FALSE(error_message.empty());
+}
+
+TEST(ColdNavGalileoBeidouIntegration, ReceiverNavGrowsOnlyAfterEachConstellationPlanCompletes) {
+    gnss_sim::NavigationState* state = gnss_sim::create_navigation_state();
+    ASSERT_NE(state, nullptr);
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::load_truth_navigation(state, mixed_nav_path().c_str(), &error_message)) << error_message;
+
+    gnss_sim::SimTime startup_time{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2041, 180000.0, &startup_time));
+    ASSERT_TRUE(
+        gnss_sim::initialize_receiver_navigation(state, gnss_sim::StartupMode::COLD, startup_time, &error_message));
+
+    int gal_satellite = 0;
+    int bds_satellite = 0;
+    ASSERT_TRUE(gnss_sim::rtklib_satellite_id_to_number("E01", &gal_satellite));
+    ASSERT_TRUE(gnss_sim::rtklib_satellite_id_to_number("C01", &bds_satellite));
+    const int gal_record = find_truth_record(state, gal_satellite);
+    const int bds_record = find_truth_record(state, bds_satellite);
+    ASSERT_GE(gal_record, 0);
+    ASSERT_GE(bds_record, 0);
+
+    gnss_sim::RtklibNavRecordInfo gal_info{};
+    gnss_sim::RtklibNavRecordInfo bds_info{};
+    ASSERT_TRUE(gnss_sim::rtklib_nav_record_info(gnss_sim::truth_navigation_store(state), gal_record, &gal_info));
+    ASSERT_TRUE(gnss_sim::rtklib_nav_record_info(gnss_sim::truth_navigation_store(state), bds_record, &bds_info));
+
+    gnss_sim::NavAcquisitionPlan gal_plan{};
+    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan(gnss_sim::SignalId::kGalileoE1, startup_time,
+                                                         gal_info.iode, &gal_plan, &error_message));
+    gnss_sim::SimTime bds_acquisition{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2041, 180014.0, &bds_acquisition));
+    gnss_sim::NavAcquisitionPlan bds_plan{};
+    ASSERT_TRUE(gnss_sim::build_cold_nav_acquisition_plan_with_variant(
+        gnss_sim::SignalId::kBeidouB1I, gnss_sim::NavScheduleVariant::kBeidouD2, bds_acquisition, bds_info.iode,
+        &bds_plan, &error_message));
+
+    bool emitted = false;
+    ASSERT_TRUE(gnss_sim::deliver_cold_nav_plan_if_complete(gal_plan, gal_record, gal_plan.availability_time, state,
+                                                           nullptr, &emitted, &error_message));
+    EXPECT_TRUE(emitted);
+    gnss_sim::RtklibNavCounts counts{};
+    ASSERT_TRUE(gnss_sim::get_rtklib_nav_counts(gnss_sim::receiver_navigation_store(state), &counts));
+    EXPECT_EQ(counts.gal_eph_count, 1);
+    EXPECT_EQ(counts.bds_eph_count, 0);
+
+    emitted = true;
+    ASSERT_TRUE(gnss_sim::deliver_cold_nav_plan_if_complete(bds_plan, bds_record, gal_plan.availability_time, state,
+                                                           nullptr, &emitted, &error_message));
+    EXPECT_FALSE(emitted);
+    ASSERT_TRUE(gnss_sim::deliver_cold_nav_plan_if_complete(bds_plan, bds_record, bds_plan.availability_time, state,
+                                                           nullptr, &emitted, &error_message));
+    EXPECT_TRUE(emitted);
+    ASSERT_TRUE(gnss_sim::get_rtklib_nav_counts(gnss_sim::receiver_navigation_store(state), &counts));
+    EXPECT_EQ(counts.gal_eph_count, 1);
+    EXPECT_EQ(counts.bds_eph_count, 1);
+
+    gnss_sim::destroy_navigation_state(state);
+}
+
+} // namespace


### PR DESCRIPTION
Closes #9.

## Summary
- extend the cold-start NAV scheduler for Galileo E1/E5b I/NAV and E5a F/NAV using distinct normal-CED page/word schedules;
- require Galileo WT1/WT2/WT3/WT4 or F/NAV pages 1-4 before normal Receiver NAV ephemeris becomes available;
- keep Galileo E6 C/NAV/HAS separate from normal broadcast ephemeris acquisition and do not silently treat RedCED as a complete RTKLIB ephemeris;
- add BeiDou D1 and D2 as explicit schedule variants rather than one generic legacy delay;
- model B-CNAV1/B-CNAV2/B-CNAV3 with separate completion rules for B1C/B2a/B2b;
- compute BeiDou schedule phase in BDT by applying the GPST-to-BDT 14 s offset;
- increase the generic fragment capacity to support the ten D2 pages while retaining the existing IOD-consistent collector and Receiver NAV delivery path;
- cover aligned, missed-fragment, cross-week, variant misuse, modern B-CNAV family, and progressive Receiver NAV tests.

## Implementation Notes
Galileo E1-B and E5b-I use their current nominal I/NAV word-swap schedules, so the same four normal CED words complete at different phases on the two signals. E5a F/NAV requires its clock/BGD page plus all three ephemeris pages. E6 is a supported observation signal but its C/NAV/HAS data are not a source of the normal broadcast ephemeris consumed by the RTKLIB Receiver NAV store.

BeiDou frame phase is evaluated in BDT, not GPST. The scheduler uses BDT = GPST - 14 s before modulo frame/page calculations. D1 requires subframes 1-3; GEO D2 requires pages 1-10 of subframe 1 over ten consecutive 3 s frames. B-CNAV1 conservatively requires one complete 18 s frame. B-CNAV2 uses the deterministic nominal MT10 -> MT11 -> MT30 sequence, and B-CNAV3 uses MT10 -> MT30. These message-order assumptions are isolated in constellation-specific schedule functions so later ICD/observed schedule refinements do not change the generic collector.

CI must pass formatting plus Ubuntu/GCC and Windows/MSVC before merge.