### PR TITLE
Implement NovAtel OEM7 RANGEA, PSRPOSA, and PSRVELA writers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ add_library(gnss_sim_core STATIC
     src/gnss/rtklib_adapter.cpp
     src/gnss/rtklib_atmosphere_adapter.cpp
     src/gnss/rtklib_bias_adapter.cpp
+    src/gnss/rtklib_output_adapter.cpp
     src/gnss/rtklib_solution_adapter.cpp
     src/gnss/satellite_engine.cpp
     src/gnss/signal_definitions.cpp
@@ -86,6 +87,8 @@ add_library(gnss_sim_core STATIC
     src/model/measurement_model.cpp
     src/model/receiver_truth.cpp
     src/model/signal_tracking.cpp
+    src/output/novatel_range_writer.cpp
+    src/output/novatel_solution_writer.cpp
     src/solution/solution_engine.cpp
 )
 add_library(gnss_sim::core ALIAS gnss_sim_core)
@@ -124,6 +127,7 @@ if(BUILD_TESTING)
         tests/unit/test_nav_message_scheduler.cpp
         tests/unit/test_nav_message_scheduler_gal_bds.cpp
         tests/unit/test_navigation_state.cpp
+        tests/unit/test_output_writers.cpp
         tests/unit/test_receiver_truth.cpp
         tests/unit/test_rtklib_adapter.cpp
         tests/unit/test_satellite_engine.cpp

--- a/docs/OEM7_WRITER_FIELDS.md
+++ b/docs/OEM7_WRITER_FIELDS.md
@@ -1,0 +1,82 @@
+# OEM7 Writer Field Sources
+
+This document freezes the V1 source of every field emitted by the `RANGEA`, `PSRPOSA`, and `PSRVELA` writers.
+Writers serialize existing simulator/solution state only. They do not recompute satellite geometry, navigation corrections,
+tracking validity, or solution validity.
+
+## Common OEM7 ASCII header
+
+| Field | V1 source |
+| --- | --- |
+| message | Fixed per writer: `RANGEA`, `PSRPOSA`, or `PSRVELA` |
+| port | Fixed protocol value `COM1` |
+| sequence | Fixed `0` |
+| idle time | Fixed `0.0` |
+| time status | Fixed `FINE`; V1 GPST is deterministic and receiver clock bias/drift are zero |
+| GPS week / SOW | `SimTime`, rounded only to the OEM7 ASCII millisecond representation |
+| receiver status | Fixed `00000000` |
+| reserved | Fixed `0` |
+| software version | Fixed `0` |
+| CRC | NovAtel CRC-32 over the ASCII payload between `#` and `*`, polynomial `0xEDB88320`, initial value zero |
+
+## RANGEA
+
+| Field | V1 source |
+| --- | --- |
+| observation count | Count of `MeasurementObservation::observation_available == true` |
+| PRN/slot | RTKLIB canonical satellite ID plus OEM7 PRN mapping: GPS/Galileo/BeiDou direct, GLONASS slot + 37, QZSS PRN + 192 |
+| glofreq | `glonass_fcn + 7` for GLONASS; otherwise `0` |
+| pseudorange | `MeasurementObservation::pseudorange_m` when valid, otherwise `0` |
+| pseudorange sigma | Deterministic nominal metadata: `0.500 m` when valid, otherwise `0`; this does **not** inject measurement noise |
+| ADR | `MeasurementObservation::adr_cycles` when valid, otherwise `0` |
+| ADR sigma | Deterministic nominal metadata: `0.050 cycles` when valid, otherwise `0`; this does **not** inject phase noise |
+| Doppler | `MeasurementObservation::doppler_hz` when valid, otherwise `0` |
+| C/N0 | `MeasurementObservation::cn0_dbhz` |
+| lock time | `MeasurementObservation::lock_time_ns`, converted to seconds for serialization |
+| tracking state | `4` (PLL tracking) when ADR is valid; `7` (FLL) for an emitted observation without valid ADR |
+| SV channel number | Fixed `0`; V1 does not model receiver hardware channel allocation |
+| phase lock | `adr_valid` |
+| parity known | `adr_valid`; V1 has no unresolved half-cycle state after ADR becomes valid |
+| code lock | `pseudorange_valid` |
+| satellite-system bits | Central `SignalDefinition::constellation` mapping |
+| signal-type bits | Central `SignalDefinition::novatel_oem7_signal_type` only |
+| all remaining tracking-status bits | Fixed `0` in V1 |
+
+RANGE records are sorted deterministically by RTKLIB satellite number and then `SignalId`. During REA signal-off the writer still
+emits a scheduled `RANGEA` message with observation count `0`.
+
+## PSRPOSA
+
+| Field | V1 source |
+| --- | --- |
+| solution status / position type | `PositionSolution::status` / `type` |
+| latitude / longitude / height | `PositionSolution`; V1 uses the RTKLIB WGS84 solution |
+| undulation | Fixed `0.0000`; no geoid model is present in V1, so serialized height equals the WGS84 ellipsoidal height |
+| datum | Fixed `WGS84` |
+| latitude / longitude / height sigma | ENU standard deviations precomputed by the solution layer from RTKLIB ECEF covariance |
+| station ID | Empty string |
+| differential age / solution age | Fixed `0.000` |
+| #SVs | Caller-supplied tracked-satellite count from receiver state |
+| #solnSVs | `PositionSolution::used_satellites` when valid, otherwise `0` |
+| reserved Uchar fields | Fixed `0` |
+| reserved hex field | Fixed `00` |
+| extended solution status | Fixed `00` |
+| Galileo/BeiDou signal-used mask | Fixed `00` in V1 |
+| GPS/GLONASS signal-used mask | Fixed `00` in V1 |
+
+An invalid position is still serialized as `INSUFFICIENT_OBS,NONE` with zero numeric solution fields.
+
+## PSRVELA
+
+| Field | V1 source |
+| --- | --- |
+| solution status / velocity type | `VelocitySolution::status` / `type` |
+| latency | Fixed `0.000`; V1 does not model receiver tracking-loop output latency |
+| differential age | Fixed `0.000` |
+| horizontal speed | `VelocitySolution::horizontal_speed_mps`, precomputed by the solution layer |
+| track over ground | `VelocitySolution::track_over_ground_deg`, precomputed from the position hint used by the velocity solver |
+| vertical speed | `VelocitySolution::vertical_speed_mps`, positive up |
+| reserved | Fixed `0` |
+
+Velocity validity remains independent of current position validity. If Doppler velocity is valid using a retained historical position
+hint, PSRVELA remains valid even when the same epoch's PSRPOSA is invalid.

--- a/src/gnss/rtklib_adapter.h
+++ b/src/gnss/rtklib_adapter.h
@@ -135,6 +135,7 @@ bool rtklib_copy_nav_record(const RtklibNavStore* source, int record_index, Rtkl
 bool rtklib_nav_store_has_satellite_ephemeris(const RtklibNavStore* store, int satellite_number);
 
 bool rtklib_satellite_id_to_number(const char* satellite_id, int* satellite_number);
+bool rtklib_satellite_number_to_id(int satellite_number, char satellite_id[4]);
 bool rtklib_observation_code(const char* rinex_signal_code, int* observation_code, int* frequency_index);
 bool get_rtklib_satellite_state(const RtklibNavStore* store, int gps_week, double sow_sec, int satellite_number,
                                 RtklibSatelliteState* state, std::string* error_message);

--- a/src/gnss/rtklib_output_adapter.cpp
+++ b/src/gnss/rtklib_output_adapter.cpp
@@ -1,0 +1,28 @@
+#include "gnss/rtklib_adapter.h"
+
+extern "C" {
+#include <rtklib.h>
+}
+
+#include <cstring>
+
+namespace gnss_sim {
+
+bool rtklib_satellite_number_to_id(int satellite_number, char satellite_id[4]) {
+    if (satellite_id == nullptr || satellite_number <= 0 || satellite_number > MAXSAT) {
+        return false;
+    }
+
+    char rtklib_id[16]{};
+    satno2id(satellite_number, rtklib_id);
+    if (std::strlen(rtklib_id) != 3) {
+        return false;
+    }
+    satellite_id[0] = rtklib_id[0];
+    satellite_id[1] = rtklib_id[1];
+    satellite_id[2] = rtklib_id[2];
+    satellite_id[3] = '\0';
+    return true;
+}
+
+} // namespace gnss_sim

--- a/src/output/novatel_ascii.h
+++ b/src/output/novatel_ascii.h
@@ -1,0 +1,82 @@
+#ifndef GNSS_SIM_SRC_OUTPUT_NOVATEL_ASCII_H_
+#define GNSS_SIM_SRC_OUTPUT_NOVATEL_ASCII_H_
+
+#include "gnss_sim/sim_time.h"
+
+#include <cstdint>
+#include <iomanip>
+#include <locale>
+#include <sstream>
+#include <string>
+
+namespace gnss_sim {
+namespace novatel_ascii {
+
+constexpr const char* kPort = "COM1";
+constexpr const char* kTimeStatus = "FINE";
+constexpr double kIdleTime = 0.0;
+constexpr std::uint32_t kReceiverStatus = 0U;
+constexpr unsigned int kReserved = 0U;
+constexpr unsigned int kSoftwareVersion = 0U;
+
+inline std::uint32_t crc32(const std::string& payload) {
+    constexpr std::uint32_t kPolynomial = UINT32_C(0xEDB88320);
+    std::uint32_t crc = 0U;
+    for (unsigned char byte : payload) {
+        crc ^= static_cast<std::uint32_t>(byte);
+        for (int bit = 0; bit < 8; ++bit) {
+            crc = (crc & 1U) != 0U ? (crc >> 1U) ^ kPolynomial : crc >> 1U;
+        }
+    }
+    return crc;
+}
+
+inline bool rounded_header_time(const SimTime& time, int* gps_week, std::int64_t* tow_milliseconds) {
+    if (gps_week == nullptr || tow_milliseconds == nullptr || time.gps_week < 0 || time.tow_ns < 0 ||
+        time.tow_ns >= GPS_WEEK_NANOSECONDS) {
+        return false;
+    }
+    constexpr std::int64_t kNanosecondsPerMillisecond = 1000000LL;
+    constexpr std::int64_t kMillisecondsPerWeek = GPS_WEEK_SECONDS * 1000LL;
+    std::int64_t rounded_ms = (time.tow_ns + kNanosecondsPerMillisecond / 2) / kNanosecondsPerMillisecond;
+    int week = time.gps_week;
+    if (rounded_ms >= kMillisecondsPerWeek) {
+        rounded_ms -= kMillisecondsPerWeek;
+        ++week;
+    }
+    *gps_week = week;
+    *tow_milliseconds = rounded_ms;
+    return true;
+}
+
+inline bool frame(const char* log_name, const SimTime& time, const std::string& body, std::string* message) {
+    if (log_name == nullptr || log_name[0] == '\0' || message == nullptr) {
+        return false;
+    }
+    int gps_week = 0;
+    std::int64_t tow_milliseconds = 0;
+    if (!rounded_header_time(time, &gps_week, &tow_milliseconds)) {
+        return false;
+    }
+
+    std::ostringstream payload;
+    payload.imbue(std::locale::classic());
+    payload << log_name << ',' << kPort << ",0," << std::fixed << std::setprecision(1) << kIdleTime << ','
+            << kTimeStatus << ',' << gps_week << ',' << (tow_milliseconds / 1000) << '.' << std::setw(3)
+            << std::setfill('0') << (tow_milliseconds % 1000) << ',' << std::hex << std::nouppercase << std::setw(8)
+            << std::setfill('0') << kReceiverStatus << std::dec << ',' << kReserved << ',' << kSoftwareVersion << ';'
+            << body;
+
+    const std::string payload_text = payload.str();
+    std::ostringstream output;
+    output.imbue(std::locale::classic());
+    output << '#' << payload_text << '*' << std::hex << std::nouppercase << std::setw(8) << std::setfill('0')
+           << crc32(payload_text) << "\r\n";
+    *message = output.str();
+    return true;
+}
+
+} // namespace novatel_ascii
+} // namespace gnss_sim
+
+#endif // GNSS_SIM_SRC_OUTPUT_NOVATEL_ASCII_H_

--- a/src/output/novatel_range_writer.cpp
+++ b/src/output/novatel_range_writer.cpp
@@ -160,8 +160,8 @@ bool format_novatel_rangea(const SimTime& time, const MeasurementObservation* ob
         const double adr_cycles = observation->adr_valid ? observation->adr_cycles : 0.0;
         const double adr_sigma_cycles = observation->adr_valid ? kAdrSigmaCycles : 0.0;
         const double doppler_hz = observation->doppler_valid ? observation->doppler_hz : 0.0;
-        const double lock_time_sec = static_cast<double>(observation->lock_time_ns) /
-                                     static_cast<double>(NANOSECONDS_PER_SECOND);
+        const double lock_time_sec =
+            static_cast<double>(observation->lock_time_ns) / static_cast<double>(NANOSECONDS_PER_SECOND);
 
         body << ',' << range_prn << ',' << glofreq << ',' << std::fixed << std::setprecision(3) << pseudorange_m << ','
              << pseudorange_sigma_m << ',' << std::setprecision(6) << adr_cycles << ',' << std::setprecision(3)

--- a/src/output/novatel_range_writer.cpp
+++ b/src/output/novatel_range_writer.cpp
@@ -1,1 +1,180 @@
-// NovAtel RANGEA writer is introduced by issue #13.
+#include "output/novatel_range_writer.h"
+
+#include "gnss/rtklib_adapter.h"
+#include "gnss/signal_definitions.h"
+#include "gnss_sim/sim_time.h"
+#include "output/novatel_ascii.h"
+
+#include <algorithm>
+#include <cmath>
+#include <iomanip>
+#include <locale>
+#include <sstream>
+#include <vector>
+
+namespace gnss_sim {
+namespace {
+
+constexpr double kPseudorangeSigmaM = 0.500;
+constexpr double kAdrSigmaCycles = 0.050;
+constexpr int kGlonassMinFcn = -7;
+constexpr int kGlonassMaxFcn = 6;
+
+void set_error(std::string* error_message, const char* message) {
+    if (error_message != nullptr) {
+        *error_message = message;
+    }
+}
+
+char constellation_id(GnssConstellation constellation) {
+    switch (constellation) {
+        case GnssConstellation::kGps:
+            return 'G';
+        case GnssConstellation::kGlonass:
+            return 'R';
+        case GnssConstellation::kGalileo:
+            return 'E';
+        case GnssConstellation::kBeidou:
+            return 'C';
+        case GnssConstellation::kQzss:
+            return 'J';
+    }
+    return '\0';
+}
+
+unsigned int constellation_status_bits(GnssConstellation constellation) {
+    switch (constellation) {
+        case GnssConstellation::kGps:
+            return 0U;
+        case GnssConstellation::kGlonass:
+            return 1U;
+        case GnssConstellation::kGalileo:
+            return 3U;
+        case GnssConstellation::kBeidou:
+            return 4U;
+        case GnssConstellation::kQzss:
+            return 5U;
+    }
+    return 7U;
+}
+
+bool satellite_fields(const SignalDefinition& definition, const MeasurementObservation& observation, int* range_prn,
+                      int* glofreq) {
+    if (range_prn == nullptr || glofreq == nullptr) {
+        return false;
+    }
+    char satellite_id[4]{};
+    if (!rtklib_satellite_number_to_id(observation.satellite_number, satellite_id) ||
+        satellite_id[0] != constellation_id(definition.constellation) || satellite_id[1] < '0' ||
+        satellite_id[1] > '9' || satellite_id[2] < '0' || satellite_id[2] > '9') {
+        return false;
+    }
+
+    const int prn = (satellite_id[1] - '0') * 10 + satellite_id[2] - '0';
+    switch (definition.constellation) {
+        case GnssConstellation::kGlonass:
+            if (observation.glonass_fcn < kGlonassMinFcn || observation.glonass_fcn > kGlonassMaxFcn) {
+                return false;
+            }
+            *range_prn = prn + 37;
+            *glofreq = observation.glonass_fcn + 7;
+            return true;
+        case GnssConstellation::kQzss:
+            *range_prn = prn + 192;
+            *glofreq = 0;
+            return true;
+        case GnssConstellation::kGps:
+        case GnssConstellation::kGalileo:
+        case GnssConstellation::kBeidou:
+            *range_prn = prn;
+            *glofreq = 0;
+            return true;
+    }
+    return false;
+}
+
+unsigned int tracking_status(const SignalDefinition& definition, const MeasurementObservation& observation) {
+    unsigned int status = observation.adr_valid ? 4U : 7U;
+    if (observation.adr_valid) {
+        status |= 1U << 10U;
+        status |= 1U << 11U;
+    }
+    if (observation.pseudorange_valid) {
+        status |= 1U << 12U;
+    }
+    status |= (constellation_status_bits(definition.constellation) & 7U) << 16U;
+    status |= (static_cast<unsigned int>(definition.novatel_oem7_signal_type) & 0x1FU) << 21U;
+    return status;
+}
+
+bool finite_observation(const MeasurementObservation& observation) {
+    return std::isfinite(observation.cn0_dbhz) && observation.cn0_dbhz >= 0.0 && observation.lock_time_ns >= 0 &&
+           (!observation.pseudorange_valid ||
+            (std::isfinite(observation.pseudorange_m) && observation.pseudorange_m > 0.0)) &&
+           (!observation.adr_valid || std::isfinite(observation.adr_cycles)) &&
+           (!observation.doppler_valid || std::isfinite(observation.doppler_hz));
+}
+
+} // namespace
+
+bool format_novatel_rangea(const SimTime& time, const MeasurementObservation* observations, int observation_count,
+                           std::string* message, std::string* error_message) {
+    if (observation_count < 0 || (observation_count > 0 && observations == nullptr) || message == nullptr) {
+        set_error(error_message, "RANGEA writer received invalid arguments");
+        return false;
+    }
+
+    std::vector<const MeasurementObservation*> emitted;
+    emitted.reserve(static_cast<std::size_t>(observation_count));
+    for (int index = 0; index < observation_count; ++index) {
+        if (observations[index].observation_available) {
+            emitted.push_back(&observations[index]);
+        }
+    }
+    std::sort(emitted.begin(), emitted.end(), [](const MeasurementObservation* lhs, const MeasurementObservation* rhs) {
+        if (lhs->satellite_number != rhs->satellite_number) {
+            return lhs->satellite_number < rhs->satellite_number;
+        }
+        return static_cast<int>(lhs->signal_id) < static_cast<int>(rhs->signal_id);
+    });
+
+    std::ostringstream body;
+    body.imbue(std::locale::classic());
+    body << emitted.size();
+    for (const MeasurementObservation* observation : emitted) {
+        const SignalDefinition* definition = find_signal_definition(observation->signal_id);
+        if (definition == nullptr || definition->novatel_oem7_signal_type < 0 ||
+            definition->novatel_oem7_signal_type > 31 || !finite_observation(*observation)) {
+            set_error(error_message, "RANGEA observation cannot be represented deterministically");
+            return false;
+        }
+        int range_prn = 0;
+        int glofreq = 0;
+        if (!satellite_fields(*definition, *observation, &range_prn, &glofreq)) {
+            set_error(error_message, "RANGEA satellite mapping is invalid");
+            return false;
+        }
+
+        const double pseudorange_m = observation->pseudorange_valid ? observation->pseudorange_m : 0.0;
+        const double pseudorange_sigma_m = observation->pseudorange_valid ? kPseudorangeSigmaM : 0.0;
+        const double adr_cycles = observation->adr_valid ? observation->adr_cycles : 0.0;
+        const double adr_sigma_cycles = observation->adr_valid ? kAdrSigmaCycles : 0.0;
+        const double doppler_hz = observation->doppler_valid ? observation->doppler_hz : 0.0;
+        const double lock_time_sec = static_cast<double>(observation->lock_time_ns) /
+                                     static_cast<double>(NANOSECONDS_PER_SECOND);
+
+        body << ',' << range_prn << ',' << glofreq << ',' << std::fixed << std::setprecision(3) << pseudorange_m << ','
+             << pseudorange_sigma_m << ',' << std::setprecision(6) << adr_cycles << ',' << std::setprecision(3)
+             << adr_sigma_cycles << ',' << doppler_hz << ',' << std::setprecision(1) << observation->cn0_dbhz << ','
+             << std::setprecision(3) << lock_time_sec << ',' << std::hex << std::nouppercase << std::setw(8)
+             << std::setfill('0') << tracking_status(*definition, *observation) << std::dec << std::setfill(' ');
+    }
+
+    if (!novatel_ascii::frame("RANGEA", time, body.str(), message)) {
+        set_error(error_message, "RANGEA header time cannot be represented");
+        return false;
+    }
+    return true;
+}
+
+} // namespace gnss_sim

--- a/src/output/novatel_range_writer.h
+++ b/src/output/novatel_range_writer.h
@@ -1,0 +1,16 @@
+#ifndef GNSS_SIM_SRC_OUTPUT_NOVATEL_RANGE_WRITER_H_
+#define GNSS_SIM_SRC_OUTPUT_NOVATEL_RANGE_WRITER_H_
+
+#include "gnss_sim/sim_types.h"
+#include "model/measurement_model.h"
+
+#include <string>
+
+namespace gnss_sim {
+
+bool format_novatel_rangea(const SimTime& time, const MeasurementObservation* observations, int observation_count,
+                           std::string* message, std::string* error_message);
+
+} // namespace gnss_sim
+
+#endif // GNSS_SIM_SRC_OUTPUT_NOVATEL_RANGE_WRITER_H_

--- a/src/output/novatel_solution_writer.cpp
+++ b/src/output/novatel_solution_writer.cpp
@@ -18,23 +18,25 @@ void set_error(std::string* error_message, const char* message) {
 
 bool consistent_position(const PositionSolution& position) {
     if (position.valid) {
-        return position.status == ReceiverSolutionStatus::kSolComputed && position.type == ReceiverSolutionType::kSingle &&
-               std::isfinite(position.latitude_deg) && std::isfinite(position.longitude_deg) &&
-               std::isfinite(position.height_m) && std::isfinite(position.latitude_std_m) &&
-               std::isfinite(position.longitude_std_m) && std::isfinite(position.height_std_m) &&
-               position.latitude_std_m >= 0.0 && position.longitude_std_m >= 0.0 && position.height_std_m >= 0.0 &&
-               position.used_satellites >= 0 && position.used_satellites <= 255;
+        return position.status == ReceiverSolutionStatus::kSolComputed &&
+               position.type == ReceiverSolutionType::kSingle && std::isfinite(position.latitude_deg) &&
+               std::isfinite(position.longitude_deg) && std::isfinite(position.height_m) &&
+               std::isfinite(position.latitude_std_m) && std::isfinite(position.longitude_std_m) &&
+               std::isfinite(position.height_std_m) && position.latitude_std_m >= 0.0 &&
+               position.longitude_std_m >= 0.0 && position.height_std_m >= 0.0 && position.used_satellites >= 0 &&
+               position.used_satellites <= 255;
     }
     return position.status == ReceiverSolutionStatus::kInsufficientObs && position.type == ReceiverSolutionType::kNone;
 }
 
 bool consistent_velocity(const VelocitySolution& velocity) {
     if (velocity.valid) {
-        return velocity.status == ReceiverSolutionStatus::kSolComputed && velocity.type == ReceiverSolutionType::kSingle &&
-               std::isfinite(velocity.horizontal_speed_mps) && velocity.horizontal_speed_mps >= 0.0 &&
-               std::isfinite(velocity.track_over_ground_deg) && velocity.track_over_ground_deg >= 0.0 &&
-               velocity.track_over_ground_deg < 360.0 && std::isfinite(velocity.vertical_speed_mps) &&
-               velocity.used_satellites >= 0 && velocity.used_satellites <= 255;
+        return velocity.status == ReceiverSolutionStatus::kSolComputed &&
+               velocity.type == ReceiverSolutionType::kSingle && std::isfinite(velocity.horizontal_speed_mps) &&
+               velocity.horizontal_speed_mps >= 0.0 && std::isfinite(velocity.track_over_ground_deg) &&
+               velocity.track_over_ground_deg >= 0.0 && velocity.track_over_ground_deg < 360.0 &&
+               std::isfinite(velocity.vertical_speed_mps) && velocity.used_satellites >= 0 &&
+               velocity.used_satellites <= 255;
     }
     return velocity.status == ReceiverSolutionStatus::kInsufficientObs && velocity.type == ReceiverSolutionType::kNone;
 }
@@ -86,8 +88,8 @@ bool format_novatel_psrvela(const SolutionEpoch& solution, std::string* message,
     std::ostringstream body;
     body.imbue(std::locale::classic());
     body << receiver_solution_status_name(velocity.status) << ',' << receiver_solution_type_name(velocity.type)
-         << ",0.000,0.000," << std::fixed << std::setprecision(4) << horizontal_speed_mps << ','
-         << std::setprecision(6) << track_over_ground_deg << ',' << std::setprecision(4) << vertical_speed_mps << ",0";
+         << ",0.000,0.000," << std::fixed << std::setprecision(4) << horizontal_speed_mps << ',' << std::setprecision(6)
+         << track_over_ground_deg << ',' << std::setprecision(4) << vertical_speed_mps << ",0";
 
     if (!novatel_ascii::frame("PSRVELA", solution.time, body.str(), message)) {
         set_error(error_message, "PSRVELA header time cannot be represented");

--- a/src/output/novatel_solution_writer.cpp
+++ b/src/output/novatel_solution_writer.cpp
@@ -1,1 +1,99 @@
-// NovAtel PSRPOSA/PSRVELA writer is introduced by issue #13.
+#include "output/novatel_solution_writer.h"
+
+#include "output/novatel_ascii.h"
+
+#include <cmath>
+#include <iomanip>
+#include <locale>
+#include <sstream>
+
+namespace gnss_sim {
+namespace {
+
+void set_error(std::string* error_message, const char* message) {
+    if (error_message != nullptr) {
+        *error_message = message;
+    }
+}
+
+bool consistent_position(const PositionSolution& position) {
+    if (position.valid) {
+        return position.status == ReceiverSolutionStatus::kSolComputed && position.type == ReceiverSolutionType::kSingle &&
+               std::isfinite(position.latitude_deg) && std::isfinite(position.longitude_deg) &&
+               std::isfinite(position.height_m) && std::isfinite(position.latitude_std_m) &&
+               std::isfinite(position.longitude_std_m) && std::isfinite(position.height_std_m) &&
+               position.latitude_std_m >= 0.0 && position.longitude_std_m >= 0.0 && position.height_std_m >= 0.0 &&
+               position.used_satellites >= 0 && position.used_satellites <= 255;
+    }
+    return position.status == ReceiverSolutionStatus::kInsufficientObs && position.type == ReceiverSolutionType::kNone;
+}
+
+bool consistent_velocity(const VelocitySolution& velocity) {
+    if (velocity.valid) {
+        return velocity.status == ReceiverSolutionStatus::kSolComputed && velocity.type == ReceiverSolutionType::kSingle &&
+               std::isfinite(velocity.horizontal_speed_mps) && velocity.horizontal_speed_mps >= 0.0 &&
+               std::isfinite(velocity.track_over_ground_deg) && velocity.track_over_ground_deg >= 0.0 &&
+               velocity.track_over_ground_deg < 360.0 && std::isfinite(velocity.vertical_speed_mps) &&
+               velocity.used_satellites >= 0 && velocity.used_satellites <= 255;
+    }
+    return velocity.status == ReceiverSolutionStatus::kInsufficientObs && velocity.type == ReceiverSolutionType::kNone;
+}
+
+} // namespace
+
+bool format_novatel_psrposa(const SolutionEpoch& solution, int tracked_satellites, std::string* message,
+                            std::string* error_message) {
+    if (message == nullptr || tracked_satellites < 0 || tracked_satellites > 255 ||
+        !consistent_position(solution.position)) {
+        set_error(error_message, "PSRPOSA solution metadata is invalid");
+        return false;
+    }
+
+    const PositionSolution& position = solution.position;
+    const double latitude_deg = position.valid ? position.latitude_deg : 0.0;
+    const double longitude_deg = position.valid ? position.longitude_deg : 0.0;
+    const double height_m = position.valid ? position.height_m : 0.0;
+    const double latitude_std_m = position.valid ? position.latitude_std_m : 0.0;
+    const double longitude_std_m = position.valid ? position.longitude_std_m : 0.0;
+    const double height_std_m = position.valid ? position.height_std_m : 0.0;
+    const int used_satellites = position.valid ? position.used_satellites : 0;
+
+    std::ostringstream body;
+    body.imbue(std::locale::classic());
+    body << receiver_solution_status_name(position.status) << ',' << receiver_solution_type_name(position.type) << ','
+         << std::fixed << std::setprecision(11) << latitude_deg << ',' << longitude_deg << ',' << std::setprecision(4)
+         << height_m << ",0.0000,WGS84," << latitude_std_m << ',' << longitude_std_m << ',' << height_std_m
+         << ",\"\",0.000,0.000," << tracked_satellites << ',' << used_satellites << ",0,0,00,00,00,00";
+
+    if (!novatel_ascii::frame("PSRPOSA", solution.time, body.str(), message)) {
+        set_error(error_message, "PSRPOSA header time cannot be represented");
+        return false;
+    }
+    return true;
+}
+
+bool format_novatel_psrvela(const SolutionEpoch& solution, std::string* message, std::string* error_message) {
+    if (message == nullptr || !consistent_velocity(solution.velocity)) {
+        set_error(error_message, "PSRVELA solution metadata is invalid");
+        return false;
+    }
+
+    const VelocitySolution& velocity = solution.velocity;
+    const double horizontal_speed_mps = velocity.valid ? velocity.horizontal_speed_mps : 0.0;
+    const double track_over_ground_deg = velocity.valid ? velocity.track_over_ground_deg : 0.0;
+    const double vertical_speed_mps = velocity.valid ? velocity.vertical_speed_mps : 0.0;
+
+    std::ostringstream body;
+    body.imbue(std::locale::classic());
+    body << receiver_solution_status_name(velocity.status) << ',' << receiver_solution_type_name(velocity.type)
+         << ",0.000,0.000," << std::fixed << std::setprecision(4) << horizontal_speed_mps << ','
+         << std::setprecision(6) << track_over_ground_deg << ',' << std::setprecision(4) << vertical_speed_mps << ",0";
+
+    if (!novatel_ascii::frame("PSRVELA", solution.time, body.str(), message)) {
+        set_error(error_message, "PSRVELA header time cannot be represented");
+        return false;
+    }
+    return true;
+}
+
+} // namespace gnss_sim

--- a/src/output/novatel_solution_writer.h
+++ b/src/output/novatel_solution_writer.h
@@ -1,0 +1,16 @@
+#ifndef GNSS_SIM_SRC_OUTPUT_NOVATEL_SOLUTION_WRITER_H_
+#define GNSS_SIM_SRC_OUTPUT_NOVATEL_SOLUTION_WRITER_H_
+
+#include "solution/solution_engine.h"
+
+#include <string>
+
+namespace gnss_sim {
+
+bool format_novatel_psrposa(const SolutionEpoch& solution, int tracked_satellites, std::string* message,
+                            std::string* error_message);
+bool format_novatel_psrvela(const SolutionEpoch& solution, std::string* message, std::string* error_message);
+
+} // namespace gnss_sim
+
+#endif // GNSS_SIM_SRC_OUTPUT_NOVATEL_SOLUTION_WRITER_H_

--- a/src/solution/solution_engine.cpp
+++ b/src/solution/solution_engine.cpp
@@ -10,6 +10,7 @@ namespace gnss_sim {
 namespace {
 
 constexpr int kMaxSolverSatellites = 64;
+constexpr double kPi = 3.141592653589793238462643383279502884;
 
 struct SelectedObservation {
     int satellite_number;
@@ -117,6 +118,76 @@ void sort_selected_observations(SelectedObservation selected[kMaxSolverSatellite
     }
 }
 
+double covariance_axis_variance(const double covariance[6], const double axis[3]) {
+    const double xx = covariance[0];
+    const double yy = covariance[1];
+    const double zz = covariance[2];
+    const double xy = covariance[3];
+    const double yz = covariance[4];
+    const double zx = covariance[5];
+    return axis[0] * axis[0] * xx + axis[1] * axis[1] * yy + axis[2] * axis[2] * zz +
+           2.0 * axis[0] * axis[1] * xy + 2.0 * axis[1] * axis[2] * yz + 2.0 * axis[2] * axis[0] * zx;
+}
+
+double nonnegative_std(double variance) {
+    if (!std::isfinite(variance)) {
+        return 0.0;
+    }
+    return std::sqrt(variance > 0.0 ? variance : 0.0);
+}
+
+void fill_local_position_std(PositionSolution* destination) {
+    const double latitude_rad = destination->latitude_deg * kPi / 180.0;
+    const double longitude_rad = destination->longitude_deg * kPi / 180.0;
+    const double sin_latitude = std::sin(latitude_rad);
+    const double cos_latitude = std::cos(latitude_rad);
+    const double sin_longitude = std::sin(longitude_rad);
+    const double cos_longitude = std::cos(longitude_rad);
+    const double east[3] = {-sin_longitude, cos_longitude, 0.0};
+    const double north[3] = {-sin_latitude * cos_longitude, -sin_latitude * sin_longitude, cos_latitude};
+    const double up[3] = {cos_latitude * cos_longitude, cos_latitude * sin_longitude, sin_latitude};
+
+    destination->latitude_std_m = nonnegative_std(covariance_axis_variance(destination->covariance_ecef_m2, north));
+    destination->longitude_std_m = nonnegative_std(covariance_axis_variance(destination->covariance_ecef_m2, east));
+    destination->height_std_m = nonnegative_std(covariance_axis_variance(destination->covariance_ecef_m2, up));
+}
+
+bool fill_local_velocity(const double position_ecef_m[3], VelocitySolution* destination) {
+    double latitude_deg = 0.0;
+    double longitude_deg = 0.0;
+    double height_m = 0.0;
+    if (!rtklib_ecef_to_llh(position_ecef_m, &latitude_deg, &longitude_deg, &height_m)) {
+        return false;
+    }
+    static_cast<void>(height_m);
+
+    const double latitude_rad = latitude_deg * kPi / 180.0;
+    const double longitude_rad = longitude_deg * kPi / 180.0;
+    const double sin_latitude = std::sin(latitude_rad);
+    const double cos_latitude = std::cos(latitude_rad);
+    const double sin_longitude = std::sin(longitude_rad);
+    const double cos_longitude = std::cos(longitude_rad);
+    const double vx = destination->velocity_ecef_mps[0];
+    const double vy = destination->velocity_ecef_mps[1];
+    const double vz = destination->velocity_ecef_mps[2];
+    const double east_mps = -sin_longitude * vx + cos_longitude * vy;
+    const double north_mps = -sin_latitude * cos_longitude * vx - sin_latitude * sin_longitude * vy + cos_latitude * vz;
+    const double up_mps = cos_latitude * cos_longitude * vx + cos_latitude * sin_longitude * vy + sin_latitude * vz;
+
+    destination->horizontal_speed_mps = std::hypot(north_mps, east_mps);
+    destination->vertical_speed_mps = up_mps;
+    if (destination->horizontal_speed_mps <= 1.0e-12) {
+        destination->track_over_ground_deg = 0.0;
+    } else {
+        double track_deg = std::atan2(east_mps, north_mps) * 180.0 / kPi;
+        if (track_deg < 0.0) {
+            track_deg += 360.0;
+        }
+        destination->track_over_ground_deg = track_deg;
+    }
+    return true;
+}
+
 void copy_position_solution(const RtklibPositionSolution& source, PositionSolution* destination) {
     copy_diagnostic(source.diagnostic, destination->diagnostic);
     if (!source.valid) {
@@ -135,13 +206,15 @@ void copy_position_solution(const RtklibPositionSolution& source, PositionSoluti
     for (int index = 0; index < 6; ++index) {
         destination->covariance_ecef_m2[index] = source.covariance_ecef_m2[index];
     }
+    fill_local_position_std(destination);
     destination->used_satellites = source.used_satellites;
 }
 
-void copy_velocity_solution(const RtklibVelocitySolution& source, VelocitySolution* destination) {
+bool copy_velocity_solution(const RtklibVelocitySolution& source, const double position_hint_ecef_m[3],
+                            VelocitySolution* destination) {
     copy_diagnostic(source.diagnostic, destination->diagnostic);
     if (!source.valid) {
-        return;
+        return true;
     }
     destination->valid = true;
     destination->status = ReceiverSolutionStatus::kSolComputed;
@@ -151,6 +224,7 @@ void copy_velocity_solution(const RtklibVelocitySolution& source, VelocitySoluti
     }
     destination->receiver_clock_drift_mps = source.receiver_clock_drift_mps;
     destination->used_satellites = source.used_satellites;
+    return fill_local_velocity(position_hint_ecef_m, destination);
 }
 
 } // namespace
@@ -229,7 +303,10 @@ bool solve_receiver_epoch(const RtklibNavStore* receiver_nav, const SimTime& epo
                                           error_message)) {
             return false;
         }
-        copy_velocity_solution(rtklib_velocity, &result.velocity);
+        if (!copy_velocity_solution(rtklib_velocity, position_hint, &result.velocity)) {
+            set_error(error_message, "cannot derive local velocity metadata from receiver position hint");
+            return false;
+        }
     }
 
     *solution = result;

--- a/src/solution/solution_engine.cpp
+++ b/src/solution/solution_engine.cpp
@@ -125,8 +125,8 @@ double covariance_axis_variance(const double covariance[6], const double axis[3]
     const double xy = covariance[3];
     const double yz = covariance[4];
     const double zx = covariance[5];
-    return axis[0] * axis[0] * xx + axis[1] * axis[1] * yy + axis[2] * axis[2] * zz +
-           2.0 * axis[0] * axis[1] * xy + 2.0 * axis[1] * axis[2] * yz + 2.0 * axis[2] * axis[0] * zx;
+    return axis[0] * axis[0] * xx + axis[1] * axis[1] * yy + axis[2] * axis[2] * zz + 2.0 * axis[0] * axis[1] * xy +
+           2.0 * axis[1] * axis[2] * yz + 2.0 * axis[2] * axis[0] * zx;
 }
 
 double nonnegative_std(double variance) {

--- a/src/solution/solution_engine.h
+++ b/src/solution/solution_engine.h
@@ -30,6 +30,9 @@ struct PositionSolution {
     double height_m;
     double receiver_clock_bias_m;
     double covariance_ecef_m2[6];
+    double latitude_std_m;
+    double longitude_std_m;
+    double height_std_m;
     int used_satellites;
     char diagnostic[128];
 };
@@ -39,6 +42,9 @@ struct VelocitySolution {
     ReceiverSolutionStatus status;
     ReceiverSolutionType type;
     double velocity_ecef_mps[3];
+    double horizontal_speed_mps;
+    double track_over_ground_deg;
+    double vertical_speed_mps;
     double receiver_clock_drift_mps;
     int used_satellites;
     char diagnostic[128];

--- a/tests/unit/test_output_writers.cpp
+++ b/tests/unit/test_output_writers.cpp
@@ -21,9 +21,9 @@ int satellite_number(const char* satellite_id) {
     return number;
 }
 
-gnss_sim::MeasurementObservation observation(const char* satellite_id, gnss_sim::SignalId signal_id,
-                                              int glonass_fcn, double pseudorange_m, double adr_cycles,
-                                              double doppler_hz, double cn0_dbhz, double lock_time_sec) {
+gnss_sim::MeasurementObservation observation(const char* satellite_id, gnss_sim::SignalId signal_id, int glonass_fcn,
+                                             double pseudorange_m, double adr_cycles, double doppler_hz,
+                                             double cn0_dbhz, double lock_time_sec) {
     gnss_sim::MeasurementObservation result{};
     result.signal_id = signal_id;
     result.satellite_number = satellite_number(satellite_id);
@@ -41,39 +41,32 @@ gnss_sim::MeasurementObservation observation(const char* satellite_id, gnss_sim:
 }
 
 TEST(NovatelAscii, OfficialBestPosCrcVectorMatchesOem7Documentation) {
-    const std::string payload =
-        "BESTPOSA,COM1,0,78.0,FINESTEERING,1427,325298.000,00000000,6145,2748;"
-        "SOL_COMPUTED,SINGLE,51.11678928753,-114.03886216575,1064.3470,-16.2708,WGS84,"
-        "2.3434,1.3043,4.7300,\"\",0.000,0.000,7,7,0,0,0,06,0,03";
+    const std::string payload = "BESTPOSA,COM1,0,78.0,FINESTEERING,1427,325298.000,00000000,6145,2748;"
+                                "SOL_COMPUTED,SINGLE,51.11678928753,-114.03886216575,1064.3470,-16.2708,WGS84,"
+                                "2.3434,1.3043,4.7300,\"\",0.000,0.000,7,7,0,0,0,06,0,03";
     EXPECT_EQ(gnss_sim::novatel_ascii::crc32(payload), 0x9c9a92bbU);
 }
 
 TEST(NovatelRangeWriter, MultiConstellationRangeAIsByteStable) {
     gnss_sim::MeasurementObservation observations[] = {
-        observation("C19", gnss_sim::SignalId::kBeidouB1C, 0, 22500000.250, -118000000.125000, 25.500, 43.3,
-                    6.750),
-        observation("G03", gnss_sim::SignalId::kGpsL1Ca, 0, 20200000.125, -106151716.123456, -1234.500, 45.2,
-                    12.345),
-        observation("J02", gnss_sim::SignalId::kQzssL5Q, 0, 24000000.000, -100000000.000000, -50.000, 40.0,
-                    5.000),
-        observation("R05", gnss_sim::SignalId::kGlonassG2, -4, 21400000.500, -87654321.250000, 345.125, 39.5,
-                    3.000),
-        observation("E11", gnss_sim::SignalId::kGalileoE5B, 0, 23200000.750, -121234567.750000, 678.250, 42.0,
-                    4.500),
+        observation("C19", gnss_sim::SignalId::kBeidouB1C, 0, 22500000.250, -118000000.125000, 25.500, 43.3, 6.750),
+        observation("G03", gnss_sim::SignalId::kGpsL1Ca, 0, 20200000.125, -106151716.123456, -1234.500, 45.2, 12.345),
+        observation("J02", gnss_sim::SignalId::kQzssL5Q, 0, 24000000.000, -100000000.000000, -50.000, 40.0, 5.000),
+        observation("R05", gnss_sim::SignalId::kGlonassG2, -4, 21400000.500, -87654321.250000, 345.125, 39.5, 3.000),
+        observation("E11", gnss_sim::SignalId::kGalileoE5B, 0, 23200000.750, -121234567.750000, 678.250, 42.0, 4.500),
     };
 
     std::string message;
     std::string error_message;
     ASSERT_TRUE(gnss_sim::format_novatel_rangea(writer_time(), observations, 5, &message, &error_message))
         << error_message;
-    EXPECT_EQ(message,
-              "#RANGEA,COM1,0,0.0,FINE,2300,12345.678,00000000,0,0;5,"
-              "3,0,20200000.125,0.500,-106151716.123456,0.050,-1234.500,45.2,12.345,00001c04,"
-              "42,3,21400000.500,0.500,-87654321.250000,0.050,345.125,39.5,3.000,00211c04,"
-              "11,0,23200000.750,0.500,-121234567.750000,0.050,678.250,42.0,4.500,02231c04,"
-              "194,0,24000000.000,0.500,-100000000.000000,0.050,-50.000,40.0,5.000,01c51c04,"
-              "19,0,22500000.250,0.500,-118000000.125000,0.050,25.500,43.3,6.750,00e41c04"
-              "*6d3dc9c0\r\n");
+    EXPECT_EQ(message, "#RANGEA,COM1,0,0.0,FINE,2300,12345.678,00000000,0,0;5,"
+                       "3,0,20200000.125,0.500,-106151716.123456,0.050,-1234.500,45.2,12.345,00001c04,"
+                       "42,3,21400000.500,0.500,-87654321.250000,0.050,345.125,39.5,3.000,00211c04,"
+                       "11,0,23200000.750,0.500,-121234567.750000,0.050,678.250,42.0,4.500,02231c04,"
+                       "194,0,24000000.000,0.500,-100000000.000000,0.050,-50.000,40.0,5.000,01c51c04,"
+                       "19,0,22500000.250,0.500,-118000000.125000,0.050,25.500,43.3,6.750,00e41c04"
+                       "*6d3dc9c0\r\n");
 }
 
 TEST(NovatelRangeWriter, ReaSignalOffEmitsZeroObservationGoldenRecord) {
@@ -100,10 +93,9 @@ TEST(NovatelSolutionWriter, ValidPsrPosAIsByteStable) {
     std::string message;
     std::string error_message;
     ASSERT_TRUE(gnss_sim::format_novatel_psrposa(solution, 8, &message, &error_message)) << error_message;
-    EXPECT_EQ(message,
-              "#PSRPOSA,COM1,0,0.0,FINE,2300,12345.678,00000000,0,0;"
-              "SOL_COMPUTED,SINGLE,20.00000000000,120.00000000000,100.0000,0.0000,WGS84,"
-              "0.2500,0.3000,0.5000,\"\",0.000,0.000,8,6,0,0,00,00,00,00*491dcb86\r\n");
+    EXPECT_EQ(message, "#PSRPOSA,COM1,0,0.0,FINE,2300,12345.678,00000000,0,0;"
+                       "SOL_COMPUTED,SINGLE,20.00000000000,120.00000000000,100.0000,0.0000,WGS84,"
+                       "0.2500,0.3000,0.5000,\"\",0.000,0.000,8,6,0,0,00,00,00,00*491dcb86\r\n");
 }
 
 TEST(NovatelSolutionWriter, InvalidPsrPosAIsStillScheduledAndByteStable) {
@@ -115,10 +107,9 @@ TEST(NovatelSolutionWriter, InvalidPsrPosAIsStillScheduledAndByteStable) {
     std::string message;
     std::string error_message;
     ASSERT_TRUE(gnss_sim::format_novatel_psrposa(solution, 3, &message, &error_message)) << error_message;
-    EXPECT_EQ(message,
-              "#PSRPOSA,COM1,0,0.0,FINE,2300,12345.678,00000000,0,0;"
-              "INSUFFICIENT_OBS,NONE,0.00000000000,0.00000000000,0.0000,0.0000,WGS84,"
-              "0.0000,0.0000,0.0000,\"\",0.000,0.000,3,0,0,0,00,00,00,00*ac9735bf\r\n");
+    EXPECT_EQ(message, "#PSRPOSA,COM1,0,0.0,FINE,2300,12345.678,00000000,0,0;"
+                       "INSUFFICIENT_OBS,NONE,0.00000000000,0.00000000000,0.0000,0.0000,WGS84,"
+                       "0.0000,0.0000,0.0000,\"\",0.000,0.000,3,0,0,0,00,00,00,00*ac9735bf\r\n");
 }
 
 TEST(NovatelSolutionWriter, VelocityValidityIsIndependentOfCurrentPosition) {
@@ -137,9 +128,8 @@ TEST(NovatelSolutionWriter, VelocityValidityIsIndependentOfCurrentPosition) {
     std::string message;
     std::string error_message;
     ASSERT_TRUE(gnss_sim::format_novatel_psrvela(solution, &message, &error_message)) << error_message;
-    EXPECT_EQ(message,
-              "#PSRVELA,COM1,0,0.0,FINE,2300,12345.678,00000000,0,0;"
-              "SOL_COMPUTED,SINGLE,0.000,0.000,12.3456,89.123456,-0.2500,0*e2198853\r\n");
+    EXPECT_EQ(message, "#PSRVELA,COM1,0,0.0,FINE,2300,12345.678,00000000,0,0;"
+                       "SOL_COMPUTED,SINGLE,0.000,0.000,12.3456,89.123456,-0.2500,0*e2198853\r\n");
 }
 
 TEST(NovatelSolutionWriter, InvalidPsrVelAIsStillScheduledAndByteStable) {
@@ -151,9 +141,8 @@ TEST(NovatelSolutionWriter, InvalidPsrVelAIsStillScheduledAndByteStable) {
     std::string message;
     std::string error_message;
     ASSERT_TRUE(gnss_sim::format_novatel_psrvela(solution, &message, &error_message)) << error_message;
-    EXPECT_EQ(message,
-              "#PSRVELA,COM1,0,0.0,FINE,2300,12345.678,00000000,0,0;"
-              "INSUFFICIENT_OBS,NONE,0.000,0.000,0.0000,0.000000,0.0000,0*e0538e06\r\n");
+    EXPECT_EQ(message, "#PSRVELA,COM1,0,0.0,FINE,2300,12345.678,00000000,0,0;"
+                       "INSUFFICIENT_OBS,NONE,0.000,0.000,0.0000,0.000000,0.0000,0*e0538e06\r\n");
 }
 
 TEST(NovatelAscii, MillisecondRoundingCarriesAcrossGpsWeek) {

--- a/tests/unit/test_output_writers.cpp
+++ b/tests/unit/test_output_writers.cpp
@@ -1,0 +1,166 @@
+#include "gnss/rtklib_adapter.h"
+#include "gnss_sim/sim_time.h"
+#include "model/measurement_model.h"
+#include "output/novatel_ascii.h"
+#include "output/novatel_range_writer.h"
+#include "output/novatel_solution_writer.h"
+#include "solution/solution_engine.h"
+
+#include <gtest/gtest.h>
+#include <string>
+
+namespace {
+
+gnss_sim::SimTime writer_time() {
+    return {2300, 12345678000000LL};
+}
+
+int satellite_number(const char* satellite_id) {
+    int number = 0;
+    EXPECT_TRUE(gnss_sim::rtklib_satellite_id_to_number(satellite_id, &number));
+    return number;
+}
+
+gnss_sim::MeasurementObservation observation(const char* satellite_id, gnss_sim::SignalId signal_id,
+                                              int glonass_fcn, double pseudorange_m, double adr_cycles,
+                                              double doppler_hz, double cn0_dbhz, double lock_time_sec) {
+    gnss_sim::MeasurementObservation result{};
+    result.signal_id = signal_id;
+    result.satellite_number = satellite_number(satellite_id);
+    result.glonass_fcn = glonass_fcn;
+    result.pseudorange_m = pseudorange_m;
+    result.adr_cycles = adr_cycles;
+    result.doppler_hz = doppler_hz;
+    result.cn0_dbhz = cn0_dbhz;
+    result.lock_time_ns = static_cast<std::int64_t>(lock_time_sec * gnss_sim::NANOSECONDS_PER_SECOND + 0.5);
+    result.observation_available = true;
+    result.pseudorange_valid = true;
+    result.doppler_valid = true;
+    result.adr_valid = true;
+    return result;
+}
+
+TEST(NovatelAscii, OfficialBestPosCrcVectorMatchesOem7Documentation) {
+    const std::string payload =
+        "BESTPOSA,COM1,0,78.0,FINESTEERING,1427,325298.000,00000000,6145,2748;"
+        "SOL_COMPUTED,SINGLE,51.11678928753,-114.03886216575,1064.3470,-16.2708,WGS84,"
+        "2.3434,1.3043,4.7300,\"\",0.000,0.000,7,7,0,0,0,06,0,03";
+    EXPECT_EQ(gnss_sim::novatel_ascii::crc32(payload), 0x9c9a92bbU);
+}
+
+TEST(NovatelRangeWriter, MultiConstellationRangeAIsByteStable) {
+    gnss_sim::MeasurementObservation observations[] = {
+        observation("C19", gnss_sim::SignalId::kBeidouB1C, 0, 22500000.250, -118000000.125000, 25.500, 43.3,
+                    6.750),
+        observation("G03", gnss_sim::SignalId::kGpsL1Ca, 0, 20200000.125, -106151716.123456, -1234.500, 45.2,
+                    12.345),
+        observation("J02", gnss_sim::SignalId::kQzssL5Q, 0, 24000000.000, -100000000.000000, -50.000, 40.0,
+                    5.000),
+        observation("R05", gnss_sim::SignalId::kGlonassG2, -4, 21400000.500, -87654321.250000, 345.125, 39.5,
+                    3.000),
+        observation("E11", gnss_sim::SignalId::kGalileoE5B, 0, 23200000.750, -121234567.750000, 678.250, 42.0,
+                    4.500),
+    };
+
+    std::string message;
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::format_novatel_rangea(writer_time(), observations, 5, &message, &error_message))
+        << error_message;
+    EXPECT_EQ(message,
+              "#RANGEA,COM1,0,0.0,FINE,2300,12345.678,00000000,0,0;5,"
+              "3,0,20200000.125,0.500,-106151716.123456,0.050,-1234.500,45.2,12.345,00001c04,"
+              "42,3,21400000.500,0.500,-87654321.250000,0.050,345.125,39.5,3.000,00211c04,"
+              "11,0,23200000.750,0.500,-121234567.750000,0.050,678.250,42.0,4.500,02231c04,"
+              "194,0,24000000.000,0.500,-100000000.000000,0.050,-50.000,40.0,5.000,01c51c04,"
+              "19,0,22500000.250,0.500,-118000000.125000,0.050,25.500,43.3,6.750,00e41c04"
+              "*6d3dc9c0\r\n");
+}
+
+TEST(NovatelRangeWriter, ReaSignalOffEmitsZeroObservationGoldenRecord) {
+    std::string message;
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::format_novatel_rangea(writer_time(), nullptr, 0, &message, &error_message)) << error_message;
+    EXPECT_EQ(message, "#RANGEA,COM1,0,0.0,FINE,2300,12345.678,00000000,0,0;0*a633981e\r\n");
+}
+
+TEST(NovatelSolutionWriter, ValidPsrPosAIsByteStable) {
+    gnss_sim::SolutionEpoch solution{};
+    solution.time = writer_time();
+    solution.position.valid = true;
+    solution.position.status = gnss_sim::ReceiverSolutionStatus::kSolComputed;
+    solution.position.type = gnss_sim::ReceiverSolutionType::kSingle;
+    solution.position.latitude_deg = 20.0;
+    solution.position.longitude_deg = 120.0;
+    solution.position.height_m = 100.0;
+    solution.position.latitude_std_m = 0.25;
+    solution.position.longitude_std_m = 0.30;
+    solution.position.height_std_m = 0.50;
+    solution.position.used_satellites = 6;
+
+    std::string message;
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::format_novatel_psrposa(solution, 8, &message, &error_message)) << error_message;
+    EXPECT_EQ(message,
+              "#PSRPOSA,COM1,0,0.0,FINE,2300,12345.678,00000000,0,0;"
+              "SOL_COMPUTED,SINGLE,20.00000000000,120.00000000000,100.0000,0.0000,WGS84,"
+              "0.2500,0.3000,0.5000,\"\",0.000,0.000,8,6,0,0,00,00,00,00*491dcb86\r\n");
+}
+
+TEST(NovatelSolutionWriter, InvalidPsrPosAIsStillScheduledAndByteStable) {
+    gnss_sim::SolutionEpoch solution{};
+    solution.time = writer_time();
+    solution.position.status = gnss_sim::ReceiverSolutionStatus::kInsufficientObs;
+    solution.position.type = gnss_sim::ReceiverSolutionType::kNone;
+
+    std::string message;
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::format_novatel_psrposa(solution, 3, &message, &error_message)) << error_message;
+    EXPECT_EQ(message,
+              "#PSRPOSA,COM1,0,0.0,FINE,2300,12345.678,00000000,0,0;"
+              "INSUFFICIENT_OBS,NONE,0.00000000000,0.00000000000,0.0000,0.0000,WGS84,"
+              "0.0000,0.0000,0.0000,\"\",0.000,0.000,3,0,0,0,00,00,00,00*ac9735bf\r\n");
+}
+
+TEST(NovatelSolutionWriter, VelocityValidityIsIndependentOfCurrentPosition) {
+    gnss_sim::SolutionEpoch solution{};
+    solution.time = writer_time();
+    solution.position.status = gnss_sim::ReceiverSolutionStatus::kInsufficientObs;
+    solution.position.type = gnss_sim::ReceiverSolutionType::kNone;
+    solution.velocity.valid = true;
+    solution.velocity.status = gnss_sim::ReceiverSolutionStatus::kSolComputed;
+    solution.velocity.type = gnss_sim::ReceiverSolutionType::kSingle;
+    solution.velocity.horizontal_speed_mps = 12.3456;
+    solution.velocity.track_over_ground_deg = 89.123456;
+    solution.velocity.vertical_speed_mps = -0.25;
+    solution.velocity.used_satellites = 7;
+
+    std::string message;
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::format_novatel_psrvela(solution, &message, &error_message)) << error_message;
+    EXPECT_EQ(message,
+              "#PSRVELA,COM1,0,0.0,FINE,2300,12345.678,00000000,0,0;"
+              "SOL_COMPUTED,SINGLE,0.000,0.000,12.3456,89.123456,-0.2500,0*e2198853\r\n");
+}
+
+TEST(NovatelSolutionWriter, InvalidPsrVelAIsStillScheduledAndByteStable) {
+    gnss_sim::SolutionEpoch solution{};
+    solution.time = writer_time();
+    solution.velocity.status = gnss_sim::ReceiverSolutionStatus::kInsufficientObs;
+    solution.velocity.type = gnss_sim::ReceiverSolutionType::kNone;
+
+    std::string message;
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::format_novatel_psrvela(solution, &message, &error_message)) << error_message;
+    EXPECT_EQ(message,
+              "#PSRVELA,COM1,0,0.0,FINE,2300,12345.678,00000000,0,0;"
+              "INSUFFICIENT_OBS,NONE,0.000,0.000,0.0000,0.000000,0.0000,0*e0538e06\r\n");
+}
+
+TEST(NovatelAscii, MillisecondRoundingCarriesAcrossGpsWeek) {
+    const gnss_sim::SimTime time{2300, gnss_sim::GPS_WEEK_NANOSECONDS - 400000LL};
+    std::string message;
+    ASSERT_TRUE(gnss_sim::novatel_ascii::frame("RANGEA", time, "0", &message));
+    EXPECT_NE(message.find("FINE,2301,0.000,"), std::string::npos);
+}
+
+} // namespace


### PR DESCRIPTION
Closes #13.

## Summary
- implement deterministic NovAtel OEM7 ASCII framing and CRC-32 for RANGEA, PSRPOSA, and PSRVELA;
- serialize RANGE observations from existing `MeasurementObservation` state only, using the central signal-definition table for OEM7 system/signal bits;
- preserve GLONASS frequency channel, lock/valid bits, C/N0, Doppler, ADR, pseudorange, and deterministic observation ordering;
- keep REA signal-off RANGEA scheduled with observation count zero;
- serialize independent position/velocity validity, including `INSUFFICIENT_OBS / NONE` and `SOL_COMPUTED / SINGLE`;
- precompute OEM7-facing local position standard deviations and local velocity metadata in the solution layer so writers do not recompute solution semantics;
- add field-by-field V1 source mapping in `docs/OEM7_WRITER_FIELDS.md`;
- add byte-level golden records for valid/invalid RANGEA, PSRPOSA, and PSRVELA, plus the OEM7 documented CRC reference vector and GPS-week millisecond carry.

## Implementation Notes
V1 RANGE standard-deviation fields are deterministic nominal metadata only: pseudorange sigma is `0.500 m` and ADR sigma is `0.050 cycles`, matching the pinned RTKLIB RANGE converter defaults. These values are serialized but do not inject measurement noise or phase noise.

Common OEM7 header values are deterministic (`COM1`, sequence 0, idle 0.0, `FINE`, receiver status 0, reserved 0, software version 0). The NovAtel ASCII CRC uses polynomial `0xEDB88320` with initial value zero over the payload between `#` and `*`.

PSRPOS undulation is `0.0000` because V1 has no geoid model; the emitted height is therefore the WGS84 ellipsoidal solution height. PSRVEL latency and differential age are fixed to zero because V1 does not model output-loop latency or differential corrections. Reserved/status signal masks are initialized to zero.

Writers never call the satellite engine, navigation correction model, tracking state machine, or solver. RTKLIB satellite-number-to-ID conversion is isolated behind the adapter boundary. Full format + Ubuntu/GCC + Windows/MSVC CI is required before merge.