### PR TITLE
Implement deterministic CN0 and shared signal tracking model

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,9 @@ add_library(gnss_sim_core STATIC
     src/gnss/rtklib_adapter.cpp
     src/gnss/satellite_engine.cpp
     src/gnss/signal_definitions.cpp
+    src/model/cn0_model.cpp
     src/model/receiver_truth.cpp
+    src/model/signal_tracking.cpp
 )
 add_library(gnss_sim::core ALIAS gnss_sim_core)
 target_include_directories(gnss_sim_core
@@ -105,6 +107,7 @@ if(BUILD_TESTING)
     FetchContent_MakeAvailable(googletest)
 
     add_executable(gnss_sim_unit_tests
+        tests/unit/test_cn0_model.cpp
         tests/unit/test_deterministic_rng.cpp
         tests/unit/test_nav_message_scheduler.cpp
         tests/unit/test_nav_message_scheduler_gal_bds.cpp
@@ -113,6 +116,7 @@ if(BUILD_TESTING)
         tests/unit/test_rtklib_adapter.cpp
         tests/unit/test_satellite_engine.cpp
         tests/unit/test_signal_definitions.cpp
+        tests/unit/test_signal_tracking.cpp
         tests/unit/test_sim_config.cpp
         tests/unit/test_sim_time.cpp
     )

--- a/src/model/cn0_model.cpp
+++ b/src/model/cn0_model.cpp
@@ -1,1 +1,134 @@
-// CN0 runtime model is introduced by issue #10.
+#include "model/cn0_model.h"
+
+#include "gnss_sim/sim_time.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+
+namespace gnss_sim {
+namespace {
+
+constexpr std::int64_t kFastPeriodNs = 20LL * NANOSECONDS_PER_SECOND;
+constexpr std::int64_t kSlowPeriodNs = 120LL * NANOSECONDS_PER_SECOND;
+constexpr double kFastAmplitudeDb = 0.25;
+constexpr double kSlowAmplitudeDb = 0.50;
+
+bool valid_time(const SimTime& time) {
+    return time.gps_week >= 0 && time.tow_ns >= 0 && time.tow_ns < GPS_WEEK_NANOSECONDS;
+}
+
+double signal_cn0_offset_db(SignalId signal_id) {
+    switch (signal_id) {
+        case SignalId::kGpsL1Ca:
+            return 0.0;
+        case SignalId::kGpsL1C:
+            return 1.0;
+        case SignalId::kGpsL2P:
+            return -2.0;
+        case SignalId::kGpsL2C:
+            return -1.0;
+        case SignalId::kGpsL5Q:
+            return 0.5;
+        case SignalId::kQzssL1Ca:
+            return 0.5;
+        case SignalId::kQzssL1C:
+            return 1.0;
+        case SignalId::kQzssL2C:
+            return -0.5;
+        case SignalId::kQzssL5Q:
+            return 0.5;
+        case SignalId::kGlonassG1:
+            return -0.5;
+        case SignalId::kGlonassG2:
+            return -1.5;
+        case SignalId::kGlonassG3:
+            return -0.5;
+        case SignalId::kGalileoE1:
+            return 0.5;
+        case SignalId::kGalileoE5A:
+            return 1.0;
+        case SignalId::kGalileoE5B:
+            return 0.5;
+        case SignalId::kGalileoE6:
+            return -0.5;
+        case SignalId::kBeidouB1I:
+            return -0.5;
+        case SignalId::kBeidouB3I:
+            return -1.0;
+        case SignalId::kBeidouB1C:
+            return 0.5;
+        case SignalId::kBeidouB2A:
+            return 0.5;
+        case SignalId::kBeidouB2B:
+            return 0.0;
+    }
+    return 0.0;
+}
+
+double elevation_baseline_dbhz(double elevation_deg) {
+    const double elevation = std::clamp(elevation_deg, 0.0, 90.0);
+    if (elevation <= 5.0) {
+        return 28.0 + 0.4 * elevation;
+    }
+    if (elevation <= 15.0) {
+        return 30.0 + 0.35 * (elevation - 5.0);
+    }
+    if (elevation <= 30.0) {
+        return 33.5 + 0.3 * (elevation - 15.0);
+    }
+    if (elevation <= 60.0) {
+        return 38.0 + 0.2 * (elevation - 30.0);
+    }
+    return 44.0 + 0.1 * (elevation - 60.0);
+}
+
+std::int64_t positive_mod(std::int64_t value, std::int64_t modulus) {
+    const std::int64_t remainder = value % modulus;
+    return remainder < 0 ? remainder + modulus : remainder;
+}
+
+double triangle_wave(std::int64_t phase_ns, std::int64_t period_ns) {
+    const double phase = static_cast<double>(positive_mod(phase_ns, period_ns)) / static_cast<double>(period_ns);
+    if (phase < 0.5) {
+        return -1.0 + 4.0 * phase;
+    }
+    return 3.0 - 4.0 * phase;
+}
+
+std::int64_t phase_offset_ns(std::uint64_t seed, SignalId signal_id, std::int64_t period_ns, std::uint64_t salt) {
+    std::uint64_t value = seed ^ salt;
+    value ^= static_cast<std::uint64_t>(static_cast<unsigned int>(signal_id) + 1U) * 0x9E3779B97F4A7C15ULL;
+    value ^= value >> 30U;
+    value *= 0xBF58476D1CE4E5B9ULL;
+    value ^= value >> 27U;
+    value *= 0x94D049BB133111EBULL;
+    value ^= value >> 31U;
+    return static_cast<std::int64_t>(value % static_cast<std::uint64_t>(period_ns));
+}
+
+} // namespace
+
+Cn0Model make_builtin_cn0_model(std::uint64_t seed) {
+    return {Cn0ModelSource::kBuiltinFallback, seed};
+}
+
+bool cn0_model_estimate_dbhz(const Cn0Model& model, SignalId signal_id, double elevation_deg, const SimTime& time,
+                             double* cn0_dbhz) {
+    if (cn0_dbhz == nullptr || !std::isfinite(elevation_deg) || !valid_time(time) ||
+        find_signal_definition(signal_id) == nullptr || model.source != Cn0ModelSource::kBuiltinFallback) {
+        return false;
+    }
+
+    const std::int64_t absolute_time_ns = static_cast<std::int64_t>(time.gps_week) * GPS_WEEK_NANOSECONDS + time.tow_ns;
+    const std::int64_t fast_phase = absolute_time_ns + phase_offset_ns(model.seed, signal_id, kFastPeriodNs, 0xA5A5U);
+    const std::int64_t slow_phase = absolute_time_ns + phase_offset_ns(model.seed, signal_id, kSlowPeriodNs, 0x5A5AU);
+
+    double value = elevation_baseline_dbhz(elevation_deg) + signal_cn0_offset_db(signal_id);
+    value += kFastAmplitudeDb * triangle_wave(fast_phase, kFastPeriodNs);
+    value += kSlowAmplitudeDb * triangle_wave(slow_phase, kSlowPeriodNs);
+    *cn0_dbhz = std::clamp(value, 20.0, 55.0);
+    return true;
+}
+
+} // namespace gnss_sim

--- a/src/model/cn0_model.h
+++ b/src/model/cn0_model.h
@@ -1,0 +1,26 @@
+#ifndef GNSS_SIM_SRC_MODEL_CN0_MODEL_H_
+#define GNSS_SIM_SRC_MODEL_CN0_MODEL_H_
+
+#include "gnss/signal_definitions.h"
+#include "gnss_sim/sim_types.h"
+
+#include <cstdint>
+
+namespace gnss_sim {
+
+enum class Cn0ModelSource {
+    kBuiltinFallback,
+};
+
+struct Cn0Model {
+    Cn0ModelSource source;
+    std::uint64_t seed;
+};
+
+Cn0Model make_builtin_cn0_model(std::uint64_t seed);
+bool cn0_model_estimate_dbhz(const Cn0Model& model, SignalId signal_id, double elevation_deg, const SimTime& time,
+                             double* cn0_dbhz);
+
+} // namespace gnss_sim
+
+#endif // GNSS_SIM_SRC_MODEL_CN0_MODEL_H_

--- a/src/model/signal_tracking.cpp
+++ b/src/model/signal_tracking.cpp
@@ -256,7 +256,6 @@ bool update_signal_tracker(SignalTracker* tracker, const SimTime& current_time, 
 
     if (compare_sim_time(current_time, tracker->search_ready_time) < 0) {
         tracker->phase = SignalTrackingPhase::kSearching;
-        tracker->state_since = tracker->state_since;
         tracker->lock_time_ns = 0;
         tracker->psr_valid = false;
         tracker->doppler_valid = false;

--- a/src/model/signal_tracking.cpp
+++ b/src/model/signal_tracking.cpp
@@ -1,1 +1,309 @@
-// Signal tracking state machine is introduced by issue #10.
+#include "model/signal_tracking.h"
+
+#include "gnss_sim/sim_time.h"
+
+#include <cmath>
+#include <cstdint>
+
+namespace gnss_sim {
+namespace {
+
+constexpr std::uint32_t kQuantileScale = 65536U;
+constexpr std::uint32_t kP50Threshold = 32768U;
+constexpr std::uint32_t kP95Threshold = 62259U;
+
+constexpr std::int64_t milliseconds(std::int64_t value) {
+    return value * 1000000LL;
+}
+
+constexpr std::int64_t seconds(std::int64_t value) {
+    return value * NANOSECONDS_PER_SECOND;
+}
+
+DelayDistribution make_delay_ms(std::int64_t minimum_ms, std::int64_t p50_ms, std::int64_t p95_ms,
+                                std::int64_t maximum_ms) {
+    return {milliseconds(minimum_ms), milliseconds(p50_ms), milliseconds(p95_ms), milliseconds(maximum_ms)};
+}
+
+void set_error(std::string* error_message, const char* message) {
+    if (error_message != nullptr) {
+        *error_message = message;
+    }
+}
+
+bool valid_time(const SimTime& time) {
+    return time.gps_week >= 0 && time.tow_ns >= 0 && time.tow_ns < GPS_WEEK_NANOSECONDS;
+}
+
+bool valid_delay_distribution(const DelayDistribution& distribution) {
+    return distribution.minimum_ns >= 0 && distribution.minimum_ns <= distribution.p50_ns &&
+           distribution.p50_ns <= distribution.p95_ns && distribution.p95_ns <= distribution.maximum_ns;
+}
+
+std::int64_t interpolate_integer(std::int64_t lower, std::int64_t upper, std::uint32_t numerator,
+                                 std::uint32_t denominator) {
+    if (upper <= lower || denominator == 0U) {
+        return lower;
+    }
+    const std::int64_t span = upper - lower;
+    return lower + (span * static_cast<std::int64_t>(numerator)) / static_cast<std::int64_t>(denominator);
+}
+
+std::int64_t sample_delay(const DelayDistribution& distribution, DeterministicRng* rng) {
+    const std::uint32_t quantile = rng_next_u32(rng) >> 16U;
+    if (quantile < kP50Threshold) {
+        return interpolate_integer(distribution.minimum_ns, distribution.p50_ns, quantile, kP50Threshold);
+    }
+    if (quantile < kP95Threshold) {
+        return interpolate_integer(distribution.p50_ns, distribution.p95_ns, quantile - kP50Threshold,
+                                   kP95Threshold - kP50Threshold);
+    }
+    return interpolate_integer(distribution.p95_ns, distribution.maximum_ns, quantile - kP95Threshold,
+                               kQuantileScale - kP95Threshold);
+}
+
+int cn0_band(double cn0_dbhz) {
+    if (cn0_dbhz >= 40.0) {
+        return 0;
+    }
+    if (cn0_dbhz >= 35.0) {
+        return 1;
+    }
+    if (cn0_dbhz >= 30.0) {
+        return 2;
+    }
+    return 3;
+}
+
+bool add_delay(const SimTime& time, std::int64_t delay_ns, SimTime* result) {
+    return delay_ns >= 0 && add_time_ns(time, delay_ns, result);
+}
+
+void clear_observation_state(SignalTracker* tracker) {
+    tracker->cn0_dbhz = 0.0;
+    tracker->lock_time_ns = 0;
+    tracker->psr_valid = false;
+    tracker->doppler_valid = false;
+    tracker->adr_valid = false;
+    tracker->observation_available = false;
+}
+
+} // namespace
+
+SignalTrackingModelConfig default_signal_tracking_model_config() {
+    SignalTrackingModelConfig config{};
+    config.hot_common_startup = make_delay_ms(400, 800, 1500, 2000);
+    config.warm_common_startup = make_delay_ms(400, 800, 1500, 2000);
+    config.warm_search_uncertainty = {seconds(2), seconds(5), seconds(15), seconds(25)};
+
+    config.hot_signal_acquisition[0] = make_delay_ms(200, 350, 550, 700);
+    config.hot_signal_acquisition[1] = make_delay_ms(300, 600, 950, 1200);
+    config.hot_signal_acquisition[2] = make_delay_ms(600, 1100, 1900, 2400);
+    config.hot_signal_acquisition[3] = make_delay_ms(1000, 2200, 3600, 4000);
+
+    config.reacquisition[0] = make_delay_ms(80, 300, 800, 1100);
+    config.reacquisition[1] = make_delay_ms(100, 500, 1100, 1500);
+    config.reacquisition[2] = make_delay_ms(200, 850, 1600, 2000);
+    config.reacquisition[3] = make_delay_ms(500, 1300, 2200, 3000);
+
+    config.psr_valid_delay_ns = milliseconds(100);
+    config.doppler_valid_delay_ns = milliseconds(150);
+    config.adr_valid_delay_ns = milliseconds(500);
+    return config;
+}
+
+bool validate_signal_tracking_model_config(const SignalTrackingModelConfig& config, std::string* error_message) {
+    if (!valid_delay_distribution(config.hot_common_startup) || !valid_delay_distribution(config.warm_common_startup) ||
+        !valid_delay_distribution(config.warm_search_uncertainty)) {
+        set_error(error_message, "startup delay distribution is invalid");
+        return false;
+    }
+    for (int index = 0; index < 4; ++index) {
+        if (!valid_delay_distribution(config.hot_signal_acquisition[index]) ||
+            !valid_delay_distribution(config.reacquisition[index])) {
+            set_error(error_message, "signal acquisition delay distribution is invalid");
+            return false;
+        }
+    }
+    if (config.psr_valid_delay_ns < 0 || config.doppler_valid_delay_ns < 0 || config.adr_valid_delay_ns < 0) {
+        set_error(error_message, "measurement-valid delays must be nonnegative");
+        return false;
+    }
+    return true;
+}
+
+bool sample_receiver_startup_timing(StartupMode startup_mode, const SignalTrackingModelConfig& config,
+                                    DeterministicRng* rng, ReceiverStartupTiming* timing) {
+    if (rng == nullptr || timing == nullptr || !validate_signal_tracking_model_config(config, nullptr)) {
+        return false;
+    }
+
+    ReceiverStartupTiming result{};
+    result.startup_mode = startup_mode;
+    if (startup_mode == StartupMode::WARM) {
+        result.common_startup_delay_ns = sample_delay(config.warm_common_startup, rng);
+        result.search_uncertainty_delay_ns = sample_delay(config.warm_search_uncertainty, rng);
+    } else {
+        result.common_startup_delay_ns = sample_delay(config.hot_common_startup, rng);
+        result.search_uncertainty_delay_ns = 0;
+    }
+    result.total_search_ready_delay_ns = result.common_startup_delay_ns + result.search_uncertainty_delay_ns;
+    *timing = result;
+    return true;
+}
+
+void reset_signal_tracker(SignalTracker* tracker, SignalId signal_id, const SimTime& reset_time) {
+    if (tracker == nullptr) {
+        return;
+    }
+    *tracker = {};
+    tracker->signal_id = signal_id;
+    tracker->phase = SignalTrackingPhase::kSignalOff;
+    tracker->acquisition_context = AcquisitionContext::kHot;
+    tracker->state_since = reset_time;
+    tracker->search_ready_time = reset_time;
+    tracker->acquisition_complete_time = reset_time;
+    tracker->tracking_start_time = reset_time;
+    tracker->psr_valid_time = reset_time;
+    tracker->doppler_valid_time = reset_time;
+    tracker->adr_valid_time = reset_time;
+    clear_observation_state(tracker);
+}
+
+bool schedule_signal_acquisition(SignalTracker* tracker, AcquisitionContext context, const SimTime& signal_on_time,
+                                 const SimTime& search_ready_time, double elevation_deg, const Cn0Model& cn0_model,
+                                 const SignalTrackingModelConfig& config, DeterministicRng* rng,
+                                 std::string* error_message) {
+    if (tracker == nullptr || rng == nullptr || !valid_time(signal_on_time) || !valid_time(search_ready_time) ||
+        compare_sim_time(search_ready_time, signal_on_time) < 0 || !std::isfinite(elevation_deg) ||
+        find_signal_definition(tracker->signal_id) == nullptr || !validate_signal_tracking_model_config(config, nullptr)) {
+        set_error(error_message, "signal acquisition schedule has invalid arguments");
+        return false;
+    }
+
+    double acquisition_cn0_dbhz = 0.0;
+    if (!cn0_model_estimate_dbhz(cn0_model, tracker->signal_id, elevation_deg, search_ready_time,
+                                 &acquisition_cn0_dbhz)) {
+        set_error(error_message, "cannot evaluate CN0 for signal acquisition");
+        return false;
+    }
+
+    const int band = cn0_band(acquisition_cn0_dbhz);
+    const DelayDistribution& distribution = context == AcquisitionContext::kReacquisition
+                                                ? config.reacquisition[band]
+                                                : config.hot_signal_acquisition[band];
+    const std::int64_t acquisition_delay_ns = sample_delay(distribution, rng);
+
+    SimTime acquisition_complete_time{};
+    SimTime psr_valid_time{};
+    SimTime doppler_valid_time{};
+    SimTime adr_valid_time{};
+    if (!add_delay(search_ready_time, acquisition_delay_ns, &acquisition_complete_time) ||
+        !add_delay(acquisition_complete_time, config.psr_valid_delay_ns, &psr_valid_time) ||
+        !add_delay(acquisition_complete_time, config.doppler_valid_delay_ns, &doppler_valid_time) ||
+        !add_delay(acquisition_complete_time, config.adr_valid_delay_ns, &adr_valid_time)) {
+        set_error(error_message, "signal acquisition schedule overflows simulation time");
+        return false;
+    }
+
+    tracker->phase = SignalTrackingPhase::kSearching;
+    tracker->acquisition_context = context;
+    tracker->state_since = signal_on_time;
+    tracker->search_ready_time = search_ready_time;
+    tracker->acquisition_complete_time = acquisition_complete_time;
+    tracker->tracking_start_time = acquisition_complete_time;
+    tracker->psr_valid_time = psr_valid_time;
+    tracker->doppler_valid_time = doppler_valid_time;
+    tracker->adr_valid_time = adr_valid_time;
+    tracker->cn0_dbhz = acquisition_cn0_dbhz;
+    tracker->scheduled = true;
+    tracker->lock_time_ns = 0;
+    tracker->psr_valid = false;
+    tracker->doppler_valid = false;
+    tracker->adr_valid = false;
+    tracker->observation_available = false;
+    return true;
+}
+
+bool update_signal_tracker(SignalTracker* tracker, const SimTime& current_time, bool signal_available,
+                           double elevation_deg, const Cn0Model& cn0_model, std::string* error_message) {
+    if (tracker == nullptr || !valid_time(current_time) || !std::isfinite(elevation_deg) ||
+        find_signal_definition(tracker->signal_id) == nullptr) {
+        set_error(error_message, "signal tracking update has invalid arguments");
+        return false;
+    }
+
+    if (!signal_available) {
+        tracker->phase = SignalTrackingPhase::kSignalOff;
+        tracker->state_since = current_time;
+        tracker->scheduled = false;
+        clear_observation_state(tracker);
+        return true;
+    }
+    if (!tracker->scheduled) {
+        set_error(error_message, "signal is available but acquisition has not been scheduled");
+        return false;
+    }
+    if (compare_sim_time(current_time, tracker->state_since) < 0) {
+        set_error(error_message, "signal tracking update precedes the scheduled signal-on time");
+        return false;
+    }
+
+    if (!cn0_model_estimate_dbhz(cn0_model, tracker->signal_id, elevation_deg, current_time, &tracker->cn0_dbhz)) {
+        set_error(error_message, "cannot evaluate CN0 for signal tracking");
+        return false;
+    }
+
+    if (compare_sim_time(current_time, tracker->search_ready_time) < 0) {
+        tracker->phase = SignalTrackingPhase::kSearching;
+        tracker->state_since = tracker->state_since;
+        tracker->lock_time_ns = 0;
+        tracker->psr_valid = false;
+        tracker->doppler_valid = false;
+        tracker->adr_valid = false;
+        tracker->observation_available = false;
+        return true;
+    }
+    if (compare_sim_time(current_time, tracker->acquisition_complete_time) < 0) {
+        if (tracker->phase != SignalTrackingPhase::kAcquiring) {
+            tracker->phase = SignalTrackingPhase::kAcquiring;
+            tracker->state_since = tracker->search_ready_time;
+        }
+        tracker->lock_time_ns = 0;
+        tracker->psr_valid = false;
+        tracker->doppler_valid = false;
+        tracker->adr_valid = false;
+        tracker->observation_available = false;
+        return true;
+    }
+
+    tracker->phase = SignalTrackingPhase::kTracking;
+    tracker->state_since = tracker->tracking_start_time;
+    std::int64_t lock_time_ns = 0;
+    if (!difference_time_ns(current_time, tracker->tracking_start_time, &lock_time_ns) || lock_time_ns < 0) {
+        set_error(error_message, "cannot compute signal lock time");
+        return false;
+    }
+    tracker->lock_time_ns = lock_time_ns;
+    tracker->psr_valid = compare_sim_time(current_time, tracker->psr_valid_time) >= 0;
+    tracker->doppler_valid = compare_sim_time(current_time, tracker->doppler_valid_time) >= 0;
+    tracker->adr_valid = compare_sim_time(current_time, tracker->adr_valid_time) >= 0;
+    tracker->observation_available = tracker->psr_valid;
+    return true;
+}
+
+const char* signal_tracking_phase_name(SignalTrackingPhase phase) {
+    switch (phase) {
+        case SignalTrackingPhase::kSignalOff:
+            return "SIGNAL_OFF";
+        case SignalTrackingPhase::kSearching:
+            return "SEARCHING";
+        case SignalTrackingPhase::kAcquiring:
+            return "ACQUIRING";
+        case SignalTrackingPhase::kTracking:
+            return "TRACKING";
+    }
+    return "UNKNOWN";
+}
+
+} // namespace gnss_sim

--- a/src/model/signal_tracking.cpp
+++ b/src/model/signal_tracking.cpp
@@ -176,7 +176,8 @@ bool schedule_signal_acquisition(SignalTracker* tracker, AcquisitionContext cont
                                  std::string* error_message) {
     if (tracker == nullptr || rng == nullptr || !valid_time(signal_on_time) || !valid_time(search_ready_time) ||
         compare_sim_time(search_ready_time, signal_on_time) < 0 || !std::isfinite(elevation_deg) ||
-        find_signal_definition(tracker->signal_id) == nullptr || !validate_signal_tracking_model_config(config, nullptr)) {
+        find_signal_definition(tracker->signal_id) == nullptr ||
+        !validate_signal_tracking_model_config(config, nullptr)) {
         set_error(error_message, "signal acquisition schedule has invalid arguments");
         return false;
     }

--- a/src/model/signal_tracking.h
+++ b/src/model/signal_tracking.h
@@ -1,0 +1,92 @@
+#ifndef GNSS_SIM_SRC_MODEL_SIGNAL_TRACKING_H_
+#define GNSS_SIM_SRC_MODEL_SIGNAL_TRACKING_H_
+
+#include "core/deterministic_rng.h"
+#include "gnss/signal_definitions.h"
+#include "gnss_sim/sim_config.h"
+#include "gnss_sim/sim_types.h"
+#include "model/cn0_model.h"
+
+#include <cstdint>
+#include <string>
+
+namespace gnss_sim {
+
+enum class SignalTrackingPhase {
+    kSignalOff,
+    kSearching,
+    kAcquiring,
+    kTracking,
+};
+
+enum class AcquisitionContext {
+    kHot,
+    kWarm,
+    kCold,
+    kReacquisition,
+};
+
+struct DelayDistribution {
+    std::int64_t minimum_ns;
+    std::int64_t p50_ns;
+    std::int64_t p95_ns;
+    std::int64_t maximum_ns;
+};
+
+struct SignalTrackingModelConfig {
+    DelayDistribution hot_common_startup;
+    DelayDistribution warm_common_startup;
+    DelayDistribution warm_search_uncertainty;
+    DelayDistribution hot_signal_acquisition[4];
+    DelayDistribution reacquisition[4];
+    std::int64_t psr_valid_delay_ns;
+    std::int64_t doppler_valid_delay_ns;
+    std::int64_t adr_valid_delay_ns;
+};
+
+struct ReceiverStartupTiming {
+    StartupMode startup_mode;
+    std::int64_t common_startup_delay_ns;
+    std::int64_t search_uncertainty_delay_ns;
+    std::int64_t total_search_ready_delay_ns;
+};
+
+struct SignalTracker {
+    SignalId signal_id;
+    SignalTrackingPhase phase;
+    AcquisitionContext acquisition_context;
+    SimTime state_since;
+    SimTime search_ready_time;
+    SimTime acquisition_complete_time;
+    SimTime tracking_start_time;
+    SimTime psr_valid_time;
+    SimTime doppler_valid_time;
+    SimTime adr_valid_time;
+    double cn0_dbhz;
+    std::int64_t lock_time_ns;
+    bool scheduled;
+    bool psr_valid;
+    bool doppler_valid;
+    bool adr_valid;
+    bool observation_available;
+};
+
+SignalTrackingModelConfig default_signal_tracking_model_config();
+bool validate_signal_tracking_model_config(const SignalTrackingModelConfig& config, std::string* error_message);
+
+bool sample_receiver_startup_timing(StartupMode startup_mode, const SignalTrackingModelConfig& config,
+                                    DeterministicRng* rng, ReceiverStartupTiming* timing);
+
+void reset_signal_tracker(SignalTracker* tracker, SignalId signal_id, const SimTime& reset_time);
+bool schedule_signal_acquisition(SignalTracker* tracker, AcquisitionContext context, const SimTime& signal_on_time,
+                                 const SimTime& search_ready_time, double elevation_deg, const Cn0Model& cn0_model,
+                                 const SignalTrackingModelConfig& config, DeterministicRng* rng,
+                                 std::string* error_message);
+bool update_signal_tracker(SignalTracker* tracker, const SimTime& current_time, bool signal_available,
+                           double elevation_deg, const Cn0Model& cn0_model, std::string* error_message);
+
+const char* signal_tracking_phase_name(SignalTrackingPhase phase);
+
+} // namespace gnss_sim
+
+#endif // GNSS_SIM_SRC_MODEL_SIGNAL_TRACKING_H_

--- a/tests/unit/test_cn0_model.cpp
+++ b/tests/unit/test_cn0_model.cpp
@@ -1,10 +1,8 @@
+#include "gnss_sim/sim_time.h"
 #include "model/cn0_model.h"
 
-#include "gnss_sim/sim_time.h"
-
-#include <gtest/gtest.h>
-
 #include <cmath>
+#include <gtest/gtest.h>
 
 namespace {
 
@@ -20,8 +18,8 @@ double estimate(gnss_sim::SignalId signal_id, double elevation_deg, double sow_s
 TEST(Cn0Model, ElevationFallbackIsContinuousAndMonotonicAtPiecewiseBoundaries) {
     const double sow = 180000.0;
     const gnss_sim::SignalId signal = gnss_sim::SignalId::kGpsL1Ca;
-    const double elevations[] = {0.0, 4.999, 5.0, 5.001, 14.999, 15.0, 15.001,
-                                 29.999, 30.0, 30.001, 59.999, 60.0, 60.001, 90.0};
+    const double elevations[] = {0.0,    4.999, 5.0,    5.001,  14.999, 15.0,   15.001,
+                                 29.999, 30.0,  30.001, 59.999, 60.0,   60.001, 90.0};
     double previous = estimate(signal, elevations[0], sow);
     for (std::size_t index = 1; index < sizeof(elevations) / sizeof(elevations[0]); ++index) {
         const double current = estimate(signal, elevations[index], sow);

--- a/tests/unit/test_cn0_model.cpp
+++ b/tests/unit/test_cn0_model.cpp
@@ -1,0 +1,70 @@
+#include "model/cn0_model.h"
+
+#include "gnss_sim/sim_time.h"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+namespace {
+
+double estimate(gnss_sim::SignalId signal_id, double elevation_deg, double sow_sec, std::uint64_t seed = 1234U) {
+    const gnss_sim::Cn0Model model = gnss_sim::make_builtin_cn0_model(seed);
+    gnss_sim::SimTime time{};
+    EXPECT_TRUE(gnss_sim::sim_time_from_week_sow(2300, sow_sec, &time));
+    double cn0_dbhz = 0.0;
+    EXPECT_TRUE(gnss_sim::cn0_model_estimate_dbhz(model, signal_id, elevation_deg, time, &cn0_dbhz));
+    return cn0_dbhz;
+}
+
+TEST(Cn0Model, ElevationFallbackIsContinuousAndMonotonicAtPiecewiseBoundaries) {
+    const double sow = 180000.0;
+    const gnss_sim::SignalId signal = gnss_sim::SignalId::kGpsL1Ca;
+    const double elevations[] = {0.0, 4.999, 5.0, 5.001, 14.999, 15.0, 15.001,
+                                 29.999, 30.0, 30.001, 59.999, 60.0, 60.001, 90.0};
+    double previous = estimate(signal, elevations[0], sow);
+    for (std::size_t index = 1; index < sizeof(elevations) / sizeof(elevations[0]); ++index) {
+        const double current = estimate(signal, elevations[index], sow);
+        EXPECT_GE(current + 1.0e-12, previous);
+        previous = current;
+    }
+    EXPECT_GT(estimate(signal, 90.0, sow), estimate(signal, 3.0, sow) + 10.0);
+}
+
+TEST(Cn0Model, SameSeedAndTimeAreExactlyRepeatable) {
+    const double first = estimate(gnss_sim::SignalId::kGalileoE5A, 42.0, 200000.25, 99U);
+    const double second = estimate(gnss_sim::SignalId::kGalileoE5A, 42.0, 200000.25, 99U);
+    EXPECT_DOUBLE_EQ(first, second);
+
+    const double later = estimate(gnss_sim::SignalId::kGalileoE5A, 42.0, 200001.25, 99U);
+    EXPECT_NE(first, later);
+    EXPECT_LT(std::abs(first - later), 1.0);
+}
+
+TEST(Cn0Model, SignalCalibrationOffsetsRemainVisible) {
+    const double l1c = estimate(gnss_sim::SignalId::kGpsL1C, 45.0, 250000.0);
+    const double l2p = estimate(gnss_sim::SignalId::kGpsL2P, 45.0, 250000.0);
+    EXPECT_GT(l1c, l2p + 1.0);
+}
+
+TEST(Cn0Model, TemporalVariationIsContinuousAcrossGpsWeekBoundary) {
+    const gnss_sim::Cn0Model model = gnss_sim::make_builtin_cn0_model(7U);
+    gnss_sim::SimTime before{};
+    gnss_sim::SimTime after{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, 604799.9, &before));
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2301, 0.1, &after));
+    double before_cn0 = 0.0;
+    double after_cn0 = 0.0;
+    ASSERT_TRUE(gnss_sim::cn0_model_estimate_dbhz(model, gnss_sim::SignalId::kBeidouB1C, 35.0, before, &before_cn0));
+    ASSERT_TRUE(gnss_sim::cn0_model_estimate_dbhz(model, gnss_sim::SignalId::kBeidouB1C, 35.0, after, &after_cn0));
+    EXPECT_LT(std::abs(after_cn0 - before_cn0), 0.2);
+}
+
+TEST(Cn0Model, InvalidArgumentsAreRejected) {
+    const gnss_sim::Cn0Model model = gnss_sim::make_builtin_cn0_model(1U);
+    gnss_sim::SimTime time{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, 1.0, &time));
+    EXPECT_FALSE(gnss_sim::cn0_model_estimate_dbhz(model, gnss_sim::SignalId::kGpsL1Ca, NAN, time, nullptr));
+}
+
+} // namespace

--- a/tests/unit/test_signal_tracking.cpp
+++ b/tests/unit/test_signal_tracking.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <string>
 #include <vector>
 
 namespace {
@@ -86,9 +87,9 @@ TEST(SignalTrackingAcquisition, LowerCn0ProducesLongerDelayAtSameRandomQuantile)
     gnss_sim::seed_rng(&high_rng, 4321U);
     gnss_sim::seed_rng(&low_rng, 4321U);
     std::string error_message;
-    ASSERT_TRUE(gnss_sim::schedule_signal_acquisition(high, gnss_sim::AcquisitionContext::kHot, start, start, 80.0,
+    ASSERT_TRUE(gnss_sim::schedule_signal_acquisition(&high, gnss_sim::AcquisitionContext::kHot, start, start, 80.0,
                                                       cn0_model, config, &high_rng, &error_message));
-    ASSERT_TRUE(gnss_sim::schedule_signal_acquisition(low, gnss_sim::AcquisitionContext::kHot, start, start, 3.0,
+    ASSERT_TRUE(gnss_sim::schedule_signal_acquisition(&low, gnss_sim::AcquisitionContext::kHot, start, start, 3.0,
                                                       cn0_model, config, &low_rng, &error_message));
     EXPECT_GT(gnss_sim::compare_sim_time(low.acquisition_complete_time, high.acquisition_complete_time), 0);
 }

--- a/tests/unit/test_signal_tracking.cpp
+++ b/tests/unit/test_signal_tracking.cpp
@@ -1,0 +1,259 @@
+#include "model/signal_tracking.h"
+
+#include "gnss_sim/sim_time.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+namespace {
+
+constexpr std::int64_t kMs = 1000000LL;
+constexpr std::int64_t kSecond = gnss_sim::NANOSECONDS_PER_SECOND;
+
+bool add_seconds(const gnss_sim::SimTime& time, double seconds, gnss_sim::SimTime* result) {
+    return gnss_sim::add_time_ns(time, static_cast<std::int64_t>(seconds * static_cast<double>(kSecond)), result);
+}
+
+gnss_sim::DelayDistribution fixed_delay(std::int64_t delay_ns) {
+    return {delay_ns, delay_ns, delay_ns, delay_ns};
+}
+
+gnss_sim::SignalTrackingModelConfig fixed_tracking_config() {
+    gnss_sim::SignalTrackingModelConfig config = gnss_sim::default_signal_tracking_model_config();
+    config.hot_common_startup = fixed_delay(0);
+    config.warm_common_startup = fixed_delay(0);
+    config.warm_search_uncertainty = fixed_delay(0);
+    for (int index = 0; index < 4; ++index) {
+        config.hot_signal_acquisition[index] = fixed_delay(500 * kMs);
+        config.reacquisition[index] = fixed_delay(300 * kMs);
+    }
+    config.psr_valid_delay_ns = 100 * kMs;
+    config.doppler_valid_delay_ns = 200 * kMs;
+    config.adr_valid_delay_ns = 500 * kMs;
+    return config;
+}
+
+TEST(SignalTrackingConfig, DefaultsAreValidAndInvalidQuantilesAreRejected) {
+    gnss_sim::SignalTrackingModelConfig config = gnss_sim::default_signal_tracking_model_config();
+    std::string error_message;
+    EXPECT_TRUE(gnss_sim::validate_signal_tracking_model_config(config, &error_message));
+
+    config.hot_common_startup.p50_ns = config.hot_common_startup.minimum_ns - 1;
+    EXPECT_FALSE(gnss_sim::validate_signal_tracking_model_config(config, &error_message));
+    EXPECT_FALSE(error_message.empty());
+}
+
+TEST(SignalTrackingStartup, SeededStartupSamplingIsExactlyRepeatableAndWarmIsSlower) {
+    const gnss_sim::SignalTrackingModelConfig config = gnss_sim::default_signal_tracking_model_config();
+    gnss_sim::DeterministicRng first_rng{};
+    gnss_sim::DeterministicRng second_rng{};
+    gnss_sim::seed_rng(&first_rng, 12345U);
+    gnss_sim::seed_rng(&second_rng, 12345U);
+
+    gnss_sim::ReceiverStartupTiming first{};
+    gnss_sim::ReceiverStartupTiming second{};
+    ASSERT_TRUE(gnss_sim::sample_receiver_startup_timing(gnss_sim::StartupMode::HOT, config, &first_rng, &first));
+    ASSERT_TRUE(gnss_sim::sample_receiver_startup_timing(gnss_sim::StartupMode::HOT, config, &second_rng, &second));
+    EXPECT_EQ(first.common_startup_delay_ns, second.common_startup_delay_ns);
+    EXPECT_EQ(first.total_search_ready_delay_ns, second.total_search_ready_delay_ns);
+
+    gnss_sim::DeterministicRng hot_rng{};
+    gnss_sim::DeterministicRng warm_rng{};
+    gnss_sim::seed_rng(&hot_rng, 77U);
+    gnss_sim::seed_rng(&warm_rng, 77U);
+    gnss_sim::ReceiverStartupTiming hot{};
+    gnss_sim::ReceiverStartupTiming warm{};
+    ASSERT_TRUE(gnss_sim::sample_receiver_startup_timing(gnss_sim::StartupMode::HOT, config, &hot_rng, &hot));
+    ASSERT_TRUE(gnss_sim::sample_receiver_startup_timing(gnss_sim::StartupMode::WARM, config, &warm_rng, &warm));
+    EXPECT_GT(warm.total_search_ready_delay_ns, hot.total_search_ready_delay_ns + kSecond);
+}
+
+TEST(SignalTrackingAcquisition, LowerCn0ProducesLongerDelayAtSameRandomQuantile) {
+    const gnss_sim::SignalTrackingModelConfig config = gnss_sim::default_signal_tracking_model_config();
+    const gnss_sim::Cn0Model cn0_model = gnss_sim::make_builtin_cn0_model(9U);
+    gnss_sim::SimTime start{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, 100000.0, &start));
+
+    gnss_sim::SignalTracker high{};
+    gnss_sim::SignalTracker low{};
+    gnss_sim::reset_signal_tracker(&high, gnss_sim::SignalId::kGpsL1Ca, start);
+    gnss_sim::reset_signal_tracker(&low, gnss_sim::SignalId::kGpsL1Ca, start);
+    gnss_sim::DeterministicRng high_rng{};
+    gnss_sim::DeterministicRng low_rng{};
+    gnss_sim::seed_rng(&high_rng, 4321U);
+    gnss_sim::seed_rng(&low_rng, 4321U);
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::schedule_signal_acquisition(high, gnss_sim::AcquisitionContext::kHot, start, start, 80.0,
+                                                      cn0_model, config, &high_rng, &error_message));
+    ASSERT_TRUE(gnss_sim::schedule_signal_acquisition(low, gnss_sim::AcquisitionContext::kHot, start, start, 3.0,
+                                                      cn0_model, config, &low_rng, &error_message));
+    EXPECT_GT(gnss_sim::compare_sim_time(low.acquisition_complete_time, high.acquisition_complete_time), 0);
+}
+
+TEST(SignalTrackingState, OneStateMachineControlsValidityLockAndSignalOffReset) {
+    const gnss_sim::SignalTrackingModelConfig config = fixed_tracking_config();
+    const gnss_sim::Cn0Model cn0_model = gnss_sim::make_builtin_cn0_model(11U);
+    gnss_sim::SimTime signal_on{};
+    gnss_sim::SimTime search_ready{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, 200000.0, &signal_on));
+    ASSERT_TRUE(add_seconds(signal_on, 1.0, &search_ready));
+
+    gnss_sim::SignalTracker tracker{};
+    gnss_sim::reset_signal_tracker(&tracker, gnss_sim::SignalId::kGalileoE1, signal_on);
+    gnss_sim::DeterministicRng rng{};
+    gnss_sim::seed_rng(&rng, 1U);
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::schedule_signal_acquisition(&tracker, gnss_sim::AcquisitionContext::kHot, signal_on,
+                                                      search_ready, 45.0, cn0_model, config, &rng, &error_message));
+
+    gnss_sim::SimTime current{};
+    ASSERT_TRUE(add_seconds(signal_on, 0.5, &current));
+    ASSERT_TRUE(gnss_sim::update_signal_tracker(&tracker, current, true, 45.0, cn0_model, &error_message));
+    EXPECT_EQ(tracker.phase, gnss_sim::SignalTrackingPhase::kSearching);
+    EXPECT_FALSE(tracker.observation_available);
+
+    ASSERT_TRUE(add_seconds(signal_on, 1.2, &current));
+    ASSERT_TRUE(gnss_sim::update_signal_tracker(&tracker, current, true, 45.0, cn0_model, &error_message));
+    EXPECT_EQ(tracker.phase, gnss_sim::SignalTrackingPhase::kAcquiring);
+    EXPECT_EQ(tracker.lock_time_ns, 0);
+
+    ASSERT_TRUE(add_seconds(signal_on, 1.5, &current));
+    ASSERT_TRUE(gnss_sim::update_signal_tracker(&tracker, current, true, 45.0, cn0_model, &error_message));
+    EXPECT_EQ(tracker.phase, gnss_sim::SignalTrackingPhase::kTracking);
+    EXPECT_EQ(tracker.lock_time_ns, 0);
+    EXPECT_FALSE(tracker.psr_valid);
+
+    ASSERT_TRUE(add_seconds(signal_on, 1.6, &current));
+    ASSERT_TRUE(gnss_sim::update_signal_tracker(&tracker, current, true, 45.0, cn0_model, &error_message));
+    EXPECT_TRUE(tracker.psr_valid);
+    EXPECT_TRUE(tracker.observation_available);
+    EXPECT_FALSE(tracker.doppler_valid);
+    EXPECT_FALSE(tracker.adr_valid);
+    EXPECT_EQ(tracker.lock_time_ns, 100 * kMs);
+
+    ASSERT_TRUE(add_seconds(signal_on, 2.0, &current));
+    ASSERT_TRUE(gnss_sim::update_signal_tracker(&tracker, current, true, 45.0, cn0_model, &error_message));
+    EXPECT_TRUE(tracker.psr_valid);
+    EXPECT_TRUE(tracker.doppler_valid);
+    EXPECT_TRUE(tracker.adr_valid);
+    EXPECT_EQ(tracker.lock_time_ns, 500 * kMs);
+
+    ASSERT_TRUE(add_seconds(signal_on, 3.0, &current));
+    ASSERT_TRUE(gnss_sim::update_signal_tracker(&tracker, current, false, 45.0, cn0_model, &error_message));
+    EXPECT_EQ(tracker.phase, gnss_sim::SignalTrackingPhase::kSignalOff);
+    EXPECT_FALSE(tracker.scheduled);
+    EXPECT_FALSE(tracker.observation_available);
+    EXPECT_FALSE(tracker.psr_valid);
+    EXPECT_FALSE(tracker.doppler_valid);
+    EXPECT_FALSE(tracker.adr_valid);
+    EXPECT_EQ(tracker.lock_time_ns, 0);
+    EXPECT_DOUBLE_EQ(tracker.cn0_dbhz, 0.0);
+}
+
+TEST(SignalTrackingState, ReacquisitionRestartsLockAndUsesFasterModel) {
+    const gnss_sim::SignalTrackingModelConfig config = fixed_tracking_config();
+    const gnss_sim::Cn0Model cn0_model = gnss_sim::make_builtin_cn0_model(12U);
+    gnss_sim::SimTime start{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, 300000.0, &start));
+    gnss_sim::SignalTracker tracker{};
+    gnss_sim::reset_signal_tracker(&tracker, gnss_sim::SignalId::kGpsL1C, start);
+    gnss_sim::DeterministicRng rng{};
+    gnss_sim::seed_rng(&rng, 2U);
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::schedule_signal_acquisition(&tracker, gnss_sim::AcquisitionContext::kReacquisition, start,
+                                                      start, 60.0, cn0_model, config, &rng, &error_message));
+
+    gnss_sim::SimTime current{};
+    ASSERT_TRUE(add_seconds(start, 0.4, &current));
+    ASSERT_TRUE(gnss_sim::update_signal_tracker(&tracker, current, true, 60.0, cn0_model, &error_message));
+    EXPECT_EQ(tracker.phase, gnss_sim::SignalTrackingPhase::kTracking);
+    EXPECT_EQ(tracker.lock_time_ns, 100 * kMs);
+    EXPECT_TRUE(tracker.psr_valid);
+    EXPECT_FALSE(tracker.adr_valid);
+}
+
+std::int64_t fourth_psr_ready_delay_ns(std::uint64_t seed, gnss_sim::StartupMode startup_mode,
+                                       gnss_sim::AcquisitionContext context) {
+    const gnss_sim::SignalTrackingModelConfig config = gnss_sim::default_signal_tracking_model_config();
+    const gnss_sim::Cn0Model cn0_model = gnss_sim::make_builtin_cn0_model(seed);
+    const gnss_sim::SignalId signals[] = {
+        gnss_sim::SignalId::kGpsL1Ca,    gnss_sim::SignalId::kGpsL1C,     gnss_sim::SignalId::kGpsL5Q,
+        gnss_sim::SignalId::kQzssL1C,    gnss_sim::SignalId::kGalileoE1,  gnss_sim::SignalId::kGalileoE5A,
+        gnss_sim::SignalId::kBeidouB1C,  gnss_sim::SignalId::kGpsL2C,     gnss_sim::SignalId::kGalileoE5B,
+        gnss_sim::SignalId::kBeidouB1I,  gnss_sim::SignalId::kGlonassG1,  gnss_sim::SignalId::kBeidouB3I,
+    };
+    const double elevations[] = {75.0, 65.0, 55.0, 50.0, 45.0, 40.0, 35.0, 30.0, 25.0, 20.0, 15.0, 10.0};
+
+    gnss_sim::SimTime start{};
+    EXPECT_TRUE(gnss_sim::sim_time_from_week_sow(2300, 180000.0, &start));
+    gnss_sim::DeterministicRng rng{};
+    gnss_sim::seed_rng(&rng, seed);
+
+    gnss_sim::SimTime search_ready = start;
+    if (context != gnss_sim::AcquisitionContext::kReacquisition) {
+        gnss_sim::ReceiverStartupTiming startup{};
+        EXPECT_TRUE(gnss_sim::sample_receiver_startup_timing(startup_mode, config, &rng, &startup));
+        EXPECT_TRUE(gnss_sim::add_time_ns(start, startup.total_search_ready_delay_ns, &search_ready));
+    }
+
+    std::int64_t delays[12]{};
+    for (int index = 0; index < 12; ++index) {
+        gnss_sim::SignalTracker tracker{};
+        gnss_sim::reset_signal_tracker(&tracker, signals[index], start);
+        std::string error_message;
+        EXPECT_TRUE(gnss_sim::schedule_signal_acquisition(&tracker, context, start, search_ready, elevations[index],
+                                                          cn0_model, config, &rng, &error_message));
+        EXPECT_TRUE(gnss_sim::difference_time_ns(tracker.psr_valid_time, start, &delays[index]));
+    }
+    std::sort(delays, delays + 12);
+    return delays[3];
+}
+
+int ceil_seconds(std::int64_t delay_ns) {
+    return static_cast<int>((delay_ns + kSecond - 1) / kSecond);
+}
+
+int percentile(std::vector<int> values, int percentile_value) {
+    std::sort(values.begin(), values.end());
+    const std::size_t index = static_cast<std::size_t>(percentile_value) * (values.size() - 1U) / 100U;
+    return values[index];
+}
+
+TEST(SignalTrackingCalibration, NominalOpenSkyEnsemblesStayNearFrozenHotWarmAndReaTargets) {
+    std::vector<int> hot;
+    std::vector<int> warm;
+    std::vector<int> rea;
+    for (std::uint64_t seed = 1U; seed <= 1024U; ++seed) {
+        hot.push_back(ceil_seconds(fourth_psr_ready_delay_ns(seed, gnss_sim::StartupMode::HOT,
+                                                            gnss_sim::AcquisitionContext::kHot)));
+        warm.push_back(ceil_seconds(fourth_psr_ready_delay_ns(seed, gnss_sim::StartupMode::WARM,
+                                                             gnss_sim::AcquisitionContext::kWarm)));
+        rea.push_back(ceil_seconds(fourth_psr_ready_delay_ns(seed, gnss_sim::StartupMode::HOT,
+                                                            gnss_sim::AcquisitionContext::kReacquisition)));
+    }
+
+    const int hot_p50 = percentile(hot, 50);
+    const int hot_p95 = percentile(hot, 95);
+    EXPECT_GE(hot_p50, 1);
+    EXPECT_LE(hot_p50, 2);
+    EXPECT_GE(hot_p95, 2);
+    EXPECT_LE(hot_p95, 4);
+
+    const int warm_p50 = percentile(warm, 50);
+    const int warm_p95 = percentile(warm, 95);
+    EXPECT_GE(warm_p50, 6);
+    EXPECT_LE(warm_p50, 9);
+    EXPECT_GE(warm_p95, 14);
+    EXPECT_LE(warm_p95, 21);
+
+    const int rea_p50 = percentile(rea, 50);
+    const int rea_p95 = percentile(rea, 95);
+    EXPECT_GE(rea_p50, 1);
+    EXPECT_LE(rea_p50, 2);
+    EXPECT_LE(rea_p95, 2);
+}
+
+} // namespace

--- a/tests/unit/test_signal_tracking.cpp
+++ b/tests/unit/test_signal_tracking.cpp
@@ -1,11 +1,9 @@
-#include "model/signal_tracking.h"
-
 #include "gnss_sim/sim_time.h"
-
-#include <gtest/gtest.h>
+#include "model/signal_tracking.h"
 
 #include <algorithm>
 #include <cstdint>
+#include <gtest/gtest.h>
 #include <string>
 #include <vector>
 
@@ -181,10 +179,10 @@ std::int64_t fourth_psr_ready_delay_ns(std::uint64_t seed, gnss_sim::StartupMode
     const gnss_sim::SignalTrackingModelConfig config = gnss_sim::default_signal_tracking_model_config();
     const gnss_sim::Cn0Model cn0_model = gnss_sim::make_builtin_cn0_model(seed);
     const gnss_sim::SignalId signals[] = {
-        gnss_sim::SignalId::kGpsL1Ca,    gnss_sim::SignalId::kGpsL1C,     gnss_sim::SignalId::kGpsL5Q,
-        gnss_sim::SignalId::kQzssL1C,    gnss_sim::SignalId::kGalileoE1,  gnss_sim::SignalId::kGalileoE5A,
-        gnss_sim::SignalId::kBeidouB1C,  gnss_sim::SignalId::kGpsL2C,     gnss_sim::SignalId::kGalileoE5B,
-        gnss_sim::SignalId::kBeidouB1I,  gnss_sim::SignalId::kGlonassG1,  gnss_sim::SignalId::kBeidouB3I,
+        gnss_sim::SignalId::kGpsL1Ca,   gnss_sim::SignalId::kGpsL1C,    gnss_sim::SignalId::kGpsL5Q,
+        gnss_sim::SignalId::kQzssL1C,   gnss_sim::SignalId::kGalileoE1, gnss_sim::SignalId::kGalileoE5A,
+        gnss_sim::SignalId::kBeidouB1C, gnss_sim::SignalId::kGpsL2C,    gnss_sim::SignalId::kGalileoE5B,
+        gnss_sim::SignalId::kBeidouB1I, gnss_sim::SignalId::kGlonassG1, gnss_sim::SignalId::kBeidouB3I,
     };
     const double elevations[] = {75.0, 65.0, 55.0, 50.0, 45.0, 40.0, 35.0, 30.0, 25.0, 20.0, 15.0, 10.0};
 
@@ -228,12 +226,12 @@ TEST(SignalTrackingCalibration, NominalOpenSkyEnsemblesStayNearFrozenHotWarmAndR
     std::vector<int> warm;
     std::vector<int> rea;
     for (std::uint64_t seed = 1U; seed <= 1024U; ++seed) {
-        hot.push_back(ceil_seconds(fourth_psr_ready_delay_ns(seed, gnss_sim::StartupMode::HOT,
-                                                            gnss_sim::AcquisitionContext::kHot)));
-        warm.push_back(ceil_seconds(fourth_psr_ready_delay_ns(seed, gnss_sim::StartupMode::WARM,
-                                                             gnss_sim::AcquisitionContext::kWarm)));
-        rea.push_back(ceil_seconds(fourth_psr_ready_delay_ns(seed, gnss_sim::StartupMode::HOT,
-                                                            gnss_sim::AcquisitionContext::kReacquisition)));
+        hot.push_back(ceil_seconds(
+            fourth_psr_ready_delay_ns(seed, gnss_sim::StartupMode::HOT, gnss_sim::AcquisitionContext::kHot)));
+        warm.push_back(ceil_seconds(
+            fourth_psr_ready_delay_ns(seed, gnss_sim::StartupMode::WARM, gnss_sim::AcquisitionContext::kWarm)));
+        rea.push_back(ceil_seconds(
+            fourth_psr_ready_delay_ns(seed, gnss_sim::StartupMode::HOT, gnss_sim::AcquisitionContext::kReacquisition)));
     }
 
     const int hot_p50 = percentile(hot, 50);


### PR DESCRIPTION
Closes #10.

## Summary
- add a runtime CN0 model interface with a deterministic built-in fallback keyed by signal, elevation, GPST, and seed;
- keep fallback elevation behavior monotonic and continuous, with small deterministic temporal variation and per-signal calibration offsets;
- implement the single shared per-signal state machine `SIGNAL_OFF -> SEARCHING -> ACQUIRING -> TRACKING`;
- derive observation availability, PSR/Doppler/ADR validity, CN0, and lock time from the same tracker state;
- add receiver-level HOT/WARM/COLD startup timing decomposition and a dedicated faster REA reacquisition model;
- use bounded P50/P95 piecewise inverse-CDF delay distributions sampled only through the pinned deterministic PCG32 RNG;
- use integer-nanosecond interpolation for sampled delays so tracking transition deadlines are reproducible across MSVC/GCC;
- keep COLD tracking acquisition independent from NAV ephemeris collection: #8/#9 continue to control EPH availability;
- add calibration regressions over 1024 deterministic seeds plus state-transition, reset, CN0-boundary, low-CN0, and GPST-week tests.

## Implementation Notes
The model does not sample TTFF directly. HOT/WARM first-fix timing remains emergent from receiver common startup, WARM search uncertainty, per-signal acquisition, measurement-valid latency, Receiver NAV availability, epoch alignment, and the later RTKLIB solution engine.

The module-level defaults are explicit in `SignalTrackingModelConfig` rather than hidden inside state transitions. HOT/COLD use the same common-startup and per-signal acquisition family; WARM adds a receiver-level search-uncertainty distribution while retaining EPH/ION as required by the frozen design. REA uses a separate reacquisition distribution and no receiver reboot delay.

The built-in CN0 fallback is deliberately isolated behind `Cn0Model`; issue #18 can replace/load an IGS-derived compact model without changing tracking consumers. CN0 affects acquisition/tracking behavior only and does not add PSR/Doppler/ADR measurement noise.

REA signal-off resets per-signal tracking/validity/lock state, but this module does not touch Receiver NAV; #15 will retain NAV at scenario level.

CI must pass format plus Ubuntu/GCC and Windows/MSVC before merge.