### PR TITLE
Implement NovAtel OEM7 and Unicore N4 navigation writers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,10 +74,12 @@ add_library(gnss_sim_core STATIC
     src/core/sim_time.cpp
     src/core/simulator.cpp
     src/gnss/nav_message_scheduler.cpp
+    src/gnss/nav_output_metadata.cpp
     src/gnss/navigation_state.cpp
     src/gnss/rtklib_adapter.cpp
     src/gnss/rtklib_atmosphere_adapter.cpp
     src/gnss/rtklib_bias_adapter.cpp
+    src/gnss/rtklib_nav_output_adapter.cpp
     src/gnss/rtklib_output_adapter.cpp
     src/gnss/rtklib_solution_adapter.cpp
     src/gnss/satellite_engine.cpp
@@ -87,8 +89,10 @@ add_library(gnss_sim_core STATIC
     src/model/measurement_model.cpp
     src/model/receiver_truth.cpp
     src/model/signal_tracking.cpp
+    src/output/novatel_nav_writer.cpp
     src/output/novatel_range_writer.cpp
     src/output/novatel_solution_writer.cpp
+    src/output/unicore_nav_writer.cpp
     src/solution/solution_engine.cpp
 )
 add_library(gnss_sim::core ALIAS gnss_sim_core)
@@ -126,6 +130,7 @@ if(BUILD_TESTING)
         tests/unit/test_measurement_model.cpp
         tests/unit/test_nav_message_scheduler.cpp
         tests/unit/test_nav_message_scheduler_gal_bds.cpp
+        tests/unit/test_nav_output_writers.cpp
         tests/unit/test_navigation_state.cpp
         tests/unit/test_output_writers.cpp
         tests/unit/test_receiver_truth.cpp

--- a/docs/NAV_WRITER_FIELDS.md
+++ b/docs/NAV_WRITER_FIELDS.md
@@ -1,0 +1,45 @@
+# Navigation Writer Field Provenance
+
+This document records the V1 source of navigation-log fields. The writers are serialization layers: they consume normalized `NavOutputRecord` values projected from Receiver NAV and do not parse RINEX or recompute satellite state.
+
+## Common source path
+
+```text
+RINEX NAV -> pinned RTKLIB parser -> Receiver NAV -> rtklib_nav_output_adapter
+          -> NavOutputRecord -> NovAtel/Unicore ASCII writer
+```
+
+`NavigationUpdateEvent::receiver_record_index` identifies the record copied into Receiver NAV by a COLD/runtime update. Duplicate truth-record delivery produces no new event and therefore no duplicate NAV log.
+
+## Keplerian ephemeris
+
+Direct RTKLIB/Receiver-NAV fields include PRN, message family, IODE/IODC, health, accuracy, Toe/Toc/transmit time, orbit parameters, harmonic corrections, clock polynomial, TGD/BGD/ISC and fit interval. `sqrt(A)` and corrected mean motion are deterministic derived metadata computed in `nav_output_metadata.cpp` before serialization.
+
+For Galileo, the pinned RTKLIB parser preserves the RINEX SV-health word with the documented bit packing: E1B DVS/HS, E5a DVS/HS and E5b DVS/HS. The normalized adapter decodes these bits before `GALEPHEMERISA`/`GALEPHA` formatting. Separate F/NAV and I/NAV clock fields are populated only from Receiver-NAV records for the same satellite; the writer does not search Truth NAV.
+
+BeiDou legacy D1/D2 maps to `BD2EPHEMA` and `BDSEPHA`. RINEX 4 B-CNAV1/2/3 maps to Unicore `BD3EPHA`; there is no frozen NovAtel OEM7 modern-BDS ephemeris record in V1, so the NovAtel writer reports that normalized record as unsupported instead of inventing a record family.
+
+`IRNSSEPHA` consumes a normalized NavIC ephemeris when present in Receiver NAV. This output capability does not modify the frozen 21-signal V1 observation table and does not enable NavIC RANGE generation.
+
+## GLONASS ephemeris
+
+Position, velocity, acceleration, `tau_n`, `gamma_n`, `delta_tau_n`, frequency channel, health, age and issue come directly from Receiver NAV `geph_t` through the adapter. Slot numbering, OEM/Unicore frequency offset representation, GPS-to-GLONASS time offset, GLONASS four-year-cycle day number and frame seconds-of-day are deterministic protocol metadata computed before the writer.
+
+## Ionosphere/UTC
+
+RINEX 4 explicit ION records are projected from RTKLIB `ion_t`. RINEX 2/3 header ionosphere arrays and UTC/leap-second metadata are exposed as deterministic normalized metadata records when no explicit record of the same system exists.
+
+- GPS legacy parameters -> NovAtel `IONUTCA`, Unicore `GPSIONA`.
+- BeiDou legacy parameters -> NovAtel `BD2IONUTCA`, Unicore `BDSIONA`.
+- Galileo NeQuick coefficients -> Unicore `GALIONA`.
+- BeiDou-3 nine-parameter explicit ionosphere data -> Unicore `BD3IONA`.
+
+QZSS ionosphere metadata is retained by Receiver NAV but is not emitted by the V1 Unicore set because no QZSS ION family is frozen in `NAV_RECORDS.md`.
+
+## Headers and CRC
+
+NovAtel NAV records reuse the deterministic OEM7 ASCII framing introduced with the observation writers. Unicore N4 uses deterministic V1 header metadata (`GPS/FINE`, version 18, status/reserved zero) and the same documented reflected CRC-32 polynomial `0xEDB88320` with initial value zero. Header metadata is protocol/fallback metadata only and is not used to alter Receiver NAV contents.
+
+## Unsupported/missing fields
+
+A writer must not fabricate a new navigation parser. If a required modern RINEX field is not retained by the pinned RTKLIB data model, the normalized adapter must be extended (and, if necessary, the pinned RTKLIB parser/structs must be extended) before that field is serialized. Reserved protocol fields may use deterministic zero values only where the protocol defines them as reserved/not modeled; health, orbit, clock, TGD/BGD/ISC and acquisition state must come from Receiver NAV.

--- a/src/gnss/nav_output_metadata.cpp
+++ b/src/gnss/nav_output_metadata.cpp
@@ -60,7 +60,8 @@ bool finalize_nav_output_record_metadata(NavOutputRecord* record) {
             return false;
         }
         eph.sqrt_semi_major_axis_sqrt_m = std::sqrt(eph.semi_major_axis_m);
-        const double mu = eph.system == NavOutputSystem::kGps || eph.system == NavOutputSystem::kQzss ? kGpsMu : kOtherMu;
+        const double mu =
+            eph.system == NavOutputSystem::kGps || eph.system == NavOutputSystem::kQzss ? kGpsMu : kOtherMu;
         eph.corrected_mean_motion_radps =
             std::sqrt(mu / (eph.semi_major_axis_m * eph.semi_major_axis_m * eph.semi_major_axis_m)) +
             eph.delta_mean_motion_radps;

--- a/src/gnss/nav_output_metadata.cpp
+++ b/src/gnss/nav_output_metadata.cpp
@@ -1,0 +1,72 @@
+#include "gnss/nav_output_record.h"
+
+extern "C" {
+#include <rtklib.h>
+}
+
+#include <cmath>
+
+namespace gnss_sim {
+namespace {
+
+constexpr double kGpsMu = 3.986005e14;
+constexpr double kOtherMu = 3.986004418e14;
+
+int calendar_day_in_glonass_cycle(gtime_t gpst) {
+    const gtime_t utc = gpst2utc(gpst);
+    double epoch[6]{};
+    time2epoch(utc, epoch);
+    const int year = static_cast<int>(epoch[0]);
+    const int cycle_start_year = year - ((year - 1996) % 4 + 4) % 4;
+    double start_epoch[6] = {static_cast<double>(cycle_start_year), 1.0, 1.0, 0.0, 0.0, 0.0};
+    return static_cast<int>(std::floor(timediff(utc, epoch2time(start_epoch)) / 86400.0)) + 1;
+}
+
+double glonass_day_seconds(gtime_t gpst) {
+    double epoch[6]{};
+    time2epoch(gpst2utc(gpst), epoch);
+    double seconds = epoch[3] * 3600.0 + epoch[4] * 60.0 + epoch[5] + 10800.0;
+    seconds = std::fmod(seconds, 86400.0);
+    if (seconds < 0.0) {
+        seconds += 86400.0;
+    }
+    return seconds;
+}
+
+} // namespace
+
+bool finalize_nav_output_record_metadata(NavOutputRecord* record) {
+    if (record == nullptr) {
+        return false;
+    }
+    if (record->kind == RtklibNavRecordKind::kEphemeris) {
+        KeplerianNavOutputData& eph = record->ephemeris;
+        if (!std::isfinite(eph.semi_major_axis_m) || eph.semi_major_axis_m <= 0.0) {
+            return false;
+        }
+        const double mu = eph.system == NavOutputSystem::kGps || eph.system == NavOutputSystem::kQzss ? kGpsMu : kOtherMu;
+        eph.corrected_mean_motion_radps =
+            std::sqrt(mu / (eph.semi_major_axis_m * eph.semi_major_axis_m * eph.semi_major_axis_m)) +
+            eph.delta_mean_motion_radps;
+        return std::isfinite(eph.corrected_mean_motion_radps);
+    }
+    if (record->kind == RtklibNavRecordKind::kGlonassEphemeris) {
+        GlonassNavOutputData& glo = record->glonass;
+        if (glo.prn <= 0 || glo.toe_week < 0 || glo.frame_week < 0 || !std::isfinite(glo.toe_sow_sec) ||
+            !std::isfinite(glo.frame_sow_sec)) {
+            return false;
+        }
+        glo.slot_offset = glo.prn + 37;
+        glo.frequency_offset = glo.frequency_channel + 7;
+        const gtime_t toe = gpst2time(glo.toe_week, glo.toe_sow_sec);
+        const gtime_t frame = gpst2time(glo.frame_week, glo.frame_sow_sec);
+        const int leap_seconds = static_cast<int>(std::llround(timediff(toe, gpst2utc(toe))));
+        glo.gps_glonass_time_offset_sec = 10800 - leap_seconds;
+        glo.calendar_day_number = calendar_day_in_glonass_cycle(toe);
+        glo.frame_time_glonass_day_sec = glonass_day_seconds(frame);
+        return true;
+    }
+    return record->kind == RtklibNavRecordKind::kIonosphere;
+}
+
+} // namespace gnss_sim

--- a/src/gnss/nav_output_metadata.cpp
+++ b/src/gnss/nav_output_metadata.cpp
@@ -33,6 +33,21 @@ double glonass_day_seconds(gtime_t gpst) {
     return seconds;
 }
 
+void decode_galileo_health(KeplerianNavOutputData* eph) {
+    if (eph->system != NavOutputSystem::kGalileo) {
+        return;
+    }
+    // Pinned RTKLIB stores the RINEX Galileo SV health word as:
+    // bit 0 E1B DVS, bits 1-2 E1B HS, bit 3 E5a DVS, bits 4-5 E5a HS,
+    // bit 6 E5b DVS, bits 7-8 E5b HS.
+    eph->galileo_e1b_dvs = eph->svh & 0x1;
+    eph->galileo_e1b_health = (eph->svh >> 1) & 0x3;
+    eph->galileo_e5a_dvs = (eph->svh >> 3) & 0x1;
+    eph->galileo_e5a_health = (eph->svh >> 4) & 0x3;
+    eph->galileo_e5b_dvs = (eph->svh >> 6) & 0x1;
+    eph->galileo_e5b_health = (eph->svh >> 7) & 0x3;
+}
+
 } // namespace
 
 bool finalize_nav_output_record_metadata(NavOutputRecord* record) {
@@ -44,11 +59,13 @@ bool finalize_nav_output_record_metadata(NavOutputRecord* record) {
         if (!std::isfinite(eph.semi_major_axis_m) || eph.semi_major_axis_m <= 0.0) {
             return false;
         }
+        eph.sqrt_semi_major_axis_sqrt_m = std::sqrt(eph.semi_major_axis_m);
         const double mu = eph.system == NavOutputSystem::kGps || eph.system == NavOutputSystem::kQzss ? kGpsMu : kOtherMu;
         eph.corrected_mean_motion_radps =
             std::sqrt(mu / (eph.semi_major_axis_m * eph.semi_major_axis_m * eph.semi_major_axis_m)) +
             eph.delta_mean_motion_radps;
-        return std::isfinite(eph.corrected_mean_motion_radps);
+        decode_galileo_health(&eph);
+        return std::isfinite(eph.sqrt_semi_major_axis_sqrt_m) && std::isfinite(eph.corrected_mean_motion_radps);
     }
     if (record->kind == RtklibNavRecordKind::kGlonassEphemeris) {
         GlonassNavOutputData& glo = record->glonass;

--- a/src/gnss/nav_output_record.h
+++ b/src/gnss/nav_output_record.h
@@ -1,0 +1,117 @@
+#ifndef GNSS_SIM_SRC_GNSS_NAV_OUTPUT_RECORD_H_
+#define GNSS_SIM_SRC_GNSS_NAV_OUTPUT_RECORD_H_
+
+#include "gnss/rtklib_adapter.h"
+
+#include <string>
+
+namespace gnss_sim {
+
+enum class NavOutputSystem {
+    kUnknown,
+    kGps,
+    kGlonass,
+    kGalileo,
+    kBeidou,
+    kQzss,
+    kNavic,
+};
+
+struct KeplerianNavOutputData {
+    NavOutputSystem system;
+    RtklibBroadcastMessageFamily message_family;
+    int satellite_number;
+    int prn;
+    int message_type;
+    int iode;
+    int iodc;
+    double sva;
+    int svh;
+    int code;
+    int flag;
+    int toe_week;
+    int toc_week;
+    int transmit_week;
+    double toe_sow_sec;
+    double toc_sow_sec;
+    double transmit_sow_sec;
+    double semi_major_axis_m;
+    double eccentricity;
+    double inclination_rad;
+    double omega0_rad;
+    double argument_of_perigee_rad;
+    double mean_anomaly_rad;
+    double delta_mean_motion_radps;
+    double omega_dot_radps;
+    double inclination_dot_radps;
+    double crc_m;
+    double crs_m;
+    double cuc_rad;
+    double cus_rad;
+    double cic_rad;
+    double cis_rad;
+    double clock_bias_sec;
+    double clock_drift_sec_per_sec;
+    double clock_drift_rate_sec_per_sec2;
+    double tgd_sec[4];
+    double isc_sec[6];
+    double fit_hours;
+    bool galileo_fnav_received;
+    bool galileo_inav_received;
+    double galileo_fnav_toc_sow_sec;
+    double galileo_fnav_clock[3];
+    double galileo_inav_toc_sow_sec;
+    double galileo_inav_clock[3];
+};
+
+struct GlonassNavOutputData {
+    int satellite_number;
+    int prn;
+    int iode;
+    int frequency_channel;
+    int svh;
+    int sva;
+    int age_days;
+    int flags;
+    int toe_week;
+    int frame_week;
+    double toe_sow_sec;
+    double frame_sow_sec;
+    double position_ecef_m[3];
+    double velocity_ecef_mps[3];
+    double acceleration_ecef_mps2[3];
+    double clock_bias_sec;
+    double relative_frequency_bias;
+    double differential_delay_sec;
+};
+
+struct IonosphereNavOutputData {
+    NavOutputSystem system;
+    int prn;
+    int message_type;
+    int transmit_week;
+    double transmit_sow_sec;
+    double coefficients[9];
+    int coefficient_count;
+    double region;
+    double utc[4];
+    int leap_seconds;
+    bool legacy_metadata;
+};
+
+struct NavOutputRecord {
+    RtklibNavRecordKind kind;
+    KeplerianNavOutputData ephemeris;
+    GlonassNavOutputData glonass;
+    IonosphereNavOutputData ionosphere;
+};
+
+int rtklib_nav_output_record_count(const RtklibNavStore* store);
+bool rtklib_nav_output_record(const RtklibNavStore* store, int output_record_index, NavOutputRecord* record,
+                              std::string* error_message);
+
+const char* nav_output_system_name(NavOutputSystem system);
+
+} // namespace gnss_sim
+
+#endif // GNSS_SIM_SRC_GNSS_NAV_OUTPUT_RECORD_H_

--- a/src/gnss/nav_output_record.h
+++ b/src/gnss/nav_output_record.h
@@ -42,6 +42,7 @@ struct KeplerianNavOutputData {
     double argument_of_perigee_rad;
     double mean_anomaly_rad;
     double delta_mean_motion_radps;
+    double corrected_mean_motion_radps;
     double omega_dot_radps;
     double inclination_dot_radps;
     double crc_m;
@@ -67,16 +68,21 @@ struct KeplerianNavOutputData {
 struct GlonassNavOutputData {
     int satellite_number;
     int prn;
-    int iode;
+    int slot_offset;
     int frequency_channel;
+    int frequency_offset;
+    int iode;
     int svh;
     int sva;
     int age_days;
     int flags;
     int toe_week;
     int frame_week;
+    int gps_glonass_time_offset_sec;
+    int calendar_day_number;
     double toe_sow_sec;
     double frame_sow_sec;
+    double frame_time_glonass_day_sec;
     double position_ecef_m[3];
     double velocity_ecef_mps[3];
     double acceleration_ecef_mps2[3];

--- a/src/gnss/nav_output_record.h
+++ b/src/gnss/nav_output_record.h
@@ -115,6 +115,7 @@ struct NavOutputRecord {
 int rtklib_nav_output_record_count(const RtklibNavStore* store);
 bool rtklib_nav_output_record(const RtklibNavStore* store, int output_record_index, NavOutputRecord* record,
                               std::string* error_message);
+bool finalize_nav_output_record_metadata(NavOutputRecord* record);
 
 const char* nav_output_system_name(NavOutputSystem system);
 

--- a/src/gnss/nav_output_record.h
+++ b/src/gnss/nav_output_record.h
@@ -36,6 +36,7 @@ struct KeplerianNavOutputData {
     double toc_sow_sec;
     double transmit_sow_sec;
     double semi_major_axis_m;
+    double sqrt_semi_major_axis_sqrt_m;
     double eccentricity;
     double inclination_rad;
     double omega0_rad;
@@ -59,6 +60,12 @@ struct KeplerianNavOutputData {
     double fit_hours;
     bool galileo_fnav_received;
     bool galileo_inav_received;
+    int galileo_e1b_dvs;
+    int galileo_e1b_health;
+    int galileo_e5a_dvs;
+    int galileo_e5a_health;
+    int galileo_e5b_dvs;
+    int galileo_e5b_health;
     double galileo_fnav_toc_sow_sec;
     double galileo_fnav_clock[3];
     double galileo_inav_toc_sow_sec;

--- a/src/gnss/navigation_state.cpp
+++ b/src/gnss/navigation_state.cpp
@@ -161,6 +161,7 @@ bool apply_truth_navigation_record(NavigationState* state, int truth_record_inde
     if (event != nullptr) {
         event->availability_time = availability_time;
         event->truth_record_index = truth_record_index;
+        event->receiver_record_index = rtklib_nav_record_count(state->receiver_nav) - 1;
         event->kind = info.kind;
         event->satellite_number = info.satellite_number;
         event->system = info.system;

--- a/src/gnss/navigation_state.h
+++ b/src/gnss/navigation_state.h
@@ -14,6 +14,7 @@ struct NavigationState;
 struct NavigationUpdateEvent {
     SimTime availability_time;
     int truth_record_index;
+    int receiver_record_index;
     RtklibNavRecordKind kind;
     int satellite_number;
     int system;

--- a/src/gnss/rtklib_nav_output_adapter.cpp
+++ b/src/gnss/rtklib_nav_output_adapter.cpp
@@ -1,0 +1,368 @@
+#include "gnss/nav_output_record.h"
+
+extern "C" {
+#include <rtklib.h>
+}
+
+#include <cmath>
+#include <cstring>
+
+namespace gnss_sim {
+
+struct RtklibNavStore {
+    nav_t nav;
+};
+
+namespace {
+
+void set_error(std::string* error_message, const char* message) {
+    if (error_message != nullptr) {
+        *error_message = message;
+    }
+}
+
+NavOutputSystem output_system(int system) {
+    switch (system) {
+        case SYS_GPS:
+            return NavOutputSystem::kGps;
+        case SYS_GLO:
+            return NavOutputSystem::kGlonass;
+        case SYS_GAL:
+            return NavOutputSystem::kGalileo;
+        case SYS_CMP:
+            return NavOutputSystem::kBeidou;
+        case SYS_QZS:
+            return NavOutputSystem::kQzss;
+        case SYS_IRN:
+            return NavOutputSystem::kNavic;
+        default:
+            return NavOutputSystem::kUnknown;
+    }
+}
+
+RtklibBroadcastMessageFamily message_family(int system, int message_type) {
+    if (system == SYS_GLO) {
+        return RtklibBroadcastMessageFamily::kGlonassFdma;
+    }
+    switch (message_type) {
+        case NAV_CNAV:
+            return RtklibBroadcastMessageFamily::kCnav;
+        case NAV_CNV1:
+            return RtklibBroadcastMessageFamily::kBeidouBcnav1;
+        case NAV_CNV2:
+            if (system == SYS_CMP) {
+                return RtklibBroadcastMessageFamily::kBeidouBcnav2;
+            }
+            return RtklibBroadcastMessageFamily::kCnav2;
+        case NAV_CNV3:
+            return RtklibBroadcastMessageFamily::kBeidouBcnav3;
+        case NAV_INAV:
+            return RtklibBroadcastMessageFamily::kGalileoInav;
+        case NAV_FNAV:
+            return RtklibBroadcastMessageFamily::kGalileoFnav;
+        default:
+            return RtklibBroadcastMessageFamily::kLegacy;
+    }
+}
+
+bool time_week_sow(gtime_t time, int* week, double* sow_sec) {
+    if (week == nullptr || sow_sec == nullptr || (time.time == 0 && time.sec == 0.0)) {
+        return false;
+    }
+    *sow_sec = time2gpst(time, week);
+    return *week >= 0 && std::isfinite(*sow_sec);
+}
+
+bool array_has_nonzero(const double* values, int count) {
+    for (int index = 0; index < count; ++index) {
+        if (std::isfinite(values[index]) && values[index] != 0.0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool has_explicit_ion(const nav_t& nav, int system) {
+    for (int index = 0; index < nav.nion; ++index) {
+        if (nav.ion[index].hdr.sys == system) {
+            return true;
+        }
+    }
+    return false;
+}
+
+int legacy_ion_systems(const nav_t& nav, int systems[4]) {
+    int count = 0;
+    if (!has_explicit_ion(nav, SYS_GPS) && array_has_nonzero(nav.ion_gps, 8)) {
+        systems[count++] = SYS_GPS;
+    }
+    if (!has_explicit_ion(nav, SYS_QZS) && array_has_nonzero(nav.ion_qzs, 8)) {
+        systems[count++] = SYS_QZS;
+    }
+    if (!has_explicit_ion(nav, SYS_GAL) && array_has_nonzero(nav.ion_gal, 4)) {
+        systems[count++] = SYS_GAL;
+    }
+    if (!has_explicit_ion(nav, SYS_CMP) && array_has_nonzero(nav.ion_cmp, 8)) {
+        systems[count++] = SYS_CMP;
+    }
+    return count;
+}
+
+void fill_galileo_companion_clocks(const nav_t& nav, int satellite_number, KeplerianNavOutputData* output) {
+    for (int index = 0; index < nav.n; ++index) {
+        const eph_t& candidate = nav.eph[index];
+        if (candidate.sat != satellite_number) {
+            continue;
+        }
+        const RtklibBroadcastMessageFamily family = message_family(SYS_GAL, candidate.hdr.msg_type);
+        int toc_week = 0;
+        double toc_sow_sec = 0.0;
+        if (!time_week_sow(candidate.toc, &toc_week, &toc_sow_sec)) {
+            continue;
+        }
+        if (family == RtklibBroadcastMessageFamily::kGalileoFnav) {
+            output->galileo_fnav_received = true;
+            output->galileo_fnav_toc_sow_sec = toc_sow_sec;
+            output->galileo_fnav_clock[0] = candidate.f0;
+            output->galileo_fnav_clock[1] = candidate.f1;
+            output->galileo_fnav_clock[2] = candidate.f2;
+        } else if (family == RtklibBroadcastMessageFamily::kGalileoInav) {
+            output->galileo_inav_received = true;
+            output->galileo_inav_toc_sow_sec = toc_sow_sec;
+            output->galileo_inav_clock[0] = candidate.f0;
+            output->galileo_inav_clock[1] = candidate.f1;
+            output->galileo_inav_clock[2] = candidate.f2;
+        }
+    }
+}
+
+bool fill_ephemeris(const nav_t& nav, int index, NavOutputRecord* record) {
+    const eph_t& eph = nav.eph[index];
+    int prn = 0;
+    const int system = satsys(eph.sat, &prn);
+    KeplerianNavOutputData output{};
+    output.system = output_system(system);
+    output.message_family = message_family(system, eph.hdr.msg_type);
+    output.satellite_number = eph.sat;
+    output.prn = prn;
+    output.message_type = eph.hdr.msg_type;
+    output.iode = eph.iode;
+    output.iodc = eph.iodc;
+    output.sva = static_cast<double>(eph.sva);
+    output.svh = eph.svh;
+    output.code = eph.code;
+    output.flag = eph.flag;
+    if (!time_week_sow(eph.toe, &output.toe_week, &output.toe_sow_sec) ||
+        !time_week_sow(eph.toc, &output.toc_week, &output.toc_sow_sec) ||
+        !time_week_sow(eph.ttr, &output.transmit_week, &output.transmit_sow_sec)) {
+        return false;
+    }
+    output.semi_major_axis_m = eph.A;
+    output.eccentricity = eph.e;
+    output.inclination_rad = eph.i0;
+    output.omega0_rad = eph.OMG0;
+    output.argument_of_perigee_rad = eph.omg;
+    output.mean_anomaly_rad = eph.M0;
+    output.delta_mean_motion_radps = eph.deln;
+    output.omega_dot_radps = eph.OMGd;
+    output.inclination_dot_radps = eph.idot;
+    output.crc_m = eph.crc;
+    output.crs_m = eph.crs;
+    output.cuc_rad = eph.cuc;
+    output.cus_rad = eph.cus;
+    output.cic_rad = eph.cic;
+    output.cis_rad = eph.cis;
+    output.clock_bias_sec = eph.f0;
+    output.clock_drift_sec_per_sec = eph.f1;
+    output.clock_drift_rate_sec_per_sec2 = eph.f2;
+    std::memcpy(output.tgd_sec, eph.tgd, sizeof(output.tgd_sec));
+    std::memcpy(output.isc_sec, eph.isc, sizeof(output.isc_sec));
+    output.fit_hours = eph.fit;
+    if (system == SYS_GAL) {
+        fill_galileo_companion_clocks(nav, eph.sat, &output);
+        if (!output.galileo_fnav_received && output.message_family == RtklibBroadcastMessageFamily::kGalileoFnav) {
+            output.galileo_fnav_received = true;
+            output.galileo_fnav_toc_sow_sec = output.toc_sow_sec;
+            output.galileo_fnav_clock[0] = eph.f0;
+            output.galileo_fnav_clock[1] = eph.f1;
+            output.galileo_fnav_clock[2] = eph.f2;
+        }
+        if (!output.galileo_inav_received && output.message_family == RtklibBroadcastMessageFamily::kGalileoInav) {
+            output.galileo_inav_received = true;
+            output.galileo_inav_toc_sow_sec = output.toc_sow_sec;
+            output.galileo_inav_clock[0] = eph.f0;
+            output.galileo_inav_clock[1] = eph.f1;
+            output.galileo_inav_clock[2] = eph.f2;
+        }
+    }
+    record->kind = RtklibNavRecordKind::kEphemeris;
+    record->ephemeris = output;
+    return output.system != NavOutputSystem::kUnknown;
+}
+
+int glonass_day_number(gtime_t gpst) {
+    double epoch[6]{};
+    time2epoch(gpst2utc(gpst), epoch);
+    const int year = static_cast<int>(epoch[0]);
+    int cycle_start_year = year - ((year - 1996) % 4 + 4) % 4;
+    double start_epoch[6] = {static_cast<double>(cycle_start_year), 1.0, 1.0, 0.0, 0.0, 0.0};
+    const double days = timediff(gpst2utc(gpst), epoch2time(start_epoch)) / 86400.0;
+    return static_cast<int>(std::floor(days)) + 1;
+}
+
+bool fill_glonass(const nav_t& nav, int index, NavOutputRecord* record) {
+    const geph_t& geph = nav.geph[index];
+    int prn = 0;
+    if (satsys(geph.sat, &prn) != SYS_GLO) {
+        return false;
+    }
+    GlonassNavOutputData output{};
+    output.satellite_number = geph.sat;
+    output.prn = prn;
+    output.iode = geph.iode;
+    output.frequency_channel = geph.frq;
+    output.svh = geph.svh;
+    output.sva = geph.sva;
+    output.age_days = geph.age;
+    output.flags = geph.flag;
+    if (!time_week_sow(geph.toe, &output.toe_week, &output.toe_sow_sec) ||
+        !time_week_sow(geph.tof, &output.frame_week, &output.frame_sow_sec)) {
+        return false;
+    }
+    std::memcpy(output.position_ecef_m, geph.pos, sizeof(output.position_ecef_m));
+    std::memcpy(output.velocity_ecef_mps, geph.vel, sizeof(output.velocity_ecef_mps));
+    std::memcpy(output.acceleration_ecef_mps2, geph.acc, sizeof(output.acceleration_ecef_mps2));
+    output.clock_bias_sec = geph.taun;
+    output.relative_frequency_bias = geph.gamn;
+    output.differential_delay_sec = geph.dtaun;
+    record->kind = RtklibNavRecordKind::kGlonassEphemeris;
+    record->glonass = output;
+    return true;
+}
+
+bool fill_explicit_ion(const nav_t& nav, int index, NavOutputRecord* record) {
+    const ion_t& ion = nav.ion[index];
+    IonosphereNavOutputData output{};
+    output.system = output_system(ion.hdr.sys);
+    output.prn = ion.hdr.prn;
+    output.message_type = ion.hdr.msg_type;
+    if (!time_week_sow(ion.trans_time, &output.transmit_week, &output.transmit_sow_sec)) {
+        return false;
+    }
+    output.coefficient_count = ion.ndata > 0 ? ion.ndata : 9;
+    if (output.coefficient_count > 9) {
+        output.coefficient_count = 9;
+    }
+    std::memcpy(output.coefficients, ion.alpha, sizeof(output.coefficients));
+    output.region = ion.region;
+    output.leap_seconds = nav.leaps;
+    output.legacy_metadata = false;
+    record->kind = RtklibNavRecordKind::kIonosphere;
+    record->ionosphere = output;
+    return output.system != NavOutputSystem::kUnknown;
+}
+
+bool fill_legacy_ion(const nav_t& nav, int system, NavOutputRecord* record) {
+    IonosphereNavOutputData output{};
+    output.system = output_system(system);
+    output.legacy_metadata = true;
+    output.leap_seconds = nav.leaps;
+    output.transmit_week = 0;
+    output.transmit_sow_sec = 0.0;
+    if (system == SYS_GPS) {
+        std::memcpy(output.coefficients, nav.ion_gps, sizeof(double) * 8);
+        std::memcpy(output.utc, nav.utc_gps, sizeof(output.utc));
+        output.coefficient_count = 8;
+    } else if (system == SYS_QZS) {
+        std::memcpy(output.coefficients, nav.ion_qzs, sizeof(double) * 8);
+        std::memcpy(output.utc, nav.utc_qzs, sizeof(output.utc));
+        output.coefficient_count = 8;
+    } else if (system == SYS_GAL) {
+        std::memcpy(output.coefficients, nav.ion_gal, sizeof(double) * 4);
+        std::memcpy(output.utc, nav.utc_gal, sizeof(output.utc));
+        output.coefficient_count = 3;
+    } else if (system == SYS_CMP) {
+        std::memcpy(output.coefficients, nav.ion_cmp, sizeof(double) * 8);
+        std::memcpy(output.utc, nav.utc_cmp, sizeof(output.utc));
+        output.coefficient_count = 8;
+    } else {
+        return false;
+    }
+    record->kind = RtklibNavRecordKind::kIonosphere;
+    record->ionosphere = output;
+    return true;
+}
+
+} // namespace
+
+int rtklib_nav_output_record_count(const RtklibNavStore* store) {
+    if (store == nullptr) {
+        return 0;
+    }
+    int systems[4]{};
+    const int metadata_count = legacy_ion_systems(store->nav, systems);
+    return store->nav.n + store->nav.ng + store->nav.nion + metadata_count;
+}
+
+bool rtklib_nav_output_record(const RtklibNavStore* store, int output_record_index, NavOutputRecord* record,
+                              std::string* error_message) {
+    if (store == nullptr || record == nullptr || output_record_index < 0 ||
+        output_record_index >= rtklib_nav_output_record_count(store)) {
+        set_error(error_message, "navigation output record request has invalid arguments");
+        return false;
+    }
+    *record = NavOutputRecord{};
+    if (output_record_index < store->nav.n) {
+        if (!fill_ephemeris(store->nav, output_record_index, record)) {
+            set_error(error_message, "cannot project RTKLIB ephemeris for navigation output");
+            return false;
+        }
+        return true;
+    }
+    output_record_index -= store->nav.n;
+    if (output_record_index < store->nav.ng) {
+        if (!fill_glonass(store->nav, output_record_index, record)) {
+            set_error(error_message, "cannot project RTKLIB GLONASS ephemeris for navigation output");
+            return false;
+        }
+        return true;
+    }
+    output_record_index -= store->nav.ng;
+    if (output_record_index < store->nav.nion) {
+        if (!fill_explicit_ion(store->nav, output_record_index, record)) {
+            set_error(error_message, "cannot project RTKLIB ionosphere record for navigation output");
+            return false;
+        }
+        return true;
+    }
+    output_record_index -= store->nav.nion;
+    int systems[4]{};
+    const int metadata_count = legacy_ion_systems(store->nav, systems);
+    if (output_record_index >= metadata_count || !fill_legacy_ion(store->nav, systems[output_record_index], record)) {
+        set_error(error_message, "cannot project legacy ionosphere metadata for navigation output");
+        return false;
+    }
+    return true;
+}
+
+const char* nav_output_system_name(NavOutputSystem system) {
+    switch (system) {
+        case NavOutputSystem::kGps:
+            return "GPS";
+        case NavOutputSystem::kGlonass:
+            return "GLO";
+        case NavOutputSystem::kGalileo:
+            return "GAL";
+        case NavOutputSystem::kBeidou:
+            return "BDS";
+        case NavOutputSystem::kQzss:
+            return "QZS";
+        case NavOutputSystem::kNavic:
+            return "IRN";
+        case NavOutputSystem::kUnknown:
+            return "UNKNOWN";
+    }
+    return "UNKNOWN";
+}
+
+} // namespace gnss_sim

--- a/src/output/novatel_nav_writer.cpp
+++ b/src/output/novatel_nav_writer.cpp
@@ -49,15 +49,16 @@ std::string generic_kepler_body(const KeplerianNavOutputData& eph, bool qzss, bo
 std::string galileo_body(const KeplerianNavOutputData& eph) {
     std::ostringstream body;
     body.imbue(std::locale::classic());
-    const double sqrt_a = std::sqrt(eph.semi_major_axis_m);
-    body << eph.prn << ',' << bool_text(eph.galileo_fnav_received) << ',' << bool_text(eph.galileo_inav_received)
-         << ",0,0,0,0,0,0," << static_cast<int>(std::llround(eph.sva)) << ',' << eph.svh << ',' << eph.iode << ','
-         << std::fixed << std::setprecision(0) << eph.toe_sow_sec << ',' << std::scientific << std::setprecision(15)
-         << sqrt_a << ',' << eph.delta_mean_motion_radps << ',' << eph.mean_anomaly_rad << ',' << eph.eccentricity << ','
-         << eph.argument_of_perigee_rad << ',' << eph.cuc_rad << ',' << eph.cus_rad << ',' << eph.crc_m << ',' << eph.crs_m
-         << ',' << eph.cic_rad << ',' << eph.cis_rad << ',' << eph.inclination_rad << ',' << eph.inclination_dot_radps << ','
-         << eph.omega0_rad << ',' << eph.omega_dot_radps << ',' << std::fixed << std::setprecision(0)
-         << eph.galileo_fnav_toc_sow_sec << ',' << std::scientific << std::setprecision(15)
+    body << eph.prn << ',' << bool_text(eph.galileo_fnav_received) << ',' << bool_text(eph.galileo_inav_received) << ','
+         << eph.galileo_e1b_health << ',' << eph.galileo_e5a_health << ',' << eph.galileo_e5b_health << ','
+         << eph.galileo_e1b_dvs << ',' << eph.galileo_e5a_dvs << ',' << eph.galileo_e5b_dvs << ','
+         << static_cast<int>(std::llround(eph.sva)) << ',' << eph.svh << ',' << eph.iode << ',' << std::fixed
+         << std::setprecision(0) << eph.toe_sow_sec << ',' << std::scientific << std::setprecision(15)
+         << eph.sqrt_semi_major_axis_sqrt_m << ',' << eph.delta_mean_motion_radps << ',' << eph.mean_anomaly_rad << ','
+         << eph.eccentricity << ',' << eph.argument_of_perigee_rad << ',' << eph.cuc_rad << ',' << eph.cus_rad << ','
+         << eph.crc_m << ',' << eph.crs_m << ',' << eph.cic_rad << ',' << eph.cis_rad << ',' << eph.inclination_rad << ','
+         << eph.inclination_dot_radps << ',' << eph.omega0_rad << ',' << eph.omega_dot_radps << ',' << std::fixed
+         << std::setprecision(0) << eph.galileo_fnav_toc_sow_sec << ',' << std::scientific << std::setprecision(15)
          << eph.galileo_fnav_clock[0] << ',' << eph.galileo_fnav_clock[1] << ',' << eph.galileo_fnav_clock[2] << ','
          << std::fixed << std::setprecision(0) << eph.galileo_inav_toc_sow_sec << ',' << std::scientific
          << std::setprecision(15) << eph.galileo_inav_clock[0] << ',' << eph.galileo_inav_clock[1] << ','

--- a/src/output/novatel_nav_writer.cpp
+++ b/src/output/novatel_nav_writer.cpp
@@ -1,1 +1,178 @@
-// NovAtel EPH/ION writer is introduced by issue #14.
+#include "output/novatel_nav_writer.h"
+
+#include "output/novatel_ascii.h"
+
+#include <cmath>
+#include <iomanip>
+#include <locale>
+#include <sstream>
+
+namespace gnss_sim {
+namespace {
+
+void set_error(std::string* error_message, const char* message) {
+    if (error_message != nullptr) {
+        *error_message = message;
+    }
+}
+
+const char* bool_text(bool value) {
+    return value ? "TRUE" : "FALSE";
+}
+
+bool legacy_bds(const KeplerianNavOutputData& eph) {
+    return eph.message_family == RtklibBroadcastMessageFamily::kLegacy;
+}
+
+std::string generic_kepler_body(const KeplerianNavOutputData& eph, bool qzss, bool beidou) {
+    std::ostringstream body;
+    body.imbue(std::locale::classic());
+    body << eph.prn << ',' << std::fixed << std::setprecision(3) << eph.transmit_sow_sec << ',' << eph.svh << ','
+         << eph.iode << ',' << eph.iode << ',' << eph.toe_week << ',' << eph.toe_week << ',' << eph.toe_sow_sec << ','
+         << std::scientific << std::setprecision(15) << eph.semi_major_axis_m << ',' << eph.delta_mean_motion_radps << ','
+         << eph.mean_anomaly_rad << ',' << eph.eccentricity << ',' << eph.argument_of_perigee_rad << ',' << eph.cuc_rad
+         << ',' << eph.cus_rad << ',' << eph.crc_m << ',' << eph.crs_m << ',' << eph.cic_rad << ',' << eph.cis_rad << ','
+         << eph.inclination_rad << ',' << eph.inclination_dot_radps << ',' << eph.omega0_rad << ',' << eph.omega_dot_radps
+         << ',' << std::dec << eph.iodc << ',' << std::fixed << std::setprecision(3) << eph.toc_sow_sec << ','
+         << std::scientific << std::setprecision(15) << eph.tgd_sec[0];
+    if (beidou) {
+        body << ',' << eph.tgd_sec[1];
+    }
+    body << ',' << eph.clock_bias_sec << ',' << eph.clock_drift_sec_per_sec << ',' << eph.clock_drift_rate_sec_per_sec2
+         << ',' << bool_text(eph.flag != 0) << ',' << eph.corrected_mean_motion_radps << ',' << eph.sva;
+    if (qzss) {
+        body << ",0,0,0,0";
+    }
+    return body.str();
+}
+
+std::string galileo_body(const KeplerianNavOutputData& eph) {
+    std::ostringstream body;
+    body.imbue(std::locale::classic());
+    const double sqrt_a = std::sqrt(eph.semi_major_axis_m);
+    body << eph.prn << ',' << bool_text(eph.galileo_fnav_received) << ',' << bool_text(eph.galileo_inav_received)
+         << ",0,0,0,0,0,0," << static_cast<int>(std::llround(eph.sva)) << ',' << eph.svh << ',' << eph.iode << ','
+         << std::fixed << std::setprecision(0) << eph.toe_sow_sec << ',' << std::scientific << std::setprecision(15)
+         << sqrt_a << ',' << eph.delta_mean_motion_radps << ',' << eph.mean_anomaly_rad << ',' << eph.eccentricity << ','
+         << eph.argument_of_perigee_rad << ',' << eph.cuc_rad << ',' << eph.cus_rad << ',' << eph.crc_m << ',' << eph.crs_m
+         << ',' << eph.cic_rad << ',' << eph.cis_rad << ',' << eph.inclination_rad << ',' << eph.inclination_dot_radps << ','
+         << eph.omega0_rad << ',' << eph.omega_dot_radps << ',' << std::fixed << std::setprecision(0)
+         << eph.galileo_fnav_toc_sow_sec << ',' << std::scientific << std::setprecision(15)
+         << eph.galileo_fnav_clock[0] << ',' << eph.galileo_fnav_clock[1] << ',' << eph.galileo_fnav_clock[2] << ','
+         << std::fixed << std::setprecision(0) << eph.galileo_inav_toc_sow_sec << ',' << std::scientific
+         << std::setprecision(15) << eph.galileo_inav_clock[0] << ',' << eph.galileo_inav_clock[1] << ','
+         << eph.galileo_inav_clock[2] << ',' << eph.tgd_sec[0] << ',' << eph.tgd_sec[1];
+    return body.str();
+}
+
+std::string glonass_body(const GlonassNavOutputData& glo) {
+    std::ostringstream body;
+    body.imbue(std::locale::classic());
+    const std::int64_t toe_ms = static_cast<std::int64_t>(std::llround(glo.toe_sow_sec * 1000.0));
+    body << glo.slot_offset << ',' << glo.frequency_offset << ",1,0," << glo.toe_week << ',' << toe_ms << ','
+         << glo.gps_glonass_time_offset_sec << ',' << glo.calendar_day_number << ",0,0," << glo.iode << ',' << glo.svh
+         << ',' << std::scientific << std::setprecision(15) << glo.position_ecef_m[0] << ',' << glo.position_ecef_m[1] << ','
+         << glo.position_ecef_m[2] << ',' << glo.velocity_ecef_mps[0] << ',' << glo.velocity_ecef_mps[1] << ','
+         << glo.velocity_ecef_mps[2] << ',' << glo.acceleration_ecef_mps2[0] << ',' << glo.acceleration_ecef_mps2[1] << ','
+         << glo.acceleration_ecef_mps2[2] << ',' << glo.clock_bias_sec << ',' << glo.relative_frequency_bias << ','
+         << glo.differential_delay_sec << ',' << std::fixed << std::setprecision(0) << glo.frame_time_glonass_day_sec << ','
+         << glo.flags << ',' << glo.sva << ',' << glo.age_days << ',' << glo.flags;
+    return body.str();
+}
+
+std::string ionutc_body(const IonosphereNavOutputData& ion, bool beidou) {
+    std::ostringstream body;
+    body.imbue(std::locale::classic());
+    body << std::scientific << std::setprecision(15);
+    for (int index = 0; index < 8; ++index) {
+        if (index != 0) {
+            body << ',';
+        }
+        body << ion.coefficients[index];
+    }
+    const int utc_week = static_cast<int>(std::llround(ion.utc[3]));
+    const int utc_tot = static_cast<int>(std::llround(ion.utc[2]));
+    const int leap_seconds = beidou ? ion.leap_seconds - 14 : ion.leap_seconds;
+    body << ',' << std::dec << utc_week << ',' << utc_tot << ',' << std::scientific << ion.utc[0] << ',' << ion.utc[1]
+         << ',' << utc_week << ",0," << leap_seconds << ',' << leap_seconds << ",0";
+    return body.str();
+}
+
+} // namespace
+
+bool format_novatel_nav_output_record(const NavOutputRecord& source, const SimTime& output_time, std::string* message,
+                                      bool* supported, std::string* error_message) {
+    if (message == nullptr || supported == nullptr) {
+        set_error(error_message, "NovAtel NAV writer request has invalid arguments");
+        return false;
+    }
+    *supported = false;
+    message->clear();
+    NavOutputRecord record = source;
+    if (!finalize_nav_output_record_metadata(&record)) {
+        set_error(error_message, "cannot finalize NovAtel NAV output metadata");
+        return false;
+    }
+
+    const char* log_name = nullptr;
+    std::string body;
+    if (record.kind == RtklibNavRecordKind::kGlonassEphemeris) {
+        log_name = "GLOEPHEMERISA";
+        body = glonass_body(record.glonass);
+    } else if (record.kind == RtklibNavRecordKind::kEphemeris) {
+        const KeplerianNavOutputData& eph = record.ephemeris;
+        switch (eph.system) {
+            case NavOutputSystem::kGps:
+                log_name = "GPSEPHEMA";
+                body = generic_kepler_body(eph, false, false);
+                break;
+            case NavOutputSystem::kQzss:
+                log_name = "QZSSEPHEMERISA";
+                body = generic_kepler_body(eph, true, false);
+                break;
+            case NavOutputSystem::kGalileo:
+                log_name = "GALEPHEMERISA";
+                body = galileo_body(eph);
+                break;
+            case NavOutputSystem::kBeidou:
+                if (legacy_bds(eph)) {
+                    log_name = "BD2EPHEMA";
+                    body = generic_kepler_body(eph, false, true);
+                }
+                break;
+            default:
+                break;
+        }
+    } else if (record.kind == RtklibNavRecordKind::kIonosphere) {
+        const IonosphereNavOutputData& ion = record.ionosphere;
+        if (ion.system == NavOutputSystem::kGps && ion.coefficient_count >= 8) {
+            log_name = "IONUTCA";
+            body = ionutc_body(ion, false);
+        } else if (ion.system == NavOutputSystem::kBeidou && ion.coefficient_count >= 8 && ion.legacy_metadata) {
+            log_name = "BD2IONUTCA";
+            body = ionutc_body(ion, true);
+        }
+    }
+
+    if (log_name == nullptr) {
+        return true;
+    }
+    if (!novatel_ascii::frame(log_name, output_time, body, message)) {
+        set_error(error_message, "NovAtel NAV header time cannot be represented");
+        return false;
+    }
+    *supported = true;
+    return true;
+}
+
+bool format_novatel_receiver_nav_record(const RtklibNavStore* receiver_nav, int output_record_index,
+                                        const SimTime& output_time, std::string* message, bool* supported,
+                                        std::string* error_message) {
+    NavOutputRecord record{};
+    if (!rtklib_nav_output_record(receiver_nav, output_record_index, &record, error_message)) {
+        return false;
+    }
+    return format_novatel_nav_output_record(record, output_time, message, supported, error_message);
+}
+
+} // namespace gnss_sim

--- a/src/output/novatel_nav_writer.cpp
+++ b/src/output/novatel_nav_writer.cpp
@@ -29,12 +29,12 @@ std::string generic_kepler_body(const KeplerianNavOutputData& eph, bool qzss, bo
     body.imbue(std::locale::classic());
     body << eph.prn << ',' << std::fixed << std::setprecision(3) << eph.transmit_sow_sec << ',' << eph.svh << ','
          << eph.iode << ',' << eph.iode << ',' << eph.toe_week << ',' << eph.toe_week << ',' << eph.toe_sow_sec << ','
-         << std::scientific << std::setprecision(15) << eph.semi_major_axis_m << ',' << eph.delta_mean_motion_radps << ','
-         << eph.mean_anomaly_rad << ',' << eph.eccentricity << ',' << eph.argument_of_perigee_rad << ',' << eph.cuc_rad
-         << ',' << eph.cus_rad << ',' << eph.crc_m << ',' << eph.crs_m << ',' << eph.cic_rad << ',' << eph.cis_rad << ','
-         << eph.inclination_rad << ',' << eph.inclination_dot_radps << ',' << eph.omega0_rad << ',' << eph.omega_dot_radps
-         << ',' << std::dec << eph.iodc << ',' << std::fixed << std::setprecision(3) << eph.toc_sow_sec << ','
-         << std::scientific << std::setprecision(15) << eph.tgd_sec[0];
+         << std::scientific << std::setprecision(15) << eph.semi_major_axis_m << ',' << eph.delta_mean_motion_radps
+         << ',' << eph.mean_anomaly_rad << ',' << eph.eccentricity << ',' << eph.argument_of_perigee_rad << ','
+         << eph.cuc_rad << ',' << eph.cus_rad << ',' << eph.crc_m << ',' << eph.crs_m << ',' << eph.cic_rad << ','
+         << eph.cis_rad << ',' << eph.inclination_rad << ',' << eph.inclination_dot_radps << ',' << eph.omega0_rad
+         << ',' << eph.omega_dot_radps << ',' << std::dec << eph.iodc << ',' << std::fixed << std::setprecision(3)
+         << eph.toc_sow_sec << ',' << std::scientific << std::setprecision(15) << eph.tgd_sec[0];
     if (beidou) {
         body << ',' << eph.tgd_sec[1];
     }
@@ -56,8 +56,8 @@ std::string galileo_body(const KeplerianNavOutputData& eph) {
          << std::setprecision(0) << eph.toe_sow_sec << ',' << std::scientific << std::setprecision(15)
          << eph.sqrt_semi_major_axis_sqrt_m << ',' << eph.delta_mean_motion_radps << ',' << eph.mean_anomaly_rad << ','
          << eph.eccentricity << ',' << eph.argument_of_perigee_rad << ',' << eph.cuc_rad << ',' << eph.cus_rad << ','
-         << eph.crc_m << ',' << eph.crs_m << ',' << eph.cic_rad << ',' << eph.cis_rad << ',' << eph.inclination_rad << ','
-         << eph.inclination_dot_radps << ',' << eph.omega0_rad << ',' << eph.omega_dot_radps << ',' << std::fixed
+         << eph.crc_m << ',' << eph.crs_m << ',' << eph.cic_rad << ',' << eph.cis_rad << ',' << eph.inclination_rad
+         << ',' << eph.inclination_dot_radps << ',' << eph.omega0_rad << ',' << eph.omega_dot_radps << ',' << std::fixed
          << std::setprecision(0) << eph.galileo_fnav_toc_sow_sec << ',' << std::scientific << std::setprecision(15)
          << eph.galileo_fnav_clock[0] << ',' << eph.galileo_fnav_clock[1] << ',' << eph.galileo_fnav_clock[2] << ','
          << std::fixed << std::setprecision(0) << eph.galileo_inav_toc_sow_sec << ',' << std::scientific
@@ -72,12 +72,13 @@ std::string glonass_body(const GlonassNavOutputData& glo) {
     const std::int64_t toe_ms = static_cast<std::int64_t>(std::llround(glo.toe_sow_sec * 1000.0));
     body << glo.slot_offset << ',' << glo.frequency_offset << ",1,0," << glo.toe_week << ',' << toe_ms << ','
          << glo.gps_glonass_time_offset_sec << ',' << glo.calendar_day_number << ",0,0," << glo.iode << ',' << glo.svh
-         << ',' << std::scientific << std::setprecision(15) << glo.position_ecef_m[0] << ',' << glo.position_ecef_m[1] << ','
-         << glo.position_ecef_m[2] << ',' << glo.velocity_ecef_mps[0] << ',' << glo.velocity_ecef_mps[1] << ','
-         << glo.velocity_ecef_mps[2] << ',' << glo.acceleration_ecef_mps2[0] << ',' << glo.acceleration_ecef_mps2[1] << ','
-         << glo.acceleration_ecef_mps2[2] << ',' << glo.clock_bias_sec << ',' << glo.relative_frequency_bias << ','
-         << glo.differential_delay_sec << ',' << std::fixed << std::setprecision(0) << glo.frame_time_glonass_day_sec << ','
-         << glo.flags << ',' << glo.sva << ',' << glo.age_days << ',' << glo.flags;
+         << ',' << std::scientific << std::setprecision(15) << glo.position_ecef_m[0] << ',' << glo.position_ecef_m[1]
+         << ',' << glo.position_ecef_m[2] << ',' << glo.velocity_ecef_mps[0] << ',' << glo.velocity_ecef_mps[1] << ','
+         << glo.velocity_ecef_mps[2] << ',' << glo.acceleration_ecef_mps2[0] << ',' << glo.acceleration_ecef_mps2[1]
+         << ',' << glo.acceleration_ecef_mps2[2] << ',' << glo.clock_bias_sec << ',' << glo.relative_frequency_bias
+         << ',' << glo.differential_delay_sec << ',' << std::fixed << std::setprecision(0)
+         << glo.frame_time_glonass_day_sec << ',' << glo.flags << ',' << glo.sva << ',' << glo.age_days << ','
+         << glo.flags;
     return body.str();
 }
 

--- a/src/output/novatel_nav_writer.h
+++ b/src/output/novatel_nav_writer.h
@@ -1,0 +1,19 @@
+#ifndef GNSS_SIM_SRC_OUTPUT_NOVATEL_NAV_WRITER_H_
+#define GNSS_SIM_SRC_OUTPUT_NOVATEL_NAV_WRITER_H_
+
+#include "gnss/nav_output_record.h"
+#include "gnss_sim/sim_types.h"
+
+#include <string>
+
+namespace gnss_sim {
+
+bool format_novatel_nav_output_record(const NavOutputRecord& record, const SimTime& output_time, std::string* message,
+                                      bool* supported, std::string* error_message);
+bool format_novatel_receiver_nav_record(const RtklibNavStore* receiver_nav, int output_record_index,
+                                        const SimTime& output_time, std::string* message, bool* supported,
+                                        std::string* error_message);
+
+} // namespace gnss_sim
+
+#endif // GNSS_SIM_SRC_OUTPUT_NOVATEL_NAV_WRITER_H_

--- a/src/output/unicore_ascii.h
+++ b/src/output/unicore_ascii.h
@@ -1,0 +1,52 @@
+#ifndef GNSS_SIM_SRC_OUTPUT_UNICORE_ASCII_H_
+#define GNSS_SIM_SRC_OUTPUT_UNICORE_ASCII_H_
+
+#include "gnss_sim/sim_time.h"
+#include "output/novatel_ascii.h"
+
+#include <cstdint>
+#include <iomanip>
+#include <locale>
+#include <sstream>
+#include <string>
+
+namespace gnss_sim {
+namespace unicore_ascii {
+
+constexpr unsigned int kCpuIdle = 0U;
+constexpr const char* kTimeReference = "GPS";
+constexpr const char* kTimeStatus = "FINE";
+constexpr unsigned int kReceiverStatus = 0U;
+constexpr unsigned int kReserved = 0U;
+constexpr unsigned int kVersion = 18U;
+constexpr unsigned int kSequence = 0U;
+
+inline bool frame(const char* log_name, const SimTime& time, const std::string& body, std::string* message) {
+    if (log_name == nullptr || log_name[0] == '\0' || message == nullptr) {
+        return false;
+    }
+    int gps_week = 0;
+    std::int64_t tow_milliseconds = 0;
+    if (!novatel_ascii::rounded_header_time(time, &gps_week, &tow_milliseconds)) {
+        return false;
+    }
+
+    std::ostringstream payload;
+    payload.imbue(std::locale::classic());
+    payload << log_name << ',' << kCpuIdle << ',' << kTimeReference << ',' << kTimeStatus << ',' << gps_week << ','
+            << tow_milliseconds << ',' << kReceiverStatus << ',' << kReserved << ',' << kVersion << ',' << kSequence
+            << ';' << body;
+
+    const std::string payload_text = payload.str();
+    std::ostringstream output;
+    output.imbue(std::locale::classic());
+    output << '#' << payload_text << '*' << std::hex << std::nouppercase << std::setw(8) << std::setfill('0')
+           << novatel_ascii::crc32(payload_text) << "\r\n";
+    *message = output.str();
+    return true;
+}
+
+} // namespace unicore_ascii
+} // namespace gnss_sim
+
+#endif // GNSS_SIM_SRC_OUTPUT_UNICORE_ASCII_H_

--- a/src/output/unicore_nav_writer.cpp
+++ b/src/output/unicore_nav_writer.cpp
@@ -61,7 +61,7 @@ std::string bd3_ephemeris_body(const KeplerianNavOutputData& eph) {
     body << eph.prn << ',' << eph.svh << ',' << static_cast<int>(std::llround(eph.sva)) << ',' << eph.iode << ','
          << eph.iodc << ',' << eph.iodc << ',' << eph.toe_week << ',' << eph.toc_week << ',' << std::fixed
          << std::setprecision(1) << eph.toe_sow_sec << ',' << eph.toc_sow_sec << ',' << std::scientific
-         << std::setprecision(15) << std::sqrt(eph.semi_major_axis_m) << ',' << eph.delta_mean_motion_radps << ','
+         << std::setprecision(15) << eph.sqrt_semi_major_axis_sqrt_m << ',' << eph.delta_mean_motion_radps << ','
          << eph.mean_anomaly_rad << ',' << eph.eccentricity << ',' << eph.argument_of_perigee_rad << ',' << eph.cuc_rad
          << ',' << eph.cus_rad << ',' << eph.crc_m << ',' << eph.crs_m << ',' << eph.cic_rad << ',' << eph.cis_rad << ','
          << eph.inclination_rad << ',' << eph.inclination_dot_radps << ',' << eph.omega0_rad << ',' << eph.omega_dot_radps
@@ -75,10 +75,12 @@ std::string bd3_ephemeris_body(const KeplerianNavOutputData& eph) {
 std::string galileo_body(const KeplerianNavOutputData& eph) {
     std::ostringstream body;
     body.imbue(std::locale::classic());
-    body << eph.prn << ',' << bool_text(eph.galileo_fnav_received) << ',' << bool_text(eph.galileo_inav_received)
-         << ",0,0,0,0,0,0," << static_cast<int>(std::llround(eph.sva)) << ',' << eph.svh << ',' << eph.iode << ','
-         << std::fixed << std::setprecision(0) << eph.toe_sow_sec << ',' << std::scientific << std::setprecision(15)
-         << std::sqrt(eph.semi_major_axis_m) << ',' << eph.delta_mean_motion_radps << ',' << eph.mean_anomaly_rad << ','
+    body << eph.prn << ',' << bool_text(eph.galileo_fnav_received) << ',' << bool_text(eph.galileo_inav_received) << ','
+         << eph.galileo_e1b_health << ',' << eph.galileo_e5a_health << ',' << eph.galileo_e5b_health << ','
+         << eph.galileo_e1b_dvs << ',' << eph.galileo_e5a_dvs << ',' << eph.galileo_e5b_dvs << ','
+         << static_cast<int>(std::llround(eph.sva)) << ',' << eph.svh << ',' << eph.iode << ',' << std::fixed
+         << std::setprecision(0) << eph.toe_sow_sec << ',' << std::scientific << std::setprecision(15)
+         << eph.sqrt_semi_major_axis_sqrt_m << ',' << eph.delta_mean_motion_radps << ',' << eph.mean_anomaly_rad << ','
          << eph.eccentricity << ',' << eph.argument_of_perigee_rad << ',' << eph.cuc_rad << ',' << eph.cus_rad << ','
          << eph.crc_m << ',' << eph.crs_m << ',' << eph.cic_rad << ',' << eph.cis_rad << ',' << eph.inclination_rad << ','
          << eph.inclination_dot_radps << ',' << eph.omega0_rad << ',' << eph.omega_dot_radps << ',' << std::fixed

--- a/src/output/unicore_nav_writer.cpp
+++ b/src/output/unicore_nav_writer.cpp
@@ -41,12 +41,12 @@ std::string legacy_kepler_body(const KeplerianNavOutputData& eph, bool beidou) {
     body.imbue(std::locale::classic());
     body << eph.prn << ',' << std::fixed << std::setprecision(1) << eph.transmit_sow_sec << ',' << eph.svh << ','
          << eph.iode << ',' << eph.iode << ',' << eph.toe_week << ',' << eph.toe_week << ',' << eph.toe_sow_sec << ','
-         << std::scientific << std::setprecision(15) << eph.semi_major_axis_m << ',' << eph.delta_mean_motion_radps << ','
-         << eph.mean_anomaly_rad << ',' << eph.eccentricity << ',' << eph.argument_of_perigee_rad << ',' << eph.cuc_rad
-         << ',' << eph.cus_rad << ',' << eph.crc_m << ',' << eph.crs_m << ',' << eph.cic_rad << ',' << eph.cis_rad << ','
-         << eph.inclination_rad << ',' << eph.inclination_dot_radps << ',' << eph.omega0_rad << ',' << eph.omega_dot_radps
-         << ',' << eph.iodc << ',' << std::fixed << std::setprecision(1) << eph.toc_sow_sec << ',' << std::scientific
-         << std::setprecision(15) << eph.tgd_sec[0];
+         << std::scientific << std::setprecision(15) << eph.semi_major_axis_m << ',' << eph.delta_mean_motion_radps
+         << ',' << eph.mean_anomaly_rad << ',' << eph.eccentricity << ',' << eph.argument_of_perigee_rad << ','
+         << eph.cuc_rad << ',' << eph.cus_rad << ',' << eph.crc_m << ',' << eph.crs_m << ',' << eph.cic_rad << ','
+         << eph.cis_rad << ',' << eph.inclination_rad << ',' << eph.inclination_dot_radps << ',' << eph.omega0_rad
+         << ',' << eph.omega_dot_radps << ',' << eph.iodc << ',' << std::fixed << std::setprecision(1)
+         << eph.toc_sow_sec << ',' << std::scientific << std::setprecision(15) << eph.tgd_sec[0];
     if (beidou) {
         body << ',' << eph.tgd_sec[1];
     }
@@ -63,12 +63,13 @@ std::string bd3_ephemeris_body(const KeplerianNavOutputData& eph) {
          << std::setprecision(1) << eph.toe_sow_sec << ',' << eph.toc_sow_sec << ',' << std::scientific
          << std::setprecision(15) << eph.sqrt_semi_major_axis_sqrt_m << ',' << eph.delta_mean_motion_radps << ','
          << eph.mean_anomaly_rad << ',' << eph.eccentricity << ',' << eph.argument_of_perigee_rad << ',' << eph.cuc_rad
-         << ',' << eph.cus_rad << ',' << eph.crc_m << ',' << eph.crs_m << ',' << eph.cic_rad << ',' << eph.cis_rad << ','
-         << eph.inclination_rad << ',' << eph.inclination_dot_radps << ',' << eph.omega0_rad << ',' << eph.omega_dot_radps
-         << ',' << eph.tgd_sec[0] << ',' << eph.tgd_sec[1] << ',' << eph.isc_sec[0] << ',' << eph.isc_sec[1] << ','
-         << eph.isc_sec[2] << ',' << eph.isc_sec[3] << ',' << eph.isc_sec[4] << ',' << eph.isc_sec[5] << ','
-         << eph.clock_bias_sec << ',' << eph.clock_drift_sec_per_sec << ',' << eph.clock_drift_rate_sec_per_sec2 << ','
-         << std::fixed << std::setprecision(0) << eph.transmit_sow_sec << ",0,0,0,0,0,0," << bds_frequency_type(eph);
+         << ',' << eph.cus_rad << ',' << eph.crc_m << ',' << eph.crs_m << ',' << eph.cic_rad << ',' << eph.cis_rad
+         << ',' << eph.inclination_rad << ',' << eph.inclination_dot_radps << ',' << eph.omega0_rad << ','
+         << eph.omega_dot_radps << ',' << eph.tgd_sec[0] << ',' << eph.tgd_sec[1] << ',' << eph.isc_sec[0] << ','
+         << eph.isc_sec[1] << ',' << eph.isc_sec[2] << ',' << eph.isc_sec[3] << ',' << eph.isc_sec[4] << ','
+         << eph.isc_sec[5] << ',' << eph.clock_bias_sec << ',' << eph.clock_drift_sec_per_sec << ','
+         << eph.clock_drift_rate_sec_per_sec2 << ',' << std::fixed << std::setprecision(0) << eph.transmit_sow_sec
+         << ",0,0,0,0,0,0," << bds_frequency_type(eph);
     return body.str();
 }
 
@@ -82,8 +83,8 @@ std::string galileo_body(const KeplerianNavOutputData& eph) {
          << std::setprecision(0) << eph.toe_sow_sec << ',' << std::scientific << std::setprecision(15)
          << eph.sqrt_semi_major_axis_sqrt_m << ',' << eph.delta_mean_motion_radps << ',' << eph.mean_anomaly_rad << ','
          << eph.eccentricity << ',' << eph.argument_of_perigee_rad << ',' << eph.cuc_rad << ',' << eph.cus_rad << ','
-         << eph.crc_m << ',' << eph.crs_m << ',' << eph.cic_rad << ',' << eph.cis_rad << ',' << eph.inclination_rad << ','
-         << eph.inclination_dot_radps << ',' << eph.omega0_rad << ',' << eph.omega_dot_radps << ',' << std::fixed
+         << eph.crc_m << ',' << eph.crs_m << ',' << eph.cic_rad << ',' << eph.cis_rad << ',' << eph.inclination_rad
+         << ',' << eph.inclination_dot_radps << ',' << eph.omega0_rad << ',' << eph.omega_dot_radps << ',' << std::fixed
          << std::setprecision(0) << eph.galileo_fnav_toc_sow_sec << ',' << std::scientific << std::setprecision(15)
          << eph.galileo_fnav_clock[0] << ',' << eph.galileo_fnav_clock[1] << ',' << eph.galileo_fnav_clock[2] << ','
          << std::fixed << std::setprecision(0) << eph.galileo_inav_toc_sow_sec << ',' << std::scientific
@@ -98,12 +99,13 @@ std::string glonass_body(const GlonassNavOutputData& glo) {
     const std::int64_t toe_ms = static_cast<std::int64_t>(std::llround(glo.toe_sow_sec * 1000.0));
     body << glo.slot_offset << ',' << glo.frequency_offset << ",1,0," << glo.toe_week << ',' << toe_ms << ','
          << glo.gps_glonass_time_offset_sec << ',' << glo.calendar_day_number << ",0,0," << glo.iode << ',' << glo.svh
-         << ',' << std::scientific << std::setprecision(15) << glo.position_ecef_m[0] << ',' << glo.position_ecef_m[1] << ','
-         << glo.position_ecef_m[2] << ',' << glo.velocity_ecef_mps[0] << ',' << glo.velocity_ecef_mps[1] << ','
-         << glo.velocity_ecef_mps[2] << ',' << glo.acceleration_ecef_mps2[0] << ',' << glo.acceleration_ecef_mps2[1] << ','
-         << glo.acceleration_ecef_mps2[2] << ',' << glo.clock_bias_sec << ',' << glo.relative_frequency_bias << ','
-         << glo.differential_delay_sec << ',' << std::fixed << std::setprecision(0) << glo.frame_time_glonass_day_sec << ','
-         << glo.flags << ',' << glo.sva << ',' << glo.age_days << ',' << glo.flags;
+         << ',' << std::scientific << std::setprecision(15) << glo.position_ecef_m[0] << ',' << glo.position_ecef_m[1]
+         << ',' << glo.position_ecef_m[2] << ',' << glo.velocity_ecef_mps[0] << ',' << glo.velocity_ecef_mps[1] << ','
+         << glo.velocity_ecef_mps[2] << ',' << glo.acceleration_ecef_mps2[0] << ',' << glo.acceleration_ecef_mps2[1]
+         << ',' << glo.acceleration_ecef_mps2[2] << ',' << glo.clock_bias_sec << ',' << glo.relative_frequency_bias
+         << ',' << glo.differential_delay_sec << ',' << std::fixed << std::setprecision(0)
+         << glo.frame_time_glonass_day_sec << ',' << glo.flags << ',' << glo.sva << ',' << glo.age_days << ','
+         << glo.flags;
     return body.str();
 }
 

--- a/src/output/unicore_nav_writer.cpp
+++ b/src/output/unicore_nav_writer.cpp
@@ -1,1 +1,235 @@
-// Unicore N4 EPH/ION writer is introduced by issue #14.
+#include "output/unicore_nav_writer.h"
+
+#include "output/unicore_ascii.h"
+
+#include <cmath>
+#include <iomanip>
+#include <locale>
+#include <sstream>
+
+namespace gnss_sim {
+namespace {
+
+void set_error(std::string* error_message, const char* message) {
+    if (error_message != nullptr) {
+        *error_message = message;
+    }
+}
+
+const char* bool_text(bool value) {
+    return value ? "TRUE" : "FALSE";
+}
+
+bool modern_bds(const KeplerianNavOutputData& eph) {
+    return eph.message_family == RtklibBroadcastMessageFamily::kBeidouBcnav1 ||
+           eph.message_family == RtklibBroadcastMessageFamily::kBeidouBcnav2 ||
+           eph.message_family == RtklibBroadcastMessageFamily::kBeidouBcnav3;
+}
+
+int bds_frequency_type(const KeplerianNavOutputData& eph) {
+    if (eph.message_family == RtklibBroadcastMessageFamily::kBeidouBcnav2) {
+        return 1;
+    }
+    if (eph.message_family == RtklibBroadcastMessageFamily::kBeidouBcnav3) {
+        return 2;
+    }
+    return 0;
+}
+
+std::string legacy_kepler_body(const KeplerianNavOutputData& eph, bool beidou) {
+    std::ostringstream body;
+    body.imbue(std::locale::classic());
+    body << eph.prn << ',' << std::fixed << std::setprecision(1) << eph.transmit_sow_sec << ',' << eph.svh << ','
+         << eph.iode << ',' << eph.iode << ',' << eph.toe_week << ',' << eph.toe_week << ',' << eph.toe_sow_sec << ','
+         << std::scientific << std::setprecision(15) << eph.semi_major_axis_m << ',' << eph.delta_mean_motion_radps << ','
+         << eph.mean_anomaly_rad << ',' << eph.eccentricity << ',' << eph.argument_of_perigee_rad << ',' << eph.cuc_rad
+         << ',' << eph.cus_rad << ',' << eph.crc_m << ',' << eph.crs_m << ',' << eph.cic_rad << ',' << eph.cis_rad << ','
+         << eph.inclination_rad << ',' << eph.inclination_dot_radps << ',' << eph.omega0_rad << ',' << eph.omega_dot_radps
+         << ',' << eph.iodc << ',' << std::fixed << std::setprecision(1) << eph.toc_sow_sec << ',' << std::scientific
+         << std::setprecision(15) << eph.tgd_sec[0];
+    if (beidou) {
+        body << ',' << eph.tgd_sec[1];
+    }
+    body << ',' << eph.clock_bias_sec << ',' << eph.clock_drift_sec_per_sec << ',' << eph.clock_drift_rate_sec_per_sec2
+         << ',' << eph.corrected_mean_motion_radps << ',' << eph.sva;
+    return body.str();
+}
+
+std::string bd3_ephemeris_body(const KeplerianNavOutputData& eph) {
+    std::ostringstream body;
+    body.imbue(std::locale::classic());
+    body << eph.prn << ',' << eph.svh << ',' << static_cast<int>(std::llround(eph.sva)) << ',' << eph.iode << ','
+         << eph.iodc << ',' << eph.iodc << ',' << eph.toe_week << ',' << eph.toc_week << ',' << std::fixed
+         << std::setprecision(1) << eph.toe_sow_sec << ',' << eph.toc_sow_sec << ',' << std::scientific
+         << std::setprecision(15) << std::sqrt(eph.semi_major_axis_m) << ',' << eph.delta_mean_motion_radps << ','
+         << eph.mean_anomaly_rad << ',' << eph.eccentricity << ',' << eph.argument_of_perigee_rad << ',' << eph.cuc_rad
+         << ',' << eph.cus_rad << ',' << eph.crc_m << ',' << eph.crs_m << ',' << eph.cic_rad << ',' << eph.cis_rad << ','
+         << eph.inclination_rad << ',' << eph.inclination_dot_radps << ',' << eph.omega0_rad << ',' << eph.omega_dot_radps
+         << ',' << eph.tgd_sec[0] << ',' << eph.tgd_sec[1] << ',' << eph.isc_sec[0] << ',' << eph.isc_sec[1] << ','
+         << eph.isc_sec[2] << ',' << eph.isc_sec[3] << ',' << eph.isc_sec[4] << ',' << eph.isc_sec[5] << ','
+         << eph.clock_bias_sec << ',' << eph.clock_drift_sec_per_sec << ',' << eph.clock_drift_rate_sec_per_sec2 << ','
+         << std::fixed << std::setprecision(0) << eph.transmit_sow_sec << ",0,0,0,0,0,0," << bds_frequency_type(eph);
+    return body.str();
+}
+
+std::string galileo_body(const KeplerianNavOutputData& eph) {
+    std::ostringstream body;
+    body.imbue(std::locale::classic());
+    body << eph.prn << ',' << bool_text(eph.galileo_fnav_received) << ',' << bool_text(eph.galileo_inav_received)
+         << ",0,0,0,0,0,0," << static_cast<int>(std::llround(eph.sva)) << ',' << eph.svh << ',' << eph.iode << ','
+         << std::fixed << std::setprecision(0) << eph.toe_sow_sec << ',' << std::scientific << std::setprecision(15)
+         << std::sqrt(eph.semi_major_axis_m) << ',' << eph.delta_mean_motion_radps << ',' << eph.mean_anomaly_rad << ','
+         << eph.eccentricity << ',' << eph.argument_of_perigee_rad << ',' << eph.cuc_rad << ',' << eph.cus_rad << ','
+         << eph.crc_m << ',' << eph.crs_m << ',' << eph.cic_rad << ',' << eph.cis_rad << ',' << eph.inclination_rad << ','
+         << eph.inclination_dot_radps << ',' << eph.omega0_rad << ',' << eph.omega_dot_radps << ',' << std::fixed
+         << std::setprecision(0) << eph.galileo_fnav_toc_sow_sec << ',' << std::scientific << std::setprecision(15)
+         << eph.galileo_fnav_clock[0] << ',' << eph.galileo_fnav_clock[1] << ',' << eph.galileo_fnav_clock[2] << ','
+         << std::fixed << std::setprecision(0) << eph.galileo_inav_toc_sow_sec << ',' << std::scientific
+         << std::setprecision(15) << eph.galileo_inav_clock[0] << ',' << eph.galileo_inav_clock[1] << ','
+         << eph.galileo_inav_clock[2] << ',' << eph.tgd_sec[0] << ',' << eph.tgd_sec[1];
+    return body.str();
+}
+
+std::string glonass_body(const GlonassNavOutputData& glo) {
+    std::ostringstream body;
+    body.imbue(std::locale::classic());
+    const std::int64_t toe_ms = static_cast<std::int64_t>(std::llround(glo.toe_sow_sec * 1000.0));
+    body << glo.slot_offset << ',' << glo.frequency_offset << ",1,0," << glo.toe_week << ',' << toe_ms << ','
+         << glo.gps_glonass_time_offset_sec << ',' << glo.calendar_day_number << ",0,0," << glo.iode << ',' << glo.svh
+         << ',' << std::scientific << std::setprecision(15) << glo.position_ecef_m[0] << ',' << glo.position_ecef_m[1] << ','
+         << glo.position_ecef_m[2] << ',' << glo.velocity_ecef_mps[0] << ',' << glo.velocity_ecef_mps[1] << ','
+         << glo.velocity_ecef_mps[2] << ',' << glo.acceleration_ecef_mps2[0] << ',' << glo.acceleration_ecef_mps2[1] << ','
+         << glo.acceleration_ecef_mps2[2] << ',' << glo.clock_bias_sec << ',' << glo.relative_frequency_bias << ','
+         << glo.differential_delay_sec << ',' << std::fixed << std::setprecision(0) << glo.frame_time_glonass_day_sec << ','
+         << glo.flags << ',' << glo.sva << ',' << glo.age_days << ',' << glo.flags;
+    return body.str();
+}
+
+std::string legacy_ion_body(const IonosphereNavOutputData& ion) {
+    std::ostringstream body;
+    body.imbue(std::locale::classic());
+    body << std::scientific << std::setprecision(15);
+    for (int index = 0; index < 8; ++index) {
+        if (index != 0) {
+            body << ',';
+        }
+        body << ion.coefficients[index];
+    }
+    const std::int64_t transmit_ms = static_cast<std::int64_t>(std::llround(ion.transmit_sow_sec * 1000.0));
+    body << ',' << ion.prn << ',' << std::dec << ion.transmit_week << ',' << transmit_ms << ",0";
+    return body.str();
+}
+
+std::string bd3_ion_body(const IonosphereNavOutputData& ion) {
+    std::ostringstream body;
+    body.imbue(std::locale::classic());
+    body << std::scientific << std::setprecision(15);
+    for (int index = 0; index < 9; ++index) {
+        if (index != 0) {
+            body << ',';
+        }
+        body << ion.coefficients[index];
+    }
+    body << ',' << std::fixed << std::setprecision(0) << ion.region;
+    return body.str();
+}
+
+std::string galileo_ion_body(const IonosphereNavOutputData& ion) {
+    std::ostringstream body;
+    body.imbue(std::locale::classic());
+    body << std::scientific << std::setprecision(15) << ion.coefficients[0] << ',' << ion.coefficients[1] << ','
+         << ion.coefficients[2] << ",0,0,0,0,0,0";
+    return body.str();
+}
+
+} // namespace
+
+bool format_unicore_nav_output_record(const NavOutputRecord& source, const SimTime& output_time, std::string* message,
+                                      bool* supported, std::string* error_message) {
+    if (message == nullptr || supported == nullptr) {
+        set_error(error_message, "Unicore NAV writer request has invalid arguments");
+        return false;
+    }
+    *supported = false;
+    message->clear();
+    NavOutputRecord record = source;
+    if (!finalize_nav_output_record_metadata(&record)) {
+        set_error(error_message, "cannot finalize Unicore NAV output metadata");
+        return false;
+    }
+
+    const char* log_name = nullptr;
+    std::string body;
+    if (record.kind == RtklibNavRecordKind::kGlonassEphemeris) {
+        log_name = "GLOEPHA";
+        body = glonass_body(record.glonass);
+    } else if (record.kind == RtklibNavRecordKind::kEphemeris) {
+        const KeplerianNavOutputData& eph = record.ephemeris;
+        switch (eph.system) {
+            case NavOutputSystem::kGps:
+                log_name = "GPSEPHA";
+                body = legacy_kepler_body(eph, false);
+                break;
+            case NavOutputSystem::kQzss:
+                log_name = "QZSSEPHA";
+                body = legacy_kepler_body(eph, false);
+                break;
+            case NavOutputSystem::kGalileo:
+                log_name = "GALEPHA";
+                body = galileo_body(eph);
+                break;
+            case NavOutputSystem::kBeidou:
+                if (modern_bds(eph)) {
+                    log_name = "BD3EPHA";
+                    body = bd3_ephemeris_body(eph);
+                } else {
+                    log_name = "BDSEPHA";
+                    body = legacy_kepler_body(eph, true);
+                }
+                break;
+            case NavOutputSystem::kNavic:
+                log_name = "IRNSSEPHA";
+                body = legacy_kepler_body(eph, false);
+                break;
+            default:
+                break;
+        }
+    } else if (record.kind == RtklibNavRecordKind::kIonosphere) {
+        const IonosphereNavOutputData& ion = record.ionosphere;
+        if (ion.system == NavOutputSystem::kGps && ion.coefficient_count >= 8) {
+            log_name = "GPSIONA";
+            body = legacy_ion_body(ion);
+        } else if (ion.system == NavOutputSystem::kBeidou && ion.coefficient_count >= 9 && !ion.legacy_metadata) {
+            log_name = "BD3IONA";
+            body = bd3_ion_body(ion);
+        } else if (ion.system == NavOutputSystem::kBeidou && ion.coefficient_count >= 8) {
+            log_name = "BDSIONA";
+            body = legacy_ion_body(ion);
+        } else if (ion.system == NavOutputSystem::kGalileo && ion.coefficient_count >= 3) {
+            log_name = "GALIONA";
+            body = galileo_ion_body(ion);
+        }
+    }
+
+    if (log_name == nullptr) {
+        return true;
+    }
+    if (!unicore_ascii::frame(log_name, output_time, body, message)) {
+        set_error(error_message, "Unicore NAV header time cannot be represented");
+        return false;
+    }
+    *supported = true;
+    return true;
+}
+
+bool format_unicore_receiver_nav_record(const RtklibNavStore* receiver_nav, int output_record_index,
+                                        const SimTime& output_time, std::string* message, bool* supported,
+                                        std::string* error_message) {
+    NavOutputRecord record{};
+    if (!rtklib_nav_output_record(receiver_nav, output_record_index, &record, error_message)) {
+        return false;
+    }
+    return format_unicore_nav_output_record(record, output_time, message, supported, error_message);
+}
+
+} // namespace gnss_sim

--- a/src/output/unicore_nav_writer.h
+++ b/src/output/unicore_nav_writer.h
@@ -1,0 +1,19 @@
+#ifndef GNSS_SIM_SRC_OUTPUT_UNICORE_NAV_WRITER_H_
+#define GNSS_SIM_SRC_OUTPUT_UNICORE_NAV_WRITER_H_
+
+#include "gnss/nav_output_record.h"
+#include "gnss_sim/sim_types.h"
+
+#include <string>
+
+namespace gnss_sim {
+
+bool format_unicore_nav_output_record(const NavOutputRecord& record, const SimTime& output_time, std::string* message,
+                                      bool* supported, std::string* error_message);
+bool format_unicore_receiver_nav_record(const RtklibNavStore* receiver_nav, int output_record_index,
+                                        const SimTime& output_time, std::string* message, bool* supported,
+                                        std::string* error_message);
+
+} // namespace gnss_sim
+
+#endif // GNSS_SIM_SRC_OUTPUT_UNICORE_NAV_WRITER_H_

--- a/tests/unit/test_nav_output_writers.cpp
+++ b/tests/unit/test_nav_output_writers.cpp
@@ -7,9 +7,9 @@
 #include "output/novatel_nav_writer.h"
 #include "output/unicore_nav_writer.h"
 
-#include <gtest/gtest.h>
-
 #include <cstdint>
+#include <cstdlib>
+#include <gtest/gtest.h>
 #include <set>
 #include <string>
 #include <vector>
@@ -39,7 +39,7 @@ bool valid_ascii_crc(const std::string& message) {
         return false;
     }
     const std::size_t star = message.rfind('*');
-    if (star == std::string::npos || star + 10 != message.size()) {
+    if (star == std::string::npos || star + 11 != message.size()) {
         return false;
     }
     const std::string payload = message.substr(1, star - 1);
@@ -59,15 +59,17 @@ void collect_supported_names(const gnss_sim::RtklibNavStore* store, bool unicore
         std::string second;
         bool first_supported = false;
         bool second_supported = false;
-        const bool first_ok = unicore ? gnss_sim::format_unicore_receiver_nav_record(
-                                           store, index, output_time(), &first, &first_supported, &error_message)
-                                     : gnss_sim::format_novatel_receiver_nav_record(
-                                           store, index, output_time(), &first, &first_supported, &error_message);
+        const bool first_ok = unicore
+                                  ? gnss_sim::format_unicore_receiver_nav_record(store, index, output_time(), &first,
+                                                                                 &first_supported, &error_message)
+                                  : gnss_sim::format_novatel_receiver_nav_record(store, index, output_time(), &first,
+                                                                                 &first_supported, &error_message);
         ASSERT_TRUE(first_ok) << error_message;
-        const bool second_ok = unicore ? gnss_sim::format_unicore_receiver_nav_record(
-                                            store, index, output_time(), &second, &second_supported, &error_message)
-                                      : gnss_sim::format_novatel_receiver_nav_record(
-                                            store, index, output_time(), &second, &second_supported, &error_message);
+        const bool second_ok = unicore
+                                   ? gnss_sim::format_unicore_receiver_nav_record(store, index, output_time(), &second,
+                                                                                  &second_supported, &error_message)
+                                   : gnss_sim::format_novatel_receiver_nav_record(store, index, output_time(), &second,
+                                                                                  &second_supported, &error_message);
         ASSERT_TRUE(second_ok) << error_message;
         EXPECT_EQ(first_supported, second_supported);
         EXPECT_EQ(first, second);
@@ -79,7 +81,7 @@ void collect_supported_names(const gnss_sim::RtklibNavStore* store, bool unicore
 }
 
 gnss_sim::NavOutputRecord synthetic_ephemeris(gnss_sim::NavOutputSystem system,
-                                                gnss_sim::RtklibBroadcastMessageFamily family) {
+                                               gnss_sim::RtklibBroadcastMessageFamily family) {
     gnss_sim::NavOutputRecord record{};
     record.kind = gnss_sim::RtklibNavRecordKind::kEphemeris;
     record.ephemeris.system = system;
@@ -185,8 +187,8 @@ TEST(NavOutputWriter, ColdUsesReceiverAvailabilityAndSuppressesDuplicateDelivery
     std::string message;
     bool supported = false;
     ASSERT_TRUE(gnss_sim::format_novatel_receiver_nav_record(gnss_sim::receiver_navigation_store(state),
-                                                             event.receiver_record_index, available, &message, &supported,
-                                                             &error_message))
+                                                             event.receiver_record_index, available, &message,
+                                                             &supported, &error_message))
         << error_message;
     EXPECT_TRUE(supported);
     EXPECT_EQ(log_name(message), "GPSEPHEMA");
@@ -218,7 +220,7 @@ TEST(NavOutputWriter, HotAndWarmRestoreTheSameDeterministicReceiverNavBytes) {
             std::string message;
             bool supported = false;
             ASSERT_TRUE(gnss_sim::format_unicore_receiver_nav_record(receiver, index, startup, &message, &supported,
-                                                                      &error_message))
+                                                                     &error_message))
                 << error_message;
             if (supported) {
                 current.push_back(message);
@@ -239,8 +241,8 @@ TEST(NavOutputWriter, SyntheticModernBdsAndNavicStayWithinFrozenOutputScope) {
     std::string error_message;
     bool supported = false;
 
-    gnss_sim::NavOutputRecord bds = synthetic_ephemeris(gnss_sim::NavOutputSystem::kBeidou,
-                                                         gnss_sim::RtklibBroadcastMessageFamily::kBeidouBcnav1);
+    gnss_sim::NavOutputRecord bds =
+        synthetic_ephemeris(gnss_sim::NavOutputSystem::kBeidou, gnss_sim::RtklibBroadcastMessageFamily::kBeidouBcnav1);
     ASSERT_TRUE(gnss_sim::format_unicore_nav_output_record(bds, output_time(), &message, &supported, &error_message))
         << error_message;
     EXPECT_TRUE(supported);
@@ -251,8 +253,8 @@ TEST(NavOutputWriter, SyntheticModernBdsAndNavicStayWithinFrozenOutputScope) {
     EXPECT_FALSE(supported);
     EXPECT_TRUE(message.empty());
 
-    gnss_sim::NavOutputRecord navic = synthetic_ephemeris(gnss_sim::NavOutputSystem::kNavic,
-                                                           gnss_sim::RtklibBroadcastMessageFamily::kLegacy);
+    gnss_sim::NavOutputRecord navic =
+        synthetic_ephemeris(gnss_sim::NavOutputSystem::kNavic, gnss_sim::RtklibBroadcastMessageFamily::kLegacy);
     ASSERT_TRUE(gnss_sim::format_unicore_nav_output_record(navic, output_time(), &message, &supported, &error_message))
         << error_message;
     EXPECT_TRUE(supported);
@@ -277,11 +279,10 @@ TEST(NavOutputWriter, Bd3IonHasByteLevelGoldenRecord) {
     ASSERT_TRUE(gnss_sim::format_unicore_nav_output_record(record, output_time(), &message, &supported, &error_message))
         << error_message;
     ASSERT_TRUE(supported);
-    EXPECT_EQ(message,
-              "#BD3IONA,0,GPS,FINE,2041,180000000,0,0,18,0;"
-              "0.000000000000000e+00,0.000000000000000e+00,0.000000000000000e+00,"
-              "0.000000000000000e+00,0.000000000000000e+00,0.000000000000000e+00,"
-              "0.000000000000000e+00,0.000000000000000e+00,0.000000000000000e+00,0*bdf5809e\r\n");
+    EXPECT_EQ(message, "#BD3IONA,0,GPS,FINE,2041,180000000,0,0,18,0;"
+                       "0.000000000000000e+00,0.000000000000000e+00,0.000000000000000e+00,"
+                       "0.000000000000000e+00,0.000000000000000e+00,0.000000000000000e+00,"
+                       "0.000000000000000e+00,0.000000000000000e+00,0.000000000000000e+00,0*bdf5809e\r\n");
 }
 
 TEST(NavOutputWriter, GalileoHealthBitsAreDecodedBeforeSerialization) {

--- a/tests/unit/test_nav_output_writers.cpp
+++ b/tests/unit/test_nav_output_writers.cpp
@@ -1,0 +1,300 @@
+#include "gnss/nav_output_record.h"
+#include "gnss/navigation_state.h"
+#include "gnss/rtklib_adapter.h"
+#include "gnss/signal_definitions.h"
+#include "gnss_sim/sim_time.h"
+#include "output/novatel_ascii.h"
+#include "output/novatel_nav_writer.h"
+#include "output/unicore_nav_writer.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::string data_path(const char* name) {
+    return std::string(GNSS_SIM_TEST_DATA_DIR) + "/" + name;
+}
+
+gnss_sim::SimTime output_time() {
+    gnss_sim::SimTime result{};
+    EXPECT_TRUE(gnss_sim::sim_time_from_week_sow(2041, 180000.0, &result));
+    return result;
+}
+
+std::string log_name(const std::string& message) {
+    if (message.empty() || message[0] != '#') {
+        return {};
+    }
+    const std::size_t comma = message.find(',');
+    return comma == std::string::npos ? std::string{} : message.substr(1, comma - 1);
+}
+
+bool valid_ascii_crc(const std::string& message) {
+    if (message.size() < 12 || message[0] != '#' || message.substr(message.size() - 2) != "\r\n") {
+        return false;
+    }
+    const std::size_t star = message.rfind('*');
+    if (star == std::string::npos || star + 10 != message.size()) {
+        return false;
+    }
+    const std::string payload = message.substr(1, star - 1);
+    const std::string crc_text = message.substr(star + 1, 8);
+    char* end = nullptr;
+    const unsigned long parsed = std::strtoul(crc_text.c_str(), &end, 16);
+    return end != nullptr && *end == '\0' && parsed == gnss_sim::novatel_ascii::crc32(payload);
+}
+
+void collect_supported_names(const gnss_sim::RtklibNavStore* store, bool unicore, std::set<std::string>* names) {
+    ASSERT_NE(store, nullptr);
+    ASSERT_NE(names, nullptr);
+    std::string error_message;
+    const int count = gnss_sim::rtklib_nav_output_record_count(store);
+    for (int index = 0; index < count; ++index) {
+        std::string first;
+        std::string second;
+        bool first_supported = false;
+        bool second_supported = false;
+        const bool first_ok = unicore ? gnss_sim::format_unicore_receiver_nav_record(
+                                           store, index, output_time(), &first, &first_supported, &error_message)
+                                     : gnss_sim::format_novatel_receiver_nav_record(
+                                           store, index, output_time(), &first, &first_supported, &error_message);
+        ASSERT_TRUE(first_ok) << error_message;
+        const bool second_ok = unicore ? gnss_sim::format_unicore_receiver_nav_record(
+                                            store, index, output_time(), &second, &second_supported, &error_message)
+                                      : gnss_sim::format_novatel_receiver_nav_record(
+                                            store, index, output_time(), &second, &second_supported, &error_message);
+        ASSERT_TRUE(second_ok) << error_message;
+        EXPECT_EQ(first_supported, second_supported);
+        EXPECT_EQ(first, second);
+        if (first_supported) {
+            EXPECT_TRUE(valid_ascii_crc(first));
+            names->insert(log_name(first));
+        }
+    }
+}
+
+gnss_sim::NavOutputRecord synthetic_ephemeris(gnss_sim::NavOutputSystem system,
+                                                gnss_sim::RtklibBroadcastMessageFamily family) {
+    gnss_sim::NavOutputRecord record{};
+    record.kind = gnss_sim::RtklibNavRecordKind::kEphemeris;
+    record.ephemeris.system = system;
+    record.ephemeris.message_family = family;
+    record.ephemeris.prn = 2;
+    record.ephemeris.iode = 3;
+    record.ephemeris.iodc = 4;
+    record.ephemeris.sva = 1.0;
+    record.ephemeris.toe_week = 2041;
+    record.ephemeris.toc_week = 2041;
+    record.ephemeris.transmit_week = 2041;
+    record.ephemeris.toe_sow_sec = 180000.0;
+    record.ephemeris.toc_sow_sec = 180000.0;
+    record.ephemeris.transmit_sow_sec = 180006.0;
+    record.ephemeris.semi_major_axis_m = 26560000.0;
+    record.ephemeris.eccentricity = 0.01;
+    record.ephemeris.inclination_rad = 0.95;
+    record.ephemeris.omega0_rad = 1.0;
+    record.ephemeris.argument_of_perigee_rad = 0.2;
+    record.ephemeris.mean_anomaly_rad = 0.3;
+    record.ephemeris.delta_mean_motion_radps = 1.0e-9;
+    record.ephemeris.omega_dot_radps = -8.0e-9;
+    record.ephemeris.inclination_dot_radps = 1.0e-10;
+    record.ephemeris.clock_bias_sec = 1.0e-4;
+    record.ephemeris.clock_drift_sec_per_sec = 2.0e-12;
+    record.ephemeris.tgd_sec[0] = 1.0e-9;
+    record.ephemeris.tgd_sec[1] = 2.0e-9;
+    record.ephemeris.galileo_fnav_received = true;
+    record.ephemeris.galileo_inav_received = true;
+    record.ephemeris.galileo_fnav_toc_sow_sec = 180000.0;
+    record.ephemeris.galileo_inav_toc_sow_sec = 180000.0;
+    return record;
+}
+
+TEST(NavOutputWriter, LegacyMixedRinexCoversFiveEphemerisFamilies) {
+    gnss_sim::RtklibNavStore* store = gnss_sim::create_rtklib_nav_store();
+    ASSERT_NE(store, nullptr);
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::load_rinex_nav_file(store, data_path("mixed_nav_2019.rnx").c_str(), &error_message))
+        << error_message;
+
+    std::set<std::string> novatel_names;
+    std::set<std::string> unicore_names;
+    collect_supported_names(store, false, &novatel_names);
+    collect_supported_names(store, true, &unicore_names);
+
+    EXPECT_TRUE(novatel_names.count("GPSEPHEMA"));
+    EXPECT_TRUE(novatel_names.count("GLOEPHEMERISA"));
+    EXPECT_TRUE(novatel_names.count("GALEPHEMERISA"));
+    EXPECT_TRUE(novatel_names.count("BD2EPHEMA"));
+    EXPECT_TRUE(novatel_names.count("QZSSEPHEMERISA"));
+    EXPECT_TRUE(unicore_names.count("GPSEPHA"));
+    EXPECT_TRUE(unicore_names.count("GLOEPHA"));
+    EXPECT_TRUE(unicore_names.count("GALEPHA"));
+    EXPECT_TRUE(unicore_names.count("BDSEPHA"));
+    EXPECT_TRUE(unicore_names.count("QZSSEPHA"));
+
+    gnss_sim::destroy_rtklib_nav_store(store);
+}
+
+TEST(NavOutputWriter, LegacyIonosphereMetadataMapsToFrozenFamilies) {
+    gnss_sim::RtklibNavStore* store = gnss_sim::create_rtklib_nav_store();
+    ASSERT_NE(store, nullptr);
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::load_rinex_nav_file(store, data_path("ionosphere_nav_2019.rnx").c_str(), &error_message))
+        << error_message;
+
+    std::set<std::string> novatel_names;
+    std::set<std::string> unicore_names;
+    collect_supported_names(store, false, &novatel_names);
+    collect_supported_names(store, true, &unicore_names);
+    EXPECT_TRUE(novatel_names.count("IONUTCA"));
+    EXPECT_TRUE(novatel_names.count("BD2IONUTCA"));
+    EXPECT_TRUE(unicore_names.count("GPSIONA"));
+    EXPECT_TRUE(unicore_names.count("BDSIONA"));
+    EXPECT_TRUE(unicore_names.count("GALIONA"));
+
+    gnss_sim::destroy_rtklib_nav_store(store);
+}
+
+TEST(NavOutputWriter, ColdUsesReceiverAvailabilityAndSuppressesDuplicateDelivery) {
+    gnss_sim::NavigationState* state = gnss_sim::create_navigation_state();
+    ASSERT_NE(state, nullptr);
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::load_truth_navigation(state, data_path("nav_updates_2019.rnx").c_str(), &error_message))
+        << error_message;
+
+    gnss_sim::SimTime startup{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2041, 179000.0, &startup));
+    ASSERT_TRUE(gnss_sim::initialize_receiver_navigation(state, gnss_sim::StartupMode::COLD, startup, &error_message))
+        << error_message;
+    EXPECT_EQ(gnss_sim::rtklib_nav_output_record_count(gnss_sim::receiver_navigation_store(state)), 0);
+
+    gnss_sim::SimTime available{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2041, 179020.0, &available));
+    gnss_sim::NavigationUpdateEvent event{};
+    bool emitted = false;
+    ASSERT_TRUE(gnss_sim::apply_truth_navigation_record(state, 0, available, &event, &emitted, &error_message))
+        << error_message;
+    ASSERT_TRUE(emitted);
+    EXPECT_EQ(event.receiver_record_index, 0);
+
+    std::string message;
+    bool supported = false;
+    ASSERT_TRUE(gnss_sim::format_novatel_receiver_nav_record(gnss_sim::receiver_navigation_store(state),
+                                                             event.receiver_record_index, available, &message, &supported,
+                                                             &error_message))
+        << error_message;
+    EXPECT_TRUE(supported);
+    EXPECT_EQ(log_name(message), "GPSEPHEMA");
+    EXPECT_TRUE(valid_ascii_crc(message));
+
+    emitted = true;
+    ASSERT_TRUE(gnss_sim::apply_truth_navigation_record(state, 0, available, &event, &emitted, &error_message))
+        << error_message;
+    EXPECT_FALSE(emitted);
+    EXPECT_EQ(gnss_sim::rtklib_nav_output_record_count(gnss_sim::receiver_navigation_store(state)), 1);
+    gnss_sim::destroy_navigation_state(state);
+}
+
+TEST(NavOutputWriter, HotAndWarmRestoreTheSameDeterministicReceiverNavBytes) {
+    std::vector<std::string> baseline;
+    for (const gnss_sim::StartupMode mode : {gnss_sim::StartupMode::HOT, gnss_sim::StartupMode::WARM}) {
+        gnss_sim::NavigationState* state = gnss_sim::create_navigation_state();
+        ASSERT_NE(state, nullptr);
+        std::string error_message;
+        ASSERT_TRUE(gnss_sim::load_truth_navigation(state, data_path("mixed_nav_2019.rnx").c_str(), &error_message))
+            << error_message;
+        gnss_sim::SimTime startup{};
+        ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2041, 300000.0, &startup));
+        ASSERT_TRUE(gnss_sim::initialize_receiver_navigation(state, mode, startup, &error_message)) << error_message;
+
+        std::vector<std::string> current;
+        const gnss_sim::RtklibNavStore* receiver = gnss_sim::receiver_navigation_store(state);
+        for (int index = 0; index < gnss_sim::rtklib_nav_output_record_count(receiver); ++index) {
+            std::string message;
+            bool supported = false;
+            ASSERT_TRUE(gnss_sim::format_unicore_receiver_nav_record(receiver, index, startup, &message, &supported,
+                                                                      &error_message))
+                << error_message;
+            if (supported) {
+                current.push_back(message);
+            }
+        }
+        if (baseline.empty()) {
+            baseline = current;
+        } else {
+            EXPECT_EQ(current, baseline);
+        }
+        gnss_sim::destroy_navigation_state(state);
+    }
+    EXPECT_FALSE(baseline.empty());
+}
+
+TEST(NavOutputWriter, SyntheticModernBdsAndNavicStayWithinFrozenOutputScope) {
+    std::string message;
+    std::string error_message;
+    bool supported = false;
+
+    gnss_sim::NavOutputRecord bds = synthetic_ephemeris(gnss_sim::NavOutputSystem::kBeidou,
+                                                         gnss_sim::RtklibBroadcastMessageFamily::kBeidouBcnav1);
+    ASSERT_TRUE(gnss_sim::format_unicore_nav_output_record(bds, output_time(), &message, &supported, &error_message))
+        << error_message;
+    EXPECT_TRUE(supported);
+    EXPECT_EQ(log_name(message), "BD3EPHA");
+    EXPECT_TRUE(valid_ascii_crc(message));
+    ASSERT_TRUE(gnss_sim::format_novatel_nav_output_record(bds, output_time(), &message, &supported, &error_message))
+        << error_message;
+    EXPECT_FALSE(supported);
+    EXPECT_TRUE(message.empty());
+
+    gnss_sim::NavOutputRecord navic = synthetic_ephemeris(gnss_sim::NavOutputSystem::kNavic,
+                                                           gnss_sim::RtklibBroadcastMessageFamily::kLegacy);
+    ASSERT_TRUE(gnss_sim::format_unicore_nav_output_record(navic, output_time(), &message, &supported, &error_message))
+        << error_message;
+    EXPECT_TRUE(supported);
+    EXPECT_EQ(log_name(message), "IRNSSEPHA");
+    EXPECT_TRUE(valid_ascii_crc(message));
+
+    std::size_t signal_count = 0;
+    gnss_sim::signal_definitions(&signal_count);
+    EXPECT_EQ(signal_count, 21U);
+}
+
+TEST(NavOutputWriter, Bd3IonHasByteLevelGoldenRecord) {
+    gnss_sim::NavOutputRecord record{};
+    record.kind = gnss_sim::RtklibNavRecordKind::kIonosphere;
+    record.ionosphere.system = gnss_sim::NavOutputSystem::kBeidou;
+    record.ionosphere.coefficient_count = 9;
+    record.ionosphere.legacy_metadata = false;
+
+    std::string message;
+    std::string error_message;
+    bool supported = false;
+    ASSERT_TRUE(gnss_sim::format_unicore_nav_output_record(record, output_time(), &message, &supported, &error_message))
+        << error_message;
+    ASSERT_TRUE(supported);
+    EXPECT_EQ(message,
+              "#BD3IONA,0,GPS,FINE,2041,180000000,0,0,18,0;"
+              "0.000000000000000e+00,0.000000000000000e+00,0.000000000000000e+00,"
+              "0.000000000000000e+00,0.000000000000000e+00,0.000000000000000e+00,"
+              "0.000000000000000e+00,0.000000000000000e+00,0.000000000000000e+00,0*bdf5809e\r\n");
+}
+
+TEST(NavOutputWriter, GalileoHealthBitsAreDecodedBeforeSerialization) {
+    gnss_sim::NavOutputRecord record =
+        synthetic_ephemeris(gnss_sim::NavOutputSystem::kGalileo, gnss_sim::RtklibBroadcastMessageFamily::kGalileoInav);
+    record.ephemeris.svh = (1 << 0) | (2 << 1) | (1 << 3) | (3 << 4) | (0 << 6) | (1 << 7);
+    ASSERT_TRUE(gnss_sim::finalize_nav_output_record_metadata(&record));
+    EXPECT_EQ(record.ephemeris.galileo_e1b_dvs, 1);
+    EXPECT_EQ(record.ephemeris.galileo_e1b_health, 2);
+    EXPECT_EQ(record.ephemeris.galileo_e5a_dvs, 1);
+    EXPECT_EQ(record.ephemeris.galileo_e5a_health, 3);
+    EXPECT_EQ(record.ephemeris.galileo_e5b_dvs, 0);
+    EXPECT_EQ(record.ephemeris.galileo_e5b_health, 1);
+}
+
+} // namespace

--- a/tests/unit/test_nav_output_writers.cpp
+++ b/tests/unit/test_nav_output_writers.cpp
@@ -81,7 +81,7 @@ void collect_supported_names(const gnss_sim::RtklibNavStore* store, bool unicore
 }
 
 gnss_sim::NavOutputRecord synthetic_ephemeris(gnss_sim::NavOutputSystem system,
-                                               gnss_sim::RtklibBroadcastMessageFamily family) {
+                                              gnss_sim::RtklibBroadcastMessageFamily family) {
     gnss_sim::NavOutputRecord record{};
     record.kind = gnss_sim::RtklibNavRecordKind::kEphemeris;
     record.ephemeris.system = system;


### PR DESCRIPTION
Closes #14.

## Summary
- add a normalized Receiver-NAV output projection so NovAtel and Unicore writers never parse RINEX or touch `eph_t/geph_t/ion_t` directly;
- serialize frozen NovAtel OEM7 EPH/ION families and Unicore N4 EPH/ION families from the same normalized Receiver NAV records;
- add `NavigationUpdateEvent::receiver_record_index` so COLD/runtime update serialization reads the exact record after it is accepted into Receiver NAV;
- expose legacy RINEX-header ionosphere/UTC metadata as normalized output records when no explicit RINEX 4 ION record supersedes them;
- decode Galileo E1B/E5a/E5b DVS/health bits using the pinned RTKLIB RINEX health-word layout;
- keep derived protocol metadata (`sqrt(A)`, corrected mean motion, GLONASS slot/frequency offsets and GLONASS time metadata) outside writer code;
- add deterministic NovAtel and Unicore ASCII framing/CRC coverage, COLD no-early-EPH and duplicate-delivery coverage, HOT/WARM byte determinism, legacy five-constellation EPH coverage, legacy ION coverage, modern BDS/BD3ION and IRNSSEPH scope checks.

## Implementation Notes
The writers are formatting layers only. Truth NAV is never supplied to a writer for COLD/runtime emission; an emitted update carries a Receiver NAV record index after the record has been copied into Receiver NAV.

`docs/NAV_WRITER_FIELDS.md` documents field provenance and the rule for unsupported/missing fields. Per-signal Galileo health/DVS is decoded from RTKLIB's packed `svh` rather than filled with synthetic healthy values. Reserved/not-modeled protocol fields are deterministic zero only where documented as reserved/not modeled.

NovAtel V1 intentionally emits legacy BeiDou through `BD2EPHEMA/BD2IONUTCA`; modern B-CNAV records are not silently converted to a non-frozen NovAtel family. Unicore maps B-CNAV1/2/3 to `BD3EPHA` with the corresponding frequency type. `IRNSSEPHA` serialization does not add NavIC observations to the frozen 21-signal RANGE set.

Full clang-format + Ubuntu/GCC + Windows/MSVC CI must pass before merge.