### PR TITLE
Implement streaming simulator loop and KS/REA/TTFF scenarios

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ add_library(gnss_sim_core STATIC
     src/output/novatel_range_writer.cpp
     src/output/novatel_solution_writer.cpp
     src/output/unicore_nav_writer.cpp
+    src/scenario/scenario_engine.cpp
     src/solution/solution_engine.cpp
 )
 add_library(gnss_sim::core ALIAS gnss_sim_core)
@@ -136,6 +137,7 @@ if(BUILD_TESTING)
         tests/unit/test_receiver_truth.cpp
         tests/unit/test_rtklib_adapter.cpp
         tests/unit/test_satellite_engine.cpp
+        tests/unit/test_scenario_engine.cpp
         tests/unit/test_signal_definitions.cpp
         tests/unit/test_signal_tracking.cpp
         tests/unit/test_sim_config.cpp
@@ -154,8 +156,23 @@ if(BUILD_TESTING)
     )
     gnss_sim_set_project_warnings(gnss_sim_unit_tests)
 
+    add_executable(gnss_sim_integration_tests
+        tests/integration/test_scenarios.cpp
+    )
+    target_include_directories(gnss_sim_integration_tests PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/src")
+    target_compile_definitions(gnss_sim_integration_tests PRIVATE
+        GNSS_SIM_TEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/tests/data/minimal")
+    target_link_libraries(gnss_sim_integration_tests PRIVATE
+        gnss_sim::core
+        gnss_sim::rtklib
+        GTest::gtest_main
+    )
+    gnss_sim_set_project_warnings(gnss_sim_integration_tests)
+
     include(GoogleTest)
     gtest_discover_tests(gnss_sim_unit_tests)
+    gtest_discover_tests(gnss_sim_integration_tests)
 
     add_test(
         NAME measurement_model_no_prng

--- a/include/gnss_sim/simulator.h
+++ b/include/gnss_sim/simulator.h
@@ -1,7 +1,40 @@
 #ifndef GNSS_SIM_SIMULATOR_H_
 #define GNSS_SIM_SIMULATOR_H_
 
+#include "gnss_sim/sim_config.h"
+#include "gnss_sim/sim_types.h"
+
+#include <cstdint>
+#include <string>
+
 namespace gnss_sim {
+
+struct SimulatorRunOptions {
+    const char* rinex_nav_path;
+    const char* output_log_path;
+    SimTime start_time;
+};
+
+struct SimulatorRunSummary {
+    std::uint64_t scheduled_epochs;
+    std::uint64_t powered_epochs;
+    std::uint64_t signal_on_epochs;
+    std::uint64_t signal_off_epochs;
+    std::uint64_t range_messages;
+    std::uint64_t psrpos_messages;
+    std::uint64_t psrvel_messages;
+    std::uint64_t nav_messages;
+    std::uint64_t power_on_events;
+    std::uint64_t power_off_events;
+    std::uint64_t signal_on_events;
+    std::uint64_t signal_off_events;
+    std::uint64_t valid_position_epochs;
+    std::uint64_t valid_velocity_epochs;
+    int max_observations_per_epoch;
+};
+
+bool run_simulator(const SimConfig& config, const SimulatorRunOptions& options, SimulatorRunSummary* summary,
+                   std::string* error_message);
 
 const char* simulator_version();
 const char* rtklib_commit_sha();

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1,9 +1,125 @@
+#include "gnss_sim/sim_config.h"
+#include "gnss_sim/sim_time.h"
 #include "gnss_sim/simulator.h"
 
+#include <cerrno>
+#include <climits>
+#include <cstdlib>
+#include <cstring>
 #include <iostream>
+#include <string>
 
-int main() {
-    std::cout << "gnss-data-simulator " << gnss_sim::simulator_version() << '\n';
-    std::cout << "RTKLIB commit: " << gnss_sim::rtklib_commit_sha() << '\n';
+namespace {
+
+void print_usage(const char* program) {
+    std::cerr << "Usage:\n  " << program
+              << " --config <config.json> --nav <input.rnx> --output <simulated.log> --week <gps-week> --sow <seconds>\n";
+}
+
+bool parse_int(const char* text, int* value) {
+    if (text == nullptr || value == nullptr || text[0] == '\0') {
+        return false;
+    }
+    errno = 0;
+    char* end = nullptr;
+    const long parsed = std::strtol(text, &end, 10);
+    if (errno != 0 || end == text || *end != '\0' || parsed < 0 || parsed > INT_MAX) {
+        return false;
+    }
+    *value = static_cast<int>(parsed);
+    return true;
+}
+
+bool parse_double(const char* text, double* value) {
+    if (text == nullptr || value == nullptr || text[0] == '\0') {
+        return false;
+    }
+    errno = 0;
+    char* end = nullptr;
+    const double parsed = std::strtod(text, &end);
+    if (errno != 0 || end == text || *end != '\0') {
+        return false;
+    }
+    *value = parsed;
+    return true;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    const char* config_path = nullptr;
+    const char* nav_path = nullptr;
+    const char* output_path = nullptr;
+    int gps_week = -1;
+    double sow_sec = -1.0;
+
+    if (argc == 2 && (std::strcmp(argv[1], "--version") == 0 || std::strcmp(argv[1], "-v") == 0)) {
+        std::cout << "gnss-data-simulator " << gnss_sim::simulator_version() << '\n';
+        std::cout << "RTKLIB commit: " << gnss_sim::rtklib_commit_sha() << '\n';
+        return 0;
+    }
+
+    for (int index = 1; index < argc; ++index) {
+        if (std::strcmp(argv[index], "--help") == 0 || std::strcmp(argv[index], "-h") == 0) {
+            print_usage(argv[0]);
+            return 0;
+        }
+        if (index + 1 >= argc) {
+            print_usage(argv[0]);
+            return 2;
+        }
+        const char* value = argv[++index];
+        if (std::strcmp(argv[index - 1], "--config") == 0) {
+            config_path = value;
+        } else if (std::strcmp(argv[index - 1], "--nav") == 0) {
+            nav_path = value;
+        } else if (std::strcmp(argv[index - 1], "--output") == 0) {
+            output_path = value;
+        } else if (std::strcmp(argv[index - 1], "--week") == 0) {
+            if (!parse_int(value, &gps_week)) {
+                std::cerr << "ERROR: --week must be a non-negative integer\n";
+                return 2;
+            }
+        } else if (std::strcmp(argv[index - 1], "--sow") == 0) {
+            if (!parse_double(value, &sow_sec)) {
+                std::cerr << "ERROR: --sow must be a finite GPS second-of-week value\n";
+                return 2;
+            }
+        } else {
+            std::cerr << "ERROR: unknown option " << argv[index - 1] << '\n';
+            print_usage(argv[0]);
+            return 2;
+        }
+    }
+
+    if (config_path == nullptr || nav_path == nullptr || output_path == nullptr || gps_week < 0 || sow_sec < 0.0) {
+        print_usage(argv[0]);
+        return 2;
+    }
+
+    gnss_sim::SimConfig config{};
+    std::string error_message;
+    if (!gnss_sim::load_sim_config_json(config_path, &config, &error_message)) {
+        std::cerr << "ERROR: " << error_message << '\n';
+        return 1;
+    }
+    gnss_sim::SimTime start_time{};
+    if (!gnss_sim::sim_time_from_week_sow(gps_week, sow_sec, &start_time)) {
+        std::cerr << "ERROR: --sow must be within the GPS week\n";
+        return 2;
+    }
+
+    const gnss_sim::SimulatorRunOptions options{nav_path, output_path, start_time};
+    gnss_sim::SimulatorRunSummary summary{};
+    if (!gnss_sim::run_simulator(config, options, &summary, &error_message)) {
+        std::cerr << "ERROR: " << error_message << '\n';
+        return 1;
+    }
+
+    std::cout << "scenario=" << gnss_sim::scenario_type_name(config.scenario) << " epochs=" << summary.scheduled_epochs
+              << " powered=" << summary.powered_epochs << " range=" << summary.range_messages
+              << " psrpos=" << summary.psrpos_messages << " psrvel=" << summary.psrvel_messages
+              << " nav=" << summary.nav_messages << " valid_pos=" << summary.valid_position_epochs
+              << " valid_vel=" << summary.valid_velocity_epochs << '\n';
     return 0;
 }

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -12,8 +12,9 @@
 namespace {
 
 void print_usage(const char* program) {
-    std::cerr << "Usage:\n  " << program
-              << " --config <config.json> --nav <input.rnx> --output <simulated.log> --week <gps-week> --sow <seconds>\n";
+    std::cerr
+        << "Usage:\n  " << program
+        << " --config <config.json> --nav <input.rnx> --output <simulated.log> --week <gps-week> --sow <seconds>\n";
 }
 
 bool parse_int(const char* text, int* value) {

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -84,8 +84,9 @@ void set_error(std::string* error_message, const std::string& message) {
 }
 
 bool valid_run_options(const SimulatorRunOptions& options) {
-    return options.rinex_nav_path != nullptr && options.rinex_nav_path[0] != '\0' && options.output_log_path != nullptr &&
-           options.output_log_path[0] != '\0' && options.start_time.gps_week >= 0 && options.start_time.tow_ns >= 0 &&
+    return options.rinex_nav_path != nullptr && options.rinex_nav_path[0] != '\0' &&
+           options.output_log_path != nullptr && options.output_log_path[0] != '\0' &&
+           options.start_time.gps_week >= 0 && options.start_time.tow_ns >= 0 &&
            options.start_time.tow_ns < GPS_WEEK_NANOSECONDS;
 }
 
@@ -260,9 +261,8 @@ bool build_satellite_runtimes(const std::vector<TruthScheduleEntry>& schedule, c
     }
     std::vector<int> satellite_numbers;
     for (const TruthScheduleEntry& entry : schedule) {
-        if (entry.info.satellite_number > 0 &&
-            std::find(satellite_numbers.begin(), satellite_numbers.end(), entry.info.satellite_number) ==
-                satellite_numbers.end()) {
+        if (entry.info.satellite_number > 0 && std::find(satellite_numbers.begin(), satellite_numbers.end(),
+                                                         entry.info.satellite_number) == satellite_numbers.end()) {
             satellite_numbers.push_back(entry.info.satellite_number);
         }
     }
@@ -450,8 +450,8 @@ bool apply_and_emit_nav(RuntimeState* runtime, const SimConfig& config, const Tr
                         std::string* error_message) {
     NavigationUpdateEvent event{};
     bool emitted = false;
-    if (!apply_truth_navigation_record(runtime->navigation, entry.truth_record_index, availability_time, &event, &emitted,
-                                       error_message)) {
+    if (!apply_truth_navigation_record(runtime->navigation, entry.truth_record_index, availability_time, &event,
+                                       &emitted, error_message)) {
         return false;
     }
     if (!emitted) {
@@ -512,18 +512,20 @@ bool suppress_superseded_cold_records(RuntimeState* runtime, const TruthSchedule
         if (compare_sim_time(entry.transmit_time, target.transmit_time) > 0) {
             break;
         }
-        if (entry.truth_record_index != target.truth_record_index && entry.info.satellite_number == target.info.satellite_number &&
-            entry.has_family && target.has_family && entry.family == target.family &&
+        if (entry.truth_record_index != target.truth_record_index &&
+            entry.info.satellite_number == target.info.satellite_number && entry.has_family && target.has_family &&
+            entry.family == target.family &&
             !navigation_truth_record_delivered(runtime->navigation, entry.truth_record_index) &&
-            !consume_truth_navigation_record_without_copy(runtime->navigation, entry.truth_record_index, error_message)) {
+            !consume_truth_navigation_record_without_copy(runtime->navigation, entry.truth_record_index,
+                                                          error_message)) {
             return false;
         }
     }
     return true;
 }
 
-bool process_cold_nav(RuntimeState* runtime, const SimConfig& config, const SimTime& current_time, std::ofstream* output,
-                      SimulatorRunSummary* summary, std::string* error_message) {
+bool process_cold_nav(RuntimeState* runtime, const SimConfig& config, const SimTime& current_time,
+                      std::ofstream* output, SimulatorRunSummary* summary, std::string* error_message) {
     const bool have_any_tracking = any_tracking(runtime->satellites);
     for (const TruthScheduleEntry& entry : runtime->truth_schedule) {
         if (!record_is_available(entry, current_time)) {
@@ -575,15 +577,17 @@ bool process_cold_nav(RuntimeState* runtime, const SimConfig& config, const SimT
 
             NavigationUpdateEvent event{};
             bool emitted = false;
-            if (!deliver_cold_nav_plan_if_complete(family_state.plan, family_state.target_truth_record_index, current_time,
-                                                   runtime->navigation, &event, &emitted, error_message)) {
+            if (!deliver_cold_nav_plan_if_complete(family_state.plan, family_state.target_truth_record_index,
+                                                   current_time, runtime->navigation, &event, &emitted,
+                                                   error_message)) {
                 return false;
             }
             if (!emitted) {
                 continue;
             }
-            if (!emit_receiver_nav_record(config, receiver_navigation_store(runtime->navigation), event.receiver_record_index,
-                                          event.availability_time, output, summary, error_message) ||
+            if (!emit_receiver_nav_record(config, receiver_navigation_store(runtime->navigation),
+                                          event.receiver_record_index, event.availability_time, output, summary,
+                                          error_message) ||
                 !suppress_superseded_cold_records(runtime, *target, error_message)) {
                 return false;
             }
@@ -632,7 +636,8 @@ bool process_receiver_nav(RuntimeState* runtime, const SimConfig& config, const 
     return process_normal_nav(runtime, config, current_time, output, summary, error_message);
 }
 
-bool update_tracking_and_measurements(RuntimeState* runtime, const SimConfig& config, const ScenarioEpochState& scenario,
+bool update_tracking_and_measurements(RuntimeState* runtime, const SimConfig& config,
+                                      const ScenarioEpochState& scenario,
                                       std::vector<MeasurementObservation>* measurements, int* tracked_satellites,
                                       std::string* error_message) {
     measurements->clear();
@@ -651,20 +656,22 @@ bool update_tracking_and_measurements(RuntimeState* runtime, const SimConfig& co
         for (SignalRuntime& signal : satellite.signals) {
             const bool signal_available = scenario.signal_available && geometry.visible;
             if (signal_available && !signal.tracker.scheduled) {
-                const AcquisitionContext context = signal.ever_scheduled ? AcquisitionContext::kReacquisition : initial_context;
+                const AcquisitionContext context =
+                    signal.ever_scheduled ? AcquisitionContext::kReacquisition : initial_context;
                 SimTime search_ready_time = scenario.time;
-                if (!signal.ever_scheduled && compare_sim_time(runtime->startup_search_ready_time, search_ready_time) > 0) {
+                if (!signal.ever_scheduled &&
+                    compare_sim_time(runtime->startup_search_ready_time, search_ready_time) > 0) {
                     search_ready_time = runtime->startup_search_ready_time;
                 }
-                if (!schedule_signal_acquisition(&signal.tracker, context, scenario.time, search_ready_time, elevation_deg,
-                                                 runtime->cn0_model, runtime->tracking_config, &runtime->rng,
-                                                 error_message)) {
+                if (!schedule_signal_acquisition(&signal.tracker, context, scenario.time, search_ready_time,
+                                                 elevation_deg, runtime->cn0_model, runtime->tracking_config,
+                                                 &runtime->rng, error_message)) {
                     return false;
                 }
                 signal.ever_scheduled = true;
             }
-            if (!update_signal_tracker(&signal.tracker, scenario.time, signal_available, elevation_deg, runtime->cn0_model,
-                                       error_message)) {
+            if (!update_signal_tracker(&signal.tracker, scenario.time, signal_available, elevation_deg,
+                                       runtime->cn0_model, error_message)) {
                 return false;
             }
             if (signal.tracker.phase != SignalTrackingPhase::kTracking) {
@@ -673,9 +680,10 @@ bool update_tracking_and_measurements(RuntimeState* runtime, const SimConfig& co
             }
             satellite_tracking = true;
             AtmosphereCorrection atmosphere{};
-            if (!compute_atmosphere_correction(config.atmosphere_mode, truth_nav, scenario.time, signal.tracker.signal_id,
-                                               0, runtime->receiver.position_ecef_m, geometry.azimuth_rad,
-                                               geometry.elevation_rad, &atmosphere, error_message)) {
+            if (!compute_atmosphere_correction(config.atmosphere_mode, truth_nav, scenario.time,
+                                               signal.tracker.signal_id, 0, runtime->receiver.position_ecef_m,
+                                               geometry.azimuth_rad, geometry.elevation_rad, &atmosphere,
+                                               error_message)) {
                 return false;
             }
             MeasurementObservation observation{};
@@ -740,10 +748,11 @@ bool run_simulator(const SimConfig& config, const SimulatorRunOptions& options, 
         return false;
     }
 
-    bool ok = load_truth_navigation(runtime.navigation, options.rinex_nav_path, error_message) &&
-              make_static_receiver_truth(config.receiver, &runtime.receiver, error_message) &&
-              build_truth_schedule(truth_navigation_store(runtime.navigation), &runtime.truth_schedule, error_message) &&
-              build_satellite_runtimes(runtime.truth_schedule, options.start_time, &runtime.satellites, error_message);
+    bool ok =
+        load_truth_navigation(runtime.navigation, options.rinex_nav_path, error_message) &&
+        make_static_receiver_truth(config.receiver, &runtime.receiver, error_message) &&
+        build_truth_schedule(truth_navigation_store(runtime.navigation), &runtime.truth_schedule, error_message) &&
+        build_satellite_runtimes(runtime.truth_schedule, options.start_time, &runtime.satellites, error_message);
     if (!ok) {
         destroy_navigation_state(runtime.navigation);
         return false;
@@ -836,8 +845,8 @@ bool run_simulator(const SimConfig& config, const SimulatorRunOptions& options, 
         SolutionEpoch solution{};
         const MeasurementObservation* data = measurements.empty() ? nullptr : measurements.data();
         if (!solve_receiver_epoch(receiver_navigation_store(runtime.navigation), current_time, data,
-                                  static_cast<int>(measurements.size()), config.elevation_mask_deg, config.atmosphere_mode,
-                                  &runtime.solution_state, &solution, error_message) ||
+                                  static_cast<int>(measurements.size()), config.elevation_mask_deg,
+                                  config.atmosphere_mode, &runtime.solution_state, &solution, error_message) ||
             !emit_epoch_logs(config, scenario, measurements, tracked_satellites, solution, &output, &result,
                              error_message)) {
             ok = false;

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -1,10 +1,869 @@
 #include "gnss_sim/simulator.h"
 
+#include "core/deterministic_rng.h"
+#include "gnss/nav_message_scheduler.h"
+#include "gnss/nav_output_record.h"
+#include "gnss/navigation_state.h"
+#include "gnss/rtklib_adapter.h"
+#include "gnss/satellite_engine.h"
+#include "gnss/signal_definitions.h"
+#include "gnss_sim/sim_time.h"
+#include "model/atmosphere_model.h"
+#include "model/cn0_model.h"
+#include "model/measurement_model.h"
+#include "model/receiver_truth.h"
+#include "model/signal_tracking.h"
+#include "output/novatel_nav_writer.h"
+#include "output/novatel_range_writer.h"
+#include "output/novatel_solution_writer.h"
+#include "scenario/scenario_engine.h"
+#include "solution/solution_engine.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <fstream>
+#include <string>
+#include <vector>
+
 #ifndef GNSS_SIM_RTKLIB_COMMIT
 #define GNSS_SIM_RTKLIB_COMMIT "unknown"
 #endif
 
 namespace gnss_sim {
+namespace {
+
+constexpr double kRadiansToDegrees = 180.0 / 3.141592653589793238462643383279502884;
+
+struct SignalRuntime {
+    SignalTracker tracker;
+    CarrierAmbiguityState ambiguity;
+    bool ever_scheduled;
+};
+
+struct ColdFamilyRuntime {
+    NavMessageFamily family;
+    bool acquired;
+    bool plan_active;
+    int target_truth_record_index;
+    NavAcquisitionPlan plan;
+};
+
+struct SatelliteRuntime {
+    int satellite_number;
+    GnssConstellation constellation;
+    std::vector<SignalRuntime> signals;
+    std::vector<ColdFamilyRuntime> cold_families;
+};
+
+struct TruthScheduleEntry {
+    int truth_record_index;
+    RtklibNavRecordInfo info;
+    SimTime transmit_time;
+    bool has_family;
+    NavMessageFamily family;
+};
+
+struct RuntimeState {
+    NavigationState* navigation;
+    ReceiverTruth receiver;
+    DeterministicRng rng;
+    Cn0Model cn0_model;
+    SignalTrackingModelConfig tracking_config;
+    SolutionEngineState solution_state;
+    StartupMode startup_mode;
+    SimTime startup_search_ready_time;
+    std::vector<SatelliteRuntime> satellites;
+    std::vector<TruthScheduleEntry> truth_schedule;
+};
+
+void set_error(std::string* error_message, const std::string& message) {
+    if (error_message != nullptr) {
+        *error_message = message;
+    }
+}
+
+bool valid_run_options(const SimulatorRunOptions& options) {
+    return options.rinex_nav_path != nullptr && options.rinex_nav_path[0] != '\0' && options.output_log_path != nullptr &&
+           options.output_log_path[0] != '\0' && options.start_time.gps_week >= 0 && options.start_time.tow_ns >= 0 &&
+           options.start_time.tow_ns < GPS_WEEK_NANOSECONDS;
+}
+
+bool write_message(std::ofstream* output, const std::string& message, std::string* error_message) {
+    if (output == nullptr || !output->is_open()) {
+        set_error(error_message, "simulator output stream is not open");
+        return false;
+    }
+    output->write(message.data(), static_cast<std::streamsize>(message.size()));
+    if (!*output) {
+        set_error(error_message, "failed to write simulated receiver log");
+        return false;
+    }
+    return true;
+}
+
+bool constellation_from_satellite(int satellite_number, GnssConstellation* constellation) {
+    if (constellation == nullptr) {
+        return false;
+    }
+    char satellite_id[4]{};
+    if (!rtklib_satellite_number_to_id(satellite_number, satellite_id)) {
+        return false;
+    }
+    switch (satellite_id[0]) {
+        case 'G':
+            *constellation = GnssConstellation::kGps;
+            return true;
+        case 'R':
+            *constellation = GnssConstellation::kGlonass;
+            return true;
+        case 'E':
+            *constellation = GnssConstellation::kGalileo;
+            return true;
+        case 'C':
+            *constellation = GnssConstellation::kBeidou;
+            return true;
+        case 'J':
+            *constellation = GnssConstellation::kQzss;
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool nav_family_from_record(const NavOutputRecord& record, NavMessageFamily* family) {
+    if (family == nullptr) {
+        return false;
+    }
+    if (record.kind == RtklibNavRecordKind::kGlonassEphemeris) {
+        *family = NavMessageFamily::kGlonassFdma;
+        return true;
+    }
+    if (record.kind != RtklibNavRecordKind::kEphemeris) {
+        return false;
+    }
+
+    const KeplerianNavOutputData& eph = record.ephemeris;
+    switch (eph.message_family) {
+        case RtklibBroadcastMessageFamily::kLegacy:
+            if (eph.system == NavOutputSystem::kGps) {
+                *family = NavMessageFamily::kGpsLnav;
+                return true;
+            }
+            if (eph.system == NavOutputSystem::kQzss) {
+                *family = NavMessageFamily::kQzssLnav;
+                return true;
+            }
+            if (eph.system == NavOutputSystem::kBeidou) {
+                *family = NavMessageFamily::kBeidouD1D2;
+                return true;
+            }
+            return false;
+        case RtklibBroadcastMessageFamily::kCnav:
+            if (eph.system == NavOutputSystem::kGps) {
+                *family = NavMessageFamily::kGpsCnav;
+                return true;
+            }
+            if (eph.system == NavOutputSystem::kQzss) {
+                *family = NavMessageFamily::kQzssCnav;
+                return true;
+            }
+            return false;
+        case RtklibBroadcastMessageFamily::kCnav2:
+            if (eph.system == NavOutputSystem::kGps) {
+                *family = NavMessageFamily::kGpsCnav2;
+                return true;
+            }
+            if (eph.system == NavOutputSystem::kQzss) {
+                *family = NavMessageFamily::kQzssCnav2;
+                return true;
+            }
+            return false;
+        case RtklibBroadcastMessageFamily::kGalileoInav:
+            *family = NavMessageFamily::kGalileoInav;
+            return true;
+        case RtklibBroadcastMessageFamily::kGalileoFnav:
+            *family = NavMessageFamily::kGalileoFnav;
+            return true;
+        case RtklibBroadcastMessageFamily::kBeidouBcnav1:
+            *family = NavMessageFamily::kBeidouBcnav1;
+            return true;
+        case RtklibBroadcastMessageFamily::kBeidouBcnav2:
+            *family = NavMessageFamily::kBeidouBcnav2;
+            return true;
+        case RtklibBroadcastMessageFamily::kBeidouBcnav3:
+            *family = NavMessageFamily::kBeidouBcnav3;
+            return true;
+        case RtklibBroadcastMessageFamily::kGlonassFdma:
+            *family = NavMessageFamily::kGlonassFdma;
+            return true;
+        case RtklibBroadcastMessageFamily::kUnknown:
+            return false;
+    }
+    return false;
+}
+
+bool build_truth_schedule(const RtklibNavStore* truth_nav, std::vector<TruthScheduleEntry>* schedule,
+                          std::string* error_message) {
+    if (truth_nav == nullptr || schedule == nullptr) {
+        set_error(error_message, "truth NAV schedule request has invalid arguments");
+        return false;
+    }
+    schedule->clear();
+    const int count = rtklib_nav_record_count(truth_nav);
+    schedule->reserve(static_cast<std::size_t>(count));
+    for (int index = 0; index < count; ++index) {
+        TruthScheduleEntry entry{};
+        entry.truth_record_index = index;
+        if (!rtklib_nav_record_info(truth_nav, index, &entry.info) ||
+            !sim_time_from_week_sow(entry.info.gps_week, entry.info.transmit_sow_sec, &entry.transmit_time)) {
+            set_error(error_message, "cannot build deterministic truth NAV transmission schedule");
+            return false;
+        }
+        if (entry.info.kind != RtklibNavRecordKind::kIonosphere) {
+            NavOutputRecord output_record{};
+            if (!rtklib_nav_output_record(truth_nav, index, &output_record, error_message)) {
+                return false;
+            }
+            entry.has_family = nav_family_from_record(output_record, &entry.family);
+        }
+        schedule->push_back(entry);
+    }
+    std::sort(schedule->begin(), schedule->end(), [](const TruthScheduleEntry& lhs, const TruthScheduleEntry& rhs) {
+        const int time_order = compare_sim_time(lhs.transmit_time, rhs.transmit_time);
+        if (time_order != 0) {
+            return time_order < 0;
+        }
+        return lhs.truth_record_index < rhs.truth_record_index;
+    });
+    return true;
+}
+
+ColdFamilyRuntime* cold_family_state(SatelliteRuntime* satellite, NavMessageFamily family) {
+    for (ColdFamilyRuntime& state : satellite->cold_families) {
+        if (state.family == family) {
+            return &state;
+        }
+    }
+    ColdFamilyRuntime state{};
+    state.family = family;
+    state.target_truth_record_index = -1;
+    satellite->cold_families.push_back(state);
+    return &satellite->cold_families.back();
+}
+
+bool build_satellite_runtimes(const std::vector<TruthScheduleEntry>& schedule, const SimTime& reset_time,
+                              std::vector<SatelliteRuntime>* satellites, std::string* error_message) {
+    if (satellites == nullptr) {
+        set_error(error_message, "satellite runtime output is null");
+        return false;
+    }
+    std::vector<int> satellite_numbers;
+    for (const TruthScheduleEntry& entry : schedule) {
+        if (entry.info.satellite_number > 0 &&
+            std::find(satellite_numbers.begin(), satellite_numbers.end(), entry.info.satellite_number) ==
+                satellite_numbers.end()) {
+            satellite_numbers.push_back(entry.info.satellite_number);
+        }
+    }
+    std::sort(satellite_numbers.begin(), satellite_numbers.end());
+    satellites->clear();
+    satellites->reserve(satellite_numbers.size());
+    std::size_t definition_count = 0;
+    const SignalDefinition* definitions = signal_definitions(&definition_count);
+    for (int satellite_number : satellite_numbers) {
+        SatelliteRuntime satellite{};
+        satellite.satellite_number = satellite_number;
+        if (!constellation_from_satellite(satellite_number, &satellite.constellation)) {
+            continue;
+        }
+        for (std::size_t index = 0; index < definition_count; ++index) {
+            if (definitions[index].constellation != satellite.constellation) {
+                continue;
+            }
+            SignalRuntime signal{};
+            reset_signal_tracker(&signal.tracker, definitions[index].signal_id, reset_time);
+            reset_carrier_ambiguity_state(&signal.ambiguity);
+            satellite.signals.push_back(signal);
+        }
+        for (const TruthScheduleEntry& entry : schedule) {
+            if (entry.info.satellite_number == satellite_number && entry.has_family) {
+                cold_family_state(&satellite, entry.family);
+            }
+        }
+        satellites->push_back(satellite);
+    }
+    if (satellites->empty()) {
+        set_error(error_message, "RINEX NAV contains no V1-supported constellation satellites");
+        return false;
+    }
+    return true;
+}
+
+SatelliteRuntime* find_satellite(std::vector<SatelliteRuntime>* satellites, int satellite_number) {
+    for (SatelliteRuntime& satellite : *satellites) {
+        if (satellite.satellite_number == satellite_number) {
+            return &satellite;
+        }
+    }
+    return nullptr;
+}
+
+bool any_tracking(const std::vector<SatelliteRuntime>& satellites) {
+    for (const SatelliteRuntime& satellite : satellites) {
+        for (const SignalRuntime& signal : satellite.signals) {
+            if (signal.tracker.phase == SignalTrackingPhase::kTracking) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool family_tracking(const SatelliteRuntime& satellite, NavMessageFamily family) {
+    for (const SignalRuntime& signal : satellite.signals) {
+        const SignalDefinition* definition = find_signal_definition(signal.tracker.signal_id);
+        if (definition != nullptr && definition->nav_message_family == family &&
+            signal.tracker.phase == SignalTrackingPhase::kTracking) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool record_output_enabled(const SimConfig& config, const NavOutputRecord& record) {
+    if (record.kind == RtklibNavRecordKind::kIonosphere) {
+        return config.output_ion;
+    }
+    return config.output_eph;
+}
+
+bool emit_receiver_nav_record(const SimConfig& config, const RtklibNavStore* receiver_nav, int receiver_record_index,
+                              const SimTime& output_time, std::ofstream* output, SimulatorRunSummary* summary,
+                              std::string* error_message) {
+    NavOutputRecord record{};
+    if (!rtklib_nav_output_record(receiver_nav, receiver_record_index, &record, error_message)) {
+        return false;
+    }
+    if (!record_output_enabled(config, record)) {
+        return true;
+    }
+    std::string message;
+    bool supported = false;
+    if (!format_novatel_nav_output_record(record, output_time, &message, &supported, error_message)) {
+        return false;
+    }
+    if (supported) {
+        if (!write_message(output, message, error_message)) {
+            return false;
+        }
+        ++summary->nav_messages;
+    }
+    return true;
+}
+
+bool emit_receiver_nav_snapshot(const SimConfig& config, const RtklibNavStore* receiver_nav, const SimTime& output_time,
+                                std::ofstream* output, SimulatorRunSummary* summary, std::string* error_message) {
+    const int count = rtklib_nav_output_record_count(receiver_nav);
+    for (int index = 0; index < count; ++index) {
+        if (!emit_receiver_nav_record(config, receiver_nav, index, output_time, output, summary, error_message)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+StartupMode scenario_startup_mode(const SimConfig& config) {
+    return config.scenario == ScenarioType::TTFF ? config.ttff.startup_mode : StartupMode::HOT;
+}
+
+AcquisitionContext startup_context(StartupMode mode) {
+    switch (mode) {
+        case StartupMode::WARM:
+            return AcquisitionContext::kWarm;
+        case StartupMode::COLD:
+            return AcquisitionContext::kCold;
+        case StartupMode::HOT:
+            return AcquisitionContext::kHot;
+    }
+    return AcquisitionContext::kHot;
+}
+
+bool receiver_power_on(RuntimeState* runtime, const SimConfig& config, const SimTime& power_on_time,
+                       std::ofstream* output, SimulatorRunSummary* summary, std::string* error_message) {
+    runtime->startup_mode = scenario_startup_mode(config);
+    if (!initialize_receiver_navigation(runtime->navigation, runtime->startup_mode, power_on_time, error_message)) {
+        return false;
+    }
+    reset_solution_engine_state(&runtime->solution_state);
+    ReceiverStartupTiming timing{};
+    if (!sample_receiver_startup_timing(runtime->startup_mode, runtime->tracking_config, &runtime->rng, &timing) ||
+        !add_time_ns(power_on_time, timing.total_search_ready_delay_ns, &runtime->startup_search_ready_time)) {
+        set_error(error_message, "cannot schedule deterministic receiver startup timing");
+        return false;
+    }
+    for (SatelliteRuntime& satellite : runtime->satellites) {
+        for (SignalRuntime& signal : satellite.signals) {
+            reset_signal_tracker(&signal.tracker, signal.tracker.signal_id, power_on_time);
+            reset_carrier_ambiguity_state(&signal.ambiguity);
+            signal.ever_scheduled = false;
+        }
+        for (ColdFamilyRuntime& family : satellite.cold_families) {
+            family.acquired = false;
+            family.plan_active = false;
+            family.target_truth_record_index = -1;
+            family.plan = NavAcquisitionPlan{};
+        }
+    }
+    if (runtime->startup_mode != StartupMode::COLD) {
+        return emit_receiver_nav_snapshot(config, receiver_navigation_store(runtime->navigation), power_on_time, output,
+                                          summary, error_message);
+    }
+    return true;
+}
+
+void receiver_power_off(RuntimeState* runtime, const SimTime& time) {
+    reset_solution_engine_state(&runtime->solution_state);
+    for (SatelliteRuntime& satellite : runtime->satellites) {
+        for (SignalRuntime& signal : satellite.signals) {
+            reset_signal_tracker(&signal.tracker, signal.tracker.signal_id, time);
+            reset_carrier_ambiguity_state(&signal.ambiguity);
+        }
+    }
+}
+
+void receiver_signal_off(RuntimeState* runtime, const SimTime& time) {
+    for (SatelliteRuntime& satellite : runtime->satellites) {
+        for (SignalRuntime& signal : satellite.signals) {
+            static_cast<void>(update_signal_tracker(&signal.tracker, time, false, 0.0, runtime->cn0_model, nullptr));
+            reset_carrier_ambiguity_state(&signal.ambiguity);
+        }
+    }
+}
+
+bool record_is_available(const TruthScheduleEntry& entry, const SimTime& current_time) {
+    return compare_sim_time(entry.transmit_time, current_time) <= 0;
+}
+
+bool apply_and_emit_nav(RuntimeState* runtime, const SimConfig& config, const TruthScheduleEntry& entry,
+                        const SimTime& availability_time, std::ofstream* output, SimulatorRunSummary* summary,
+                        std::string* error_message) {
+    NavigationUpdateEvent event{};
+    bool emitted = false;
+    if (!apply_truth_navigation_record(runtime->navigation, entry.truth_record_index, availability_time, &event, &emitted,
+                                       error_message)) {
+        return false;
+    }
+    if (!emitted) {
+        return true;
+    }
+    return emit_receiver_nav_record(config, receiver_navigation_store(runtime->navigation), event.receiver_record_index,
+                                    event.availability_time, output, summary, error_message);
+}
+
+bool best_cold_plan(const SatelliteRuntime& satellite, const TruthScheduleEntry& target, NavAcquisitionPlan* plan,
+                    bool* found, std::string* error_message) {
+    *found = false;
+    for (const SignalRuntime& signal : satellite.signals) {
+        const SignalDefinition* definition = find_signal_definition(signal.tracker.signal_id);
+        if (definition == nullptr || !target.has_family || definition->nav_message_family != target.family ||
+            signal.tracker.phase != SignalTrackingPhase::kTracking) {
+            continue;
+        }
+        SimTime acquisition_time = target.transmit_time;
+        if (compare_sim_time(signal.tracker.tracking_start_time, acquisition_time) > 0) {
+            acquisition_time = signal.tracker.tracking_start_time;
+        }
+        NavScheduleVariant variant = NavScheduleVariant::kDefault;
+        if (target.family == NavMessageFamily::kBeidouD1D2) {
+            variant = target.info.prn <= 5 ? NavScheduleVariant::kBeidouD2 : NavScheduleVariant::kBeidouD1;
+        }
+        NavAcquisitionPlan candidate{};
+        if (!build_cold_nav_acquisition_plan_with_variant(signal.tracker.signal_id, variant, acquisition_time,
+                                                          target.info.iode, &candidate, error_message)) {
+            continue;
+        }
+        if (!*found || compare_sim_time(candidate.availability_time, plan->availability_time) < 0) {
+            *plan = candidate;
+            *found = true;
+        }
+    }
+    return true;
+}
+
+const TruthScheduleEntry* latest_cold_target(const RuntimeState& runtime, int satellite_number, NavMessageFamily family,
+                                             const SimTime& current_time) {
+    const TruthScheduleEntry* target = nullptr;
+    for (const TruthScheduleEntry& entry : runtime.truth_schedule) {
+        if (!record_is_available(entry, current_time)) {
+            break;
+        }
+        if (entry.info.satellite_number == satellite_number && entry.has_family && entry.family == family &&
+            !navigation_truth_record_delivered(runtime.navigation, entry.truth_record_index)) {
+            target = &entry;
+        }
+    }
+    return target;
+}
+
+bool suppress_superseded_cold_records(RuntimeState* runtime, const TruthScheduleEntry& target,
+                                      std::string* error_message) {
+    for (const TruthScheduleEntry& entry : runtime->truth_schedule) {
+        if (compare_sim_time(entry.transmit_time, target.transmit_time) > 0) {
+            break;
+        }
+        if (entry.truth_record_index != target.truth_record_index && entry.info.satellite_number == target.info.satellite_number &&
+            entry.has_family && target.has_family && entry.family == target.family &&
+            !navigation_truth_record_delivered(runtime->navigation, entry.truth_record_index) &&
+            !consume_truth_navigation_record_without_copy(runtime->navigation, entry.truth_record_index, error_message)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool process_cold_nav(RuntimeState* runtime, const SimConfig& config, const SimTime& current_time, std::ofstream* output,
+                      SimulatorRunSummary* summary, std::string* error_message) {
+    const bool have_any_tracking = any_tracking(runtime->satellites);
+    for (const TruthScheduleEntry& entry : runtime->truth_schedule) {
+        if (!record_is_available(entry, current_time)) {
+            break;
+        }
+        if (entry.info.kind == RtklibNavRecordKind::kIonosphere && have_any_tracking &&
+            !navigation_truth_record_delivered(runtime->navigation, entry.truth_record_index) &&
+            !apply_and_emit_nav(runtime, config, entry, current_time, output, summary, error_message)) {
+            return false;
+        }
+    }
+
+    for (SatelliteRuntime& satellite : runtime->satellites) {
+        for (ColdFamilyRuntime& family_state : satellite.cold_families) {
+            if (family_state.acquired) {
+                if (!family_tracking(satellite, family_state.family)) {
+                    continue;
+                }
+                for (const TruthScheduleEntry& entry : runtime->truth_schedule) {
+                    if (!record_is_available(entry, current_time)) {
+                        break;
+                    }
+                    if (entry.info.satellite_number == satellite.satellite_number && entry.has_family &&
+                        entry.family == family_state.family &&
+                        !navigation_truth_record_delivered(runtime->navigation, entry.truth_record_index) &&
+                        !apply_and_emit_nav(runtime, config, entry, current_time, output, summary, error_message)) {
+                        return false;
+                    }
+                }
+                continue;
+            }
+
+            const TruthScheduleEntry* target =
+                latest_cold_target(*runtime, satellite.satellite_number, family_state.family, current_time);
+            if (target == nullptr) {
+                continue;
+            }
+            NavAcquisitionPlan candidate{};
+            bool found_candidate = false;
+            if (!best_cold_plan(satellite, *target, &candidate, &found_candidate, error_message) || !found_candidate) {
+                continue;
+            }
+            if (!family_state.plan_active || family_state.target_truth_record_index != target->truth_record_index ||
+                compare_sim_time(candidate.availability_time, family_state.plan.availability_time) < 0) {
+                family_state.plan = candidate;
+                family_state.plan_active = true;
+                family_state.target_truth_record_index = target->truth_record_index;
+            }
+
+            NavigationUpdateEvent event{};
+            bool emitted = false;
+            if (!deliver_cold_nav_plan_if_complete(family_state.plan, family_state.target_truth_record_index, current_time,
+                                                   runtime->navigation, &event, &emitted, error_message)) {
+                return false;
+            }
+            if (!emitted) {
+                continue;
+            }
+            if (!emit_receiver_nav_record(config, receiver_navigation_store(runtime->navigation), event.receiver_record_index,
+                                          event.availability_time, output, summary, error_message) ||
+                !suppress_superseded_cold_records(runtime, *target, error_message)) {
+                return false;
+            }
+            family_state.acquired = true;
+            family_state.plan_active = false;
+        }
+    }
+    return true;
+}
+
+bool process_normal_nav(RuntimeState* runtime, const SimConfig& config, const SimTime& current_time,
+                        std::ofstream* output, SimulatorRunSummary* summary, std::string* error_message) {
+    const bool have_any_tracking = any_tracking(runtime->satellites);
+    for (const TruthScheduleEntry& entry : runtime->truth_schedule) {
+        if (!record_is_available(entry, current_time)) {
+            break;
+        }
+        if (navigation_truth_record_delivered(runtime->navigation, entry.truth_record_index)) {
+            continue;
+        }
+        bool can_receive = false;
+        if (entry.info.kind == RtklibNavRecordKind::kIonosphere) {
+            can_receive = have_any_tracking;
+        } else {
+            const SatelliteRuntime* satellite = nullptr;
+            for (const SatelliteRuntime& candidate : runtime->satellites) {
+                if (candidate.satellite_number == entry.info.satellite_number) {
+                    satellite = &candidate;
+                    break;
+                }
+            }
+            can_receive = satellite != nullptr && entry.has_family && family_tracking(*satellite, entry.family);
+        }
+        if (can_receive && !apply_and_emit_nav(runtime, config, entry, current_time, output, summary, error_message)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool process_receiver_nav(RuntimeState* runtime, const SimConfig& config, const SimTime& current_time,
+                          std::ofstream* output, SimulatorRunSummary* summary, std::string* error_message) {
+    if (runtime->startup_mode == StartupMode::COLD) {
+        return process_cold_nav(runtime, config, current_time, output, summary, error_message);
+    }
+    return process_normal_nav(runtime, config, current_time, output, summary, error_message);
+}
+
+bool update_tracking_and_measurements(RuntimeState* runtime, const SimConfig& config, const ScenarioEpochState& scenario,
+                                      std::vector<MeasurementObservation>* measurements, int* tracked_satellites,
+                                      std::string* error_message) {
+    measurements->clear();
+    *tracked_satellites = 0;
+    const RtklibNavStore* truth_nav = truth_navigation_store(runtime->navigation);
+    const AcquisitionContext initial_context = startup_context(runtime->startup_mode);
+
+    for (SatelliteRuntime& satellite : runtime->satellites) {
+        SatelliteGeometry geometry{};
+        if (!compute_satellite_geometry(truth_nav, runtime->receiver, scenario.time, satellite.satellite_number,
+                                        config.elevation_mask_deg, &geometry, error_message)) {
+            return false;
+        }
+        const double elevation_deg = geometry.elevation_rad * kRadiansToDegrees;
+        bool satellite_tracking = false;
+        for (SignalRuntime& signal : satellite.signals) {
+            const bool signal_available = scenario.signal_available && geometry.visible;
+            if (signal_available && !signal.tracker.scheduled) {
+                const AcquisitionContext context = signal.ever_scheduled ? AcquisitionContext::kReacquisition : initial_context;
+                SimTime search_ready_time = scenario.time;
+                if (!signal.ever_scheduled && compare_sim_time(runtime->startup_search_ready_time, search_ready_time) > 0) {
+                    search_ready_time = runtime->startup_search_ready_time;
+                }
+                if (!schedule_signal_acquisition(&signal.tracker, context, scenario.time, search_ready_time, elevation_deg,
+                                                 runtime->cn0_model, runtime->tracking_config, &runtime->rng,
+                                                 error_message)) {
+                    return false;
+                }
+                signal.ever_scheduled = true;
+            }
+            if (!update_signal_tracker(&signal.tracker, scenario.time, signal_available, elevation_deg, runtime->cn0_model,
+                                       error_message)) {
+                return false;
+            }
+            if (signal.tracker.phase != SignalTrackingPhase::kTracking) {
+                reset_carrier_ambiguity_state(&signal.ambiguity);
+                continue;
+            }
+            satellite_tracking = true;
+            AtmosphereCorrection atmosphere{};
+            if (!compute_atmosphere_correction(config.atmosphere_mode, truth_nav, scenario.time, signal.tracker.signal_id,
+                                               0, runtime->receiver.position_ecef_m, geometry.azimuth_rad,
+                                               geometry.elevation_rad, &atmosphere, error_message)) {
+                return false;
+            }
+            MeasurementObservation observation{};
+            if (!generate_zero_noise_measurement(truth_nav, geometry, signal.tracker, atmosphere, &signal.ambiguity,
+                                                 &observation, error_message)) {
+                return false;
+            }
+            measurements->push_back(observation);
+        }
+        if (satellite_tracking) {
+            ++(*tracked_satellites);
+        }
+    }
+    return true;
+}
+
+bool emit_epoch_logs(const SimConfig& config, const ScenarioEpochState& scenario,
+                     const std::vector<MeasurementObservation>& measurements, int tracked_satellites,
+                     const SolutionEpoch& solution, std::ofstream* output, SimulatorRunSummary* summary,
+                     std::string* error_message) {
+    std::string message;
+    const MeasurementObservation* data = measurements.empty() ? nullptr : measurements.data();
+    if (!format_novatel_rangea(scenario.time, data, static_cast<int>(measurements.size()), &message, error_message) ||
+        !write_message(output, message, error_message)) {
+        return false;
+    }
+    ++summary->range_messages;
+
+    if (!format_novatel_psrposa(solution, tracked_satellites, &message, error_message) ||
+        !write_message(output, message, error_message)) {
+        return false;
+    }
+    ++summary->psrpos_messages;
+
+    if (!format_novatel_psrvela(solution, &message, error_message) || !write_message(output, message, error_message)) {
+        return false;
+    }
+    ++summary->psrvel_messages;
+    return true;
+}
+
+} // namespace
+
+bool run_simulator(const SimConfig& config, const SimulatorRunOptions& options, SimulatorRunSummary* summary,
+                   std::string* error_message) {
+    if (summary == nullptr || !valid_run_options(options) || !validate_sim_config(config, error_message)) {
+        if (summary == nullptr || !valid_run_options(options)) {
+            set_error(error_message, "simulator run request has invalid arguments");
+        }
+        return false;
+    }
+    if (config.atmosphere_mode == AtmosphereMode::UNSPECIFIED) {
+        set_error(error_message, "simulation requires atmosphere_mode to be explicitly none or broadcast");
+        return false;
+    }
+
+    SimulatorRunSummary result{};
+    RuntimeState runtime{};
+    runtime.navigation = create_navigation_state();
+    if (runtime.navigation == nullptr) {
+        set_error(error_message, "cannot allocate simulator navigation state");
+        return false;
+    }
+
+    bool ok = load_truth_navigation(runtime.navigation, options.rinex_nav_path, error_message) &&
+              make_static_receiver_truth(config.receiver, &runtime.receiver, error_message) &&
+              build_truth_schedule(truth_navigation_store(runtime.navigation), &runtime.truth_schedule, error_message) &&
+              build_satellite_runtimes(runtime.truth_schedule, options.start_time, &runtime.satellites, error_message);
+    if (!ok) {
+        destroy_navigation_state(runtime.navigation);
+        return false;
+    }
+
+    seed_rng(&runtime.rng, config.seed);
+    runtime.cn0_model = make_builtin_cn0_model(config.seed);
+    runtime.tracking_config = default_signal_tracking_model_config();
+
+    ScenarioEngine scenario_engine{};
+    if (!initialize_scenario_engine(config, options.start_time, &scenario_engine, error_message)) {
+        destroy_navigation_state(runtime.navigation);
+        return false;
+    }
+
+    std::ofstream output(options.output_log_path, std::ios::binary | std::ios::trunc);
+    if (!output) {
+        set_error(error_message, std::string("cannot open simulator output: ") + options.output_log_path);
+        destroy_navigation_state(runtime.navigation);
+        return false;
+    }
+
+    std::uint64_t epoch_count = 0;
+    if (!epoch_count_for_duration(config.duration_ns, config.sampling_rate_hz, &epoch_count)) {
+        set_error(error_message, "cannot compute simulator epoch count");
+        destroy_navigation_state(runtime.navigation);
+        return false;
+    }
+    result.scheduled_epochs = epoch_count;
+
+    std::vector<MeasurementObservation> measurements;
+    std::size_t signal_count = 0;
+    static_cast<void>(signal_definitions(&signal_count));
+    measurements.reserve(runtime.satellites.size() * signal_count);
+
+    for (std::uint64_t epoch_index = 0; epoch_index < epoch_count; ++epoch_index) {
+        SimTime current_time{};
+        if (!epoch_time_at_index(options.start_time, config.sampling_rate_hz, epoch_index, &current_time)) {
+            set_error(error_message, "cannot advance simulator integer epoch clock");
+            ok = false;
+            break;
+        }
+        ScenarioEpochState scenario{};
+        if (!update_scenario_engine(&scenario_engine, current_time, &scenario, error_message)) {
+            ok = false;
+            break;
+        }
+        if (scenario.power_on_transition) {
+            ++result.power_on_events;
+            if (!receiver_power_on(&runtime, config, current_time, &output, &result, error_message)) {
+                ok = false;
+                break;
+            }
+        }
+        if (scenario.power_off_transition) {
+            ++result.power_off_events;
+            receiver_power_off(&runtime, current_time);
+        }
+        if (scenario.signal_on_transition) {
+            ++result.signal_on_events;
+        }
+        if (scenario.signal_off_transition) {
+            ++result.signal_off_events;
+            if (scenario.receiver_powered) {
+                receiver_signal_off(&runtime, current_time);
+            }
+        }
+
+        if (!scenario.receiver_powered) {
+            continue;
+        }
+        ++result.powered_epochs;
+        if (scenario.signal_available) {
+            ++result.signal_on_epochs;
+        } else {
+            ++result.signal_off_epochs;
+        }
+
+        int tracked_satellites = 0;
+        if (!update_tracking_and_measurements(&runtime, config, scenario, &measurements, &tracked_satellites,
+                                              error_message) ||
+            !process_receiver_nav(&runtime, config, current_time, &output, &result, error_message)) {
+            ok = false;
+            break;
+        }
+        if (static_cast<int>(measurements.size()) > result.max_observations_per_epoch) {
+            result.max_observations_per_epoch = static_cast<int>(measurements.size());
+        }
+
+        SolutionEpoch solution{};
+        const MeasurementObservation* data = measurements.empty() ? nullptr : measurements.data();
+        if (!solve_receiver_epoch(receiver_navigation_store(runtime.navigation), current_time, data,
+                                  static_cast<int>(measurements.size()), config.elevation_mask_deg, config.atmosphere_mode,
+                                  &runtime.solution_state, &solution, error_message) ||
+            !emit_epoch_logs(config, scenario, measurements, tracked_satellites, solution, &output, &result,
+                             error_message)) {
+            ok = false;
+            break;
+        }
+        if (solution.position.valid) {
+            ++result.valid_position_epochs;
+        }
+        if (solution.velocity.valid) {
+            ++result.valid_velocity_epochs;
+        }
+    }
+
+    output.flush();
+    if (!output && ok) {
+        set_error(error_message, "failed to flush simulated receiver log");
+        ok = false;
+    }
+    output.close();
+    destroy_navigation_state(runtime.navigation);
+    if (!ok) {
+        return false;
+    }
+    *summary = result;
+    return true;
+}
 
 const char* simulator_version() {
     return "0.1.0-dev";

--- a/src/gnss/navigation_state.cpp
+++ b/src/gnss/navigation_state.cpp
@@ -60,6 +60,33 @@ bool record_transmitted_at_or_before(const RtklibNavStore* truth_nav, int record
     return compare_sim_time(record_time, time) <= 0;
 }
 
+bool same_record_identity(const RtklibNavRecordInfo& lhs, const RtklibNavRecordInfo& rhs) {
+    if (lhs.kind != rhs.kind || lhs.satellite_number != rhs.satellite_number || lhs.system != rhs.system ||
+        lhs.prn != rhs.prn || lhs.message_type != rhs.message_type || lhs.iode != rhs.iode || lhs.iodc != rhs.iodc ||
+        lhs.gps_week != rhs.gps_week) {
+        return false;
+    }
+    SimTime lhs_time{};
+    SimTime rhs_time{};
+    if (!sim_time_from_week_sow(lhs.gps_week, lhs.transmit_sow_sec, &lhs_time) ||
+        !sim_time_from_week_sow(rhs.gps_week, rhs.transmit_sow_sec, &rhs_time)) {
+        return false;
+    }
+    return compare_sim_time(lhs_time, rhs_time) == 0;
+}
+
+int find_receiver_record_index(const RtklibNavStore* receiver_nav, const RtklibNavRecordInfo& source_info) {
+    const int count = rtklib_nav_record_count(receiver_nav);
+    for (int index = count - 1; index >= 0; --index) {
+        RtklibNavRecordInfo receiver_info{};
+        if (rtklib_nav_record_info(receiver_nav, index, &receiver_info) &&
+            same_record_identity(source_info, receiver_info)) {
+            return index;
+        }
+    }
+    return -1;
+}
+
 } // namespace
 
 NavigationState* create_navigation_state() {
@@ -157,11 +184,17 @@ bool apply_truth_navigation_record(NavigationState* state, int truth_record_inde
         return false;
     }
 
+    const int receiver_record_index = find_receiver_record_index(state->receiver_nav, info);
+    if (receiver_record_index < 0) {
+        set_error(error_message, "cannot locate copied receiver navigation record");
+        return false;
+    }
+
     state->delivered_records[truth_record_index] = 1;
     if (event != nullptr) {
         event->availability_time = availability_time;
         event->truth_record_index = truth_record_index;
-        event->receiver_record_index = rtklib_nav_record_count(state->receiver_nav) - 1;
+        event->receiver_record_index = receiver_record_index;
         event->kind = info.kind;
         event->satellite_number = info.satellite_number;
         event->system = info.system;

--- a/src/gnss/navigation_state.cpp
+++ b/src/gnss/navigation_state.cpp
@@ -207,6 +207,17 @@ bool apply_truth_navigation_record(NavigationState* state, int truth_record_inde
     return true;
 }
 
+bool consume_truth_navigation_record_without_copy(NavigationState* state, int truth_record_index,
+                                                  std::string* error_message) {
+    if (state == nullptr || state->delivered_records == nullptr || truth_record_index < 0 ||
+        truth_record_index >= state->delivered_record_count) {
+        set_error(error_message, "navigation consume request has invalid arguments");
+        return false;
+    }
+    state->delivered_records[truth_record_index] = 1;
+    return true;
+}
+
 const RtklibNavStore* truth_navigation_store(const NavigationState* state) {
     return state == nullptr ? nullptr : state->truth_nav;
 }

--- a/src/gnss/navigation_state.h
+++ b/src/gnss/navigation_state.h
@@ -32,6 +32,8 @@ bool initialize_receiver_navigation(NavigationState* state, StartupMode startup_
                                     std::string* error_message);
 bool apply_truth_navigation_record(NavigationState* state, int truth_record_index, const SimTime& availability_time,
                                    NavigationUpdateEvent* event, bool* emitted, std::string* error_message);
+bool consume_truth_navigation_record_without_copy(NavigationState* state, int truth_record_index,
+                                                  std::string* error_message);
 
 const RtklibNavStore* truth_navigation_store(const NavigationState* state);
 const RtklibNavStore* receiver_navigation_store(const NavigationState* state);

--- a/src/scenario/scenario_engine.cpp
+++ b/src/scenario/scenario_engine.cpp
@@ -1,1 +1,103 @@
-// KS/REA/TTFF scenario implementation is introduced by issue #15.
+#include "scenario/scenario_engine.h"
+
+#include "gnss_sim/sim_time.h"
+
+namespace gnss_sim {
+namespace {
+
+void set_error(std::string* error_message, const char* message) {
+    if (error_message != nullptr) {
+        *error_message = message;
+    }
+}
+
+bool valid_time(const SimTime& time) {
+    return time.gps_week >= 0 && time.tow_ns >= 0 && time.tow_ns < GPS_WEEK_NANOSECONDS;
+}
+
+bool compute_state(const ScenarioEngine& engine, const SimTime& current_time, ScenarioEpochState* state) {
+    std::int64_t elapsed_ns = 0;
+    if (!difference_time_ns(current_time, engine.start_time, &elapsed_ns) || elapsed_ns < 0) {
+        return false;
+    }
+
+    ScenarioEpochState result{};
+    result.time = current_time;
+    result.receiver_powered = true;
+    result.signal_available = true;
+
+    if (engine.config.scenario == ScenarioType::REA) {
+        const std::int64_t period_ns = engine.config.rea.signal_on_ns + engine.config.rea.signal_off_ns;
+        result.cycle_index = static_cast<std::uint64_t>(elapsed_ns / period_ns);
+        result.phase_elapsed_ns = elapsed_ns % period_ns;
+        result.signal_available = result.phase_elapsed_ns < engine.config.rea.signal_on_ns;
+    } else if (engine.config.scenario == ScenarioType::TTFF) {
+        const std::int64_t period_ns = engine.config.ttff.power_on_ns + engine.config.ttff.power_off_ns;
+        result.cycle_index = static_cast<std::uint64_t>(elapsed_ns / period_ns);
+        result.phase_elapsed_ns = elapsed_ns % period_ns;
+        result.receiver_powered = result.phase_elapsed_ns < engine.config.ttff.power_on_ns;
+        result.signal_available = result.receiver_powered;
+    } else {
+        result.cycle_index = 0U;
+        result.phase_elapsed_ns = elapsed_ns;
+    }
+
+    *state = result;
+    return true;
+}
+
+} // namespace
+
+bool initialize_scenario_engine(const SimConfig& config, const SimTime& start_time, ScenarioEngine* engine,
+                                std::string* error_message) {
+    if (engine == nullptr || !valid_time(start_time)) {
+        set_error(error_message, "scenario engine initialization has invalid arguments");
+        return false;
+    }
+    if (!validate_sim_config(config, error_message)) {
+        return false;
+    }
+
+    ScenarioEngine result{};
+    result.config = config;
+    result.start_time = start_time;
+    result.last_time = start_time;
+    result.initialized = true;
+    *engine = result;
+    return true;
+}
+
+bool update_scenario_engine(ScenarioEngine* engine, const SimTime& current_time, ScenarioEpochState* state,
+                            std::string* error_message) {
+    if (engine == nullptr || state == nullptr || !engine->initialized || !valid_time(current_time) ||
+        compare_sim_time(current_time, engine->start_time) < 0 ||
+        (engine->have_last_state && compare_sim_time(current_time, engine->last_time) < 0)) {
+        set_error(error_message, "scenario engine update has invalid or non-monotonic time");
+        return false;
+    }
+
+    ScenarioEpochState result{};
+    if (!compute_state(*engine, current_time, &result)) {
+        set_error(error_message, "cannot compute scenario state");
+        return false;
+    }
+
+    if (!engine->have_last_state) {
+        result.power_on_transition = result.receiver_powered;
+        result.signal_on_transition = result.signal_available;
+    } else {
+        result.power_on_transition = !engine->last_receiver_powered && result.receiver_powered;
+        result.power_off_transition = engine->last_receiver_powered && !result.receiver_powered;
+        result.signal_on_transition = !engine->last_signal_available && result.signal_available;
+        result.signal_off_transition = engine->last_signal_available && !result.signal_available;
+    }
+
+    engine->last_time = current_time;
+    engine->last_receiver_powered = result.receiver_powered;
+    engine->last_signal_available = result.signal_available;
+    engine->have_last_state = true;
+    *state = result;
+    return true;
+}
+
+} // namespace gnss_sim

--- a/src/scenario/scenario_engine.h
+++ b/src/scenario/scenario_engine.h
@@ -1,0 +1,41 @@
+#ifndef GNSS_SIM_SRC_SCENARIO_SCENARIO_ENGINE_H_
+#define GNSS_SIM_SRC_SCENARIO_SCENARIO_ENGINE_H_
+
+#include "gnss_sim/sim_config.h"
+#include "gnss_sim/sim_types.h"
+
+#include <cstdint>
+#include <string>
+
+namespace gnss_sim {
+
+struct ScenarioEpochState {
+    SimTime time;
+    bool receiver_powered;
+    bool signal_available;
+    bool power_on_transition;
+    bool power_off_transition;
+    bool signal_on_transition;
+    bool signal_off_transition;
+    std::uint64_t cycle_index;
+    std::int64_t phase_elapsed_ns;
+};
+
+struct ScenarioEngine {
+    SimConfig config;
+    SimTime start_time;
+    SimTime last_time;
+    bool initialized;
+    bool have_last_state;
+    bool last_receiver_powered;
+    bool last_signal_available;
+};
+
+bool initialize_scenario_engine(const SimConfig& config, const SimTime& start_time, ScenarioEngine* engine,
+                                std::string* error_message);
+bool update_scenario_engine(ScenarioEngine* engine, const SimTime& current_time, ScenarioEpochState* state,
+                            std::string* error_message);
+
+} // namespace gnss_sim
+
+#endif // GNSS_SIM_SRC_SCENARIO_SCENARIO_ENGINE_H_

--- a/tests/integration/test_scenarios.cpp
+++ b/tests/integration/test_scenarios.cpp
@@ -1,0 +1,156 @@
+#include "gnss_sim/sim_config.h"
+#include "gnss_sim/sim_time.h"
+#include "gnss_sim/simulator.h"
+
+#include <cstdio>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <string>
+
+namespace {
+
+std::string nav_path() {
+    return std::string(GNSS_SIM_TEST_DATA_DIR) + "/gps_loopback_nav.rnx";
+}
+
+gnss_sim::SimTime start_time() {
+    gnss_sim::SimTime time{};
+    EXPECT_TRUE(gnss_sim::sim_time_from_week_sow(2253, 172900.0, &time));
+    return time;
+}
+
+gnss_sim::SimConfig base_config(gnss_sim::ScenarioType scenario) {
+    gnss_sim::SimConfig config = gnss_sim::default_sim_config();
+    config.scenario = scenario;
+    config.atmosphere_mode = gnss_sim::AtmosphereMode::NONE;
+    config.elevation_mask_deg = 0.0;
+    config.output_eph = true;
+    config.output_ion = true;
+    config.seed = 1U;
+    return config;
+}
+
+std::string test_output_path(const char* name) {
+    return std::string("gnss_sim_") + name + ".log";
+}
+
+bool run(const gnss_sim::SimConfig& config, const char* name, gnss_sim::SimulatorRunSummary* summary,
+         std::string* error_message) {
+    const std::string output_path = test_output_path(name);
+    std::remove(output_path.c_str());
+    const std::string input_path = nav_path();
+    const gnss_sim::SimulatorRunOptions options{input_path.c_str(), output_path.c_str(), start_time()};
+    const bool ok = gnss_sim::run_simulator(config, options, summary, error_message);
+    if (!ok) {
+        std::remove(output_path.c_str());
+    }
+    return ok;
+}
+
+bool file_contains(const std::string& path, const std::string& text) {
+    std::ifstream input(path, std::ios::binary);
+    const std::string contents((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
+    return contents.find(text) != std::string::npos;
+}
+
+TEST(StreamingSimulator, KsProducesOneLogSetPerEpoch) {
+    gnss_sim::SimConfig config = base_config(gnss_sim::ScenarioType::KS);
+    config.sampling_rate_hz = 5;
+    config.duration_ns = 10LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    gnss_sim::SimulatorRunSummary summary{};
+    std::string error_message;
+    ASSERT_TRUE(run(config, "ks", &summary, &error_message)) << error_message;
+    EXPECT_EQ(summary.scheduled_epochs, 50U);
+    EXPECT_EQ(summary.powered_epochs, 50U);
+    EXPECT_EQ(summary.signal_on_epochs, 50U);
+    EXPECT_EQ(summary.range_messages, 50U);
+    EXPECT_EQ(summary.psrpos_messages, 50U);
+    EXPECT_EQ(summary.psrvel_messages, 50U);
+    EXPECT_EQ(summary.power_on_events, 1U);
+    EXPECT_EQ(summary.power_off_events, 0U);
+    EXPECT_GT(summary.max_observations_per_epoch, 0);
+    EXPECT_GT(summary.valid_position_epochs, 0U);
+    EXPECT_GT(summary.valid_velocity_epochs, 0U);
+    std::remove(test_output_path("ks").c_str());
+}
+
+TEST(StreamingSimulator, ReaKeepsLogsRunningWithZeroRangeDuringSignalOff) {
+    gnss_sim::SimConfig config = base_config(gnss_sim::ScenarioType::REA);
+    config.sampling_rate_hz = 10;
+    config.duration_ns = 6LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    config.rea.signal_on_ns = 2LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    config.rea.signal_off_ns = 1LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    gnss_sim::SimulatorRunSummary summary{};
+    std::string error_message;
+    ASSERT_TRUE(run(config, "rea", &summary, &error_message)) << error_message;
+    EXPECT_EQ(summary.scheduled_epochs, 60U);
+    EXPECT_EQ(summary.powered_epochs, 60U);
+    EXPECT_EQ(summary.signal_on_epochs, 40U);
+    EXPECT_EQ(summary.signal_off_epochs, 20U);
+    EXPECT_EQ(summary.range_messages, 60U);
+    EXPECT_EQ(summary.psrpos_messages, 60U);
+    EXPECT_EQ(summary.psrvel_messages, 60U);
+    EXPECT_EQ(summary.power_off_events, 0U);
+    EXPECT_EQ(summary.signal_off_events, 2U);
+    EXPECT_EQ(summary.signal_on_events, 2U);
+    EXPECT_TRUE(file_contains(test_output_path("rea"), ";0*"));
+    EXPECT_TRUE(file_contains(test_output_path("rea"), "INSUFFICIENT_OBS,NONE"));
+    std::remove(test_output_path("rea").c_str());
+}
+
+void expect_ttff_log_suppression(gnss_sim::StartupMode mode, const char* name) {
+    gnss_sim::SimConfig config = base_config(gnss_sim::ScenarioType::TTFF);
+    config.ttff.startup_mode = mode;
+    config.sampling_rate_hz = 10;
+    config.duration_ns = 8LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    config.ttff.power_on_ns = 3LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    config.ttff.power_off_ns = 1LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    gnss_sim::SimulatorRunSummary summary{};
+    std::string error_message;
+    ASSERT_TRUE(run(config, name, &summary, &error_message)) << error_message;
+    EXPECT_EQ(summary.scheduled_epochs, 80U);
+    EXPECT_EQ(summary.powered_epochs, 60U);
+    EXPECT_EQ(summary.range_messages, 60U);
+    EXPECT_EQ(summary.psrpos_messages, 60U);
+    EXPECT_EQ(summary.psrvel_messages, 60U);
+    EXPECT_EQ(summary.power_on_events, 2U);
+    EXPECT_EQ(summary.power_off_events, 2U);
+    std::remove(test_output_path(name).c_str());
+}
+
+TEST(StreamingSimulator, HotTtffSuppressesAllReceiverLogsWhilePowerIsOff) {
+    expect_ttff_log_suppression(gnss_sim::StartupMode::HOT, "ttff_hot");
+}
+
+TEST(StreamingSimulator, WarmTtffSuppressesAllReceiverLogsWhilePowerIsOff) {
+    expect_ttff_log_suppression(gnss_sim::StartupMode::WARM, "ttff_warm");
+}
+
+TEST(StreamingSimulator, ColdTtffAcquiresEphemerisBeforeSolutionBecomesValid) {
+    gnss_sim::SimConfig config = base_config(gnss_sim::ScenarioType::TTFF);
+    config.ttff.startup_mode = gnss_sim::StartupMode::COLD;
+    config.sampling_rate_hz = 1;
+    config.duration_ns = 40LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    config.ttff.power_on_ns = 40LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    config.ttff.power_off_ns = 2LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    gnss_sim::SimulatorRunSummary summary{};
+    std::string error_message;
+    ASSERT_TRUE(run(config, "ttff_cold", &summary, &error_message)) << error_message;
+    EXPECT_EQ(summary.scheduled_epochs, 40U);
+    EXPECT_EQ(summary.powered_epochs, 40U);
+    EXPECT_GT(summary.nav_messages, 0U);
+    EXPECT_GT(summary.valid_position_epochs, 0U);
+    EXPECT_GT(summary.valid_velocity_epochs, 0U);
+    EXPECT_TRUE(file_contains(test_output_path("ttff_cold"), "#GPSEPHEMA,"));
+    std::remove(test_output_path("ttff_cold").c_str());
+}
+
+TEST(StreamingSimulator, OneSecondDurationHasExactEpochCountAtEveryFrozenRate) {
+    for (const int rate : {1, 5, 10, 20, 50}) {
+        std::uint64_t count = 0;
+        ASSERT_TRUE(gnss_sim::epoch_count_for_duration(gnss_sim::NANOSECONDS_PER_SECOND, rate, &count));
+        EXPECT_EQ(count, static_cast<std::uint64_t>(rate));
+    }
+}
+
+} // namespace

--- a/tests/unit/test_navigation_state.cpp
+++ b/tests/unit/test_navigation_state.cpp
@@ -197,7 +197,8 @@ TEST_F(NavigationStateTest, MixedTypeAppendReportsActualReceiverPartitionIndex) 
         ASSERT_TRUE(gnss_sim::rtklib_nav_record_info(gnss_sim::truth_navigation_store(state_), index, &info));
         if (info.kind == gnss_sim::RtklibNavRecordKind::kGlonassEphemeris && glo_index < 0) {
             glo_index = index;
-        } else if (info.kind == gnss_sim::RtklibNavRecordKind::kEphemeris && info.satellite_number > 0 && gps_index < 0) {
+        } else if (info.kind == gnss_sim::RtklibNavRecordKind::kEphemeris && info.satellite_number > 0 &&
+                   gps_index < 0) {
             char satellite_id[4]{};
             ASSERT_TRUE(gnss_sim::rtklib_satellite_number_to_id(info.satellite_number, satellite_id));
             if (satellite_id[0] == 'G') {
@@ -210,15 +211,15 @@ TEST_F(NavigationStateTest, MixedTypeAppendReportsActualReceiverPartitionIndex) 
 
     bool emitted = false;
     gnss_sim::NavigationUpdateEvent glo_event{};
-    ASSERT_TRUE(gnss_sim::apply_truth_navigation_record(state_, glo_index, startup_time, &glo_event, &emitted,
-                                                         &error_message))
+    ASSERT_TRUE(
+        gnss_sim::apply_truth_navigation_record(state_, glo_index, startup_time, &glo_event, &emitted, &error_message))
         << error_message;
     ASSERT_TRUE(emitted);
 
     gnss_sim::NavigationUpdateEvent gps_event{};
     emitted = false;
-    ASSERT_TRUE(gnss_sim::apply_truth_navigation_record(state_, gps_index, startup_time, &gps_event, &emitted,
-                                                         &error_message))
+    ASSERT_TRUE(
+        gnss_sim::apply_truth_navigation_record(state_, gps_index, startup_time, &gps_event, &emitted, &error_message))
         << error_message;
     ASSERT_TRUE(emitted);
 

--- a/tests/unit/test_navigation_state.cpp
+++ b/tests/unit/test_navigation_state.cpp
@@ -1,3 +1,4 @@
+#include "gnss/nav_output_record.h"
 #include "gnss/navigation_state.h"
 #include "gnss/rtklib_adapter.h"
 #include "gnss_sim/sim_time.h"
@@ -178,6 +179,56 @@ TEST_F(NavigationStateTest, ColdStartAcceptsSchedulerDeliveredEphemerisAfterStar
     EXPECT_TRUE(emitted);
     EXPECT_TRUE(
         gnss_sim::rtklib_nav_store_has_satellite_ephemeris(gnss_sim::receiver_navigation_store(state_), gps_satellite));
+}
+
+TEST_F(NavigationStateTest, MixedTypeAppendReportsActualReceiverPartitionIndex) {
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::load_truth_navigation(state_, mixed_nav_path().c_str(), &error_message)) << error_message;
+    gnss_sim::SimTime startup_time{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2041, 180000.0, &startup_time));
+    ASSERT_TRUE(
+        gnss_sim::initialize_receiver_navigation(state_, gnss_sim::StartupMode::COLD, startup_time, &error_message))
+        << error_message;
+
+    int glo_index = -1;
+    int gps_index = -1;
+    for (int index = 0; index < gnss_sim::navigation_truth_record_count(state_); ++index) {
+        gnss_sim::RtklibNavRecordInfo info{};
+        ASSERT_TRUE(gnss_sim::rtklib_nav_record_info(gnss_sim::truth_navigation_store(state_), index, &info));
+        if (info.kind == gnss_sim::RtklibNavRecordKind::kGlonassEphemeris && glo_index < 0) {
+            glo_index = index;
+        } else if (info.kind == gnss_sim::RtklibNavRecordKind::kEphemeris && info.satellite_number > 0 && gps_index < 0) {
+            char satellite_id[4]{};
+            ASSERT_TRUE(gnss_sim::rtklib_satellite_number_to_id(info.satellite_number, satellite_id));
+            if (satellite_id[0] == 'G') {
+                gps_index = index;
+            }
+        }
+    }
+    ASSERT_GE(glo_index, 0);
+    ASSERT_GE(gps_index, 0);
+
+    bool emitted = false;
+    gnss_sim::NavigationUpdateEvent glo_event{};
+    ASSERT_TRUE(gnss_sim::apply_truth_navigation_record(state_, glo_index, startup_time, &glo_event, &emitted,
+                                                         &error_message))
+        << error_message;
+    ASSERT_TRUE(emitted);
+
+    gnss_sim::NavigationUpdateEvent gps_event{};
+    emitted = false;
+    ASSERT_TRUE(gnss_sim::apply_truth_navigation_record(state_, gps_index, startup_time, &gps_event, &emitted,
+                                                         &error_message))
+        << error_message;
+    ASSERT_TRUE(emitted);
+
+    gnss_sim::NavOutputRecord output_record{};
+    ASSERT_TRUE(gnss_sim::rtklib_nav_output_record(gnss_sim::receiver_navigation_store(state_),
+                                                   gps_event.receiver_record_index, &output_record, &error_message))
+        << error_message;
+    EXPECT_EQ(output_record.kind, gnss_sim::RtklibNavRecordKind::kEphemeris);
+    EXPECT_EQ(output_record.ephemeris.satellite_number, gps_event.satellite_number);
+    EXPECT_EQ(gps_event.receiver_record_index, 0);
 }
 
 } // namespace

--- a/tests/unit/test_scenario_engine.cpp
+++ b/tests/unit/test_scenario_engine.cpp
@@ -1,0 +1,103 @@
+#include "gnss_sim/sim_config.h"
+#include "gnss_sim/sim_time.h"
+#include "scenario/scenario_engine.h"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+gnss_sim::SimTime make_time(int week, double sow) {
+    gnss_sim::SimTime time{};
+    EXPECT_TRUE(gnss_sim::sim_time_from_week_sow(week, sow, &time));
+    return time;
+}
+
+TEST(ScenarioEngine, KsRemainsPoweredAndSignalOn) {
+    gnss_sim::SimConfig config = gnss_sim::default_sim_config();
+    config.scenario = gnss_sim::ScenarioType::KS;
+    gnss_sim::ScenarioEngine engine{};
+    std::string error;
+    ASSERT_TRUE(gnss_sim::initialize_scenario_engine(config, make_time(2300, 604799.5), &engine, &error)) << error;
+
+    gnss_sim::ScenarioEpochState state{};
+    ASSERT_TRUE(gnss_sim::update_scenario_engine(&engine, make_time(2300, 604799.5), &state, &error)) << error;
+    EXPECT_TRUE(state.receiver_powered);
+    EXPECT_TRUE(state.signal_available);
+    EXPECT_TRUE(state.power_on_transition);
+    EXPECT_TRUE(state.signal_on_transition);
+
+    ASSERT_TRUE(gnss_sim::update_scenario_engine(&engine, make_time(2301, 0.5), &state, &error)) << error;
+    EXPECT_TRUE(state.receiver_powered);
+    EXPECT_TRUE(state.signal_available);
+    EXPECT_FALSE(state.power_on_transition);
+    EXPECT_FALSE(state.signal_on_transition);
+}
+
+TEST(ScenarioEngine, ReaChangesSignalAtExactIntegerBoundaries) {
+    gnss_sim::SimConfig config = gnss_sim::default_sim_config();
+    config.scenario = gnss_sim::ScenarioType::REA;
+    config.rea.signal_on_ns = 300LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    config.rea.signal_off_ns = 10LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    const gnss_sim::SimTime start = make_time(2300, 1000.0);
+    gnss_sim::ScenarioEngine engine{};
+    std::string error;
+    ASSERT_TRUE(gnss_sim::initialize_scenario_engine(config, start, &engine, &error)) << error;
+
+    gnss_sim::ScenarioEpochState state{};
+    ASSERT_TRUE(gnss_sim::update_scenario_engine(&engine, start, &state, &error));
+    ASSERT_TRUE(gnss_sim::update_scenario_engine(&engine, make_time(2300, 1299.999), &state, &error));
+    EXPECT_TRUE(state.signal_available);
+    ASSERT_TRUE(gnss_sim::update_scenario_engine(&engine, make_time(2300, 1300.0), &state, &error));
+    EXPECT_FALSE(state.signal_available);
+    EXPECT_TRUE(state.signal_off_transition);
+    EXPECT_TRUE(state.receiver_powered);
+    ASSERT_TRUE(gnss_sim::update_scenario_engine(&engine, make_time(2300, 1310.0), &state, &error));
+    EXPECT_TRUE(state.signal_available);
+    EXPECT_TRUE(state.signal_on_transition);
+    EXPECT_EQ(state.cycle_index, 1U);
+}
+
+TEST(ScenarioEngine, TtffPowerOffSuppressesSignalAndRestartsEachCycle) {
+    gnss_sim::SimConfig config = gnss_sim::default_sim_config();
+    config.scenario = gnss_sim::ScenarioType::TTFF;
+    const gnss_sim::SimTime start = make_time(2300, 2000.0);
+    gnss_sim::ScenarioEngine engine{};
+    std::string error;
+    ASSERT_TRUE(gnss_sim::initialize_scenario_engine(config, start, &engine, &error)) << error;
+
+    gnss_sim::ScenarioEpochState state{};
+    ASSERT_TRUE(gnss_sim::update_scenario_engine(&engine, start, &state, &error));
+    ASSERT_TRUE(gnss_sim::update_scenario_engine(&engine, make_time(2300, 2300.0), &state, &error));
+    EXPECT_FALSE(state.receiver_powered);
+    EXPECT_FALSE(state.signal_available);
+    EXPECT_TRUE(state.power_off_transition);
+    EXPECT_TRUE(state.signal_off_transition);
+    ASSERT_TRUE(gnss_sim::update_scenario_engine(&engine, make_time(2300, 2330.0), &state, &error));
+    EXPECT_TRUE(state.receiver_powered);
+    EXPECT_TRUE(state.signal_available);
+    EXPECT_TRUE(state.power_on_transition);
+    EXPECT_TRUE(state.signal_on_transition);
+    EXPECT_EQ(state.cycle_index, 1U);
+}
+
+TEST(ScenarioEngine, EventEffectiveAtFirstEpochAtOrAfterBoundary) {
+    gnss_sim::SimConfig config = gnss_sim::default_sim_config();
+    config.scenario = gnss_sim::ScenarioType::REA;
+    config.rea.signal_on_ns = 1000500000LL;
+    config.rea.signal_off_ns = 1000000000LL;
+    config.sampling_rate_hz = 10;
+    const gnss_sim::SimTime start = make_time(2300, 1000.0);
+    gnss_sim::ScenarioEngine engine{};
+    std::string error;
+    ASSERT_TRUE(gnss_sim::initialize_scenario_engine(config, start, &engine, &error));
+
+    gnss_sim::ScenarioEpochState state{};
+    ASSERT_TRUE(gnss_sim::update_scenario_engine(&engine, start, &state, &error));
+    ASSERT_TRUE(gnss_sim::update_scenario_engine(&engine, make_time(2300, 1001.0), &state, &error));
+    EXPECT_TRUE(state.signal_available);
+    ASSERT_TRUE(gnss_sim::update_scenario_engine(&engine, make_time(2300, 1001.1), &state, &error));
+    EXPECT_FALSE(state.signal_available);
+    EXPECT_TRUE(state.signal_off_transition);
+}
+
+} // namespace


### PR DESCRIPTION
Closes #15.

## Summary
- add an integer-time scenario engine for KS, REA, and TTFF with explicit power/signal transition events;
- add a streaming simulator run API and minimal CLI (`--config/--nav/--output/--week/--sow`);
- keep a single per-epoch orchestration path: scenario -> truth geometry -> signal tracking -> Receiver NAV acquisition/update -> zero-noise observations -> RTKLIB solution -> receiver logs;
- stream RANGEA/PSRPOSA/PSRVELA and supported NovAtel NAV records directly to disk without retaining epoch history;
- keep REA receiver power/NAV state alive while RF is off and continue zero-observation/invalid-solution logs;
- suppress all receiver logs during TTFF power-off and reapply HOT/WARM/COLD startup semantics at every OFF->ON transition;
- drive COLD ephemeris availability from the existing constellation NAV fragment schedulers, selecting the earliest usable tracked signal for each NAV family;
- prevent COLD startup from replaying superseded historical ephemerides after the current broadcast ephemeris is decoded;
- fix mixed-type Receiver NAV event indexing so an appended EPH/GLO/ION record resolves to its actual post-partition index instead of assuming `count-1`;
- add unit tests for exact scenario boundaries/cross-week behavior and short KS, REA, HOT TTFF, WARM TTFF, and COLD TTFF integration runs.

## Implementation Notes
`run_simulator()` intentionally requires `atmosphere_mode` to be explicitly `none` or `broadcast`. The project-wide V1 atmosphere default was not frozen by #19, so this PR does not silently choose one; integration tests use `none` for the ideal deterministic loopback.

The runtime keeps only fixed per-satellite/per-signal tracking/ambiguity state, the decoded Receiver NAV store, and the finite RINEX NAV schedule. It does not accumulate observations or solutions with run duration. Receiver log messages are framed by the existing output writers and written immediately.

Truth CSV/manifest serialization remains #16; this PR establishes the orchestration points and run summary without duplicating #16 output ownership.

Full clang-format + Ubuntu/GCC + Windows/MSVC CI must pass before merge.