### PR TITLE
Implement streamed truth outputs and reproducibility manifest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,18 @@ set(GNSS_SIM_RTKLIB_COMMIT "dc596ba725ccaa5ab5963d7e7ec85b52ae743969" CACHE STRI
 set(GNSS_SIM_CJSON_COMMIT "acc76239bee01d8e9c858ae2cab296704e52d916" CACHE STRING
     "Pinned cJSON commit used by this simulator build")
 
+execute_process(
+    COMMAND git rev-parse HEAD
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    RESULT_VARIABLE GNSS_SIM_GIT_RESULT
+    OUTPUT_VARIABLE GNSS_SIM_SOURCE_COMMIT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+if(NOT GNSS_SIM_GIT_RESULT EQUAL 0 OR GNSS_SIM_SOURCE_COMMIT STREQUAL "")
+    set(GNSS_SIM_SOURCE_COMMIT "unknown")
+endif()
+
 if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/third_party/RTKLIB/src/rtklib.h")
     message(FATAL_ERROR
         "RTKLIB submodule is missing. Run: git submodule update --init --recursive")
@@ -92,6 +104,7 @@ add_library(gnss_sim_core STATIC
     src/output/novatel_nav_writer.cpp
     src/output/novatel_range_writer.cpp
     src/output/novatel_solution_writer.cpp
+    src/output/truth_writer.cpp
     src/output/unicore_nav_writer.cpp
     src/scenario/scenario_engine.cpp
     src/solution/solution_engine.cpp
@@ -101,6 +114,8 @@ target_include_directories(gnss_sim_core
     PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"
     PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src"
 )
+target_compile_definitions(gnss_sim_core PRIVATE
+    GNSS_SIM_SOURCE_COMMIT="${GNSS_SIM_SOURCE_COMMIT}")
 target_link_libraries(gnss_sim_core
     PRIVATE gnss_sim::rtklib gnss_sim::cjson
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,7 @@ if(BUILD_TESTING)
 
     add_executable(gnss_sim_integration_tests
         tests/integration/test_scenarios.cpp
+        tests/integration/test_truth_outputs.cpp
     )
     target_include_directories(gnss_sim_integration_tests PRIVATE
         "${CMAKE_CURRENT_SOURCE_DIR}/src")

--- a/include/gnss_sim/simulator.h
+++ b/include/gnss_sim/simulator.h
@@ -37,6 +37,7 @@ bool run_simulator(const SimConfig& config, const SimulatorRunOptions& options, 
                    std::string* error_message);
 
 const char* simulator_version();
+const char* simulator_commit_sha();
 const char* rtklib_commit_sha();
 
 } // namespace gnss_sim

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -16,6 +16,7 @@
 #include "output/novatel_nav_writer.h"
 #include "output/novatel_range_writer.h"
 #include "output/novatel_solution_writer.h"
+#include "output/truth_writer.h"
 #include "scenario/scenario_engine.h"
 #include "solution/solution_engine.h"
 
@@ -28,6 +29,9 @@
 
 #ifndef GNSS_SIM_RTKLIB_COMMIT
 #define GNSS_SIM_RTKLIB_COMMIT "unknown"
+#endif
+#ifndef GNSS_SIM_SOURCE_COMMIT
+#define GNSS_SIM_SOURCE_COMMIT "unknown"
 #endif
 
 namespace gnss_sim {
@@ -639,7 +643,7 @@ bool process_receiver_nav(RuntimeState* runtime, const SimConfig& config, const 
 bool update_tracking_and_measurements(RuntimeState* runtime, const SimConfig& config,
                                       const ScenarioEpochState& scenario,
                                       std::vector<MeasurementObservation>* measurements, int* tracked_satellites,
-                                      std::string* error_message) {
+                                      TruthWriter* truth_writer, std::string* error_message) {
     measurements->clear();
     *tracked_satellites = 0;
     const RtklibNavStore* truth_nav = truth_navigation_store(runtime->navigation);
@@ -688,7 +692,9 @@ bool update_tracking_and_measurements(RuntimeState* runtime, const SimConfig& co
             }
             MeasurementObservation observation{};
             if (!generate_zero_noise_measurement(truth_nav, geometry, signal.tracker, atmosphere, &signal.ambiguity,
-                                                 &observation, error_message)) {
+                                                 &observation, error_message) ||
+                !truth_writer_write_observation(truth_writer, runtime->receiver, geometry, signal.tracker, observation,
+                                                error_message)) {
                 return false;
             }
             measurements->push_back(observation);
@@ -775,9 +781,18 @@ bool run_simulator(const SimConfig& config, const SimulatorRunOptions& options, 
         return false;
     }
 
+    TruthWriter* truth_writer =
+        create_truth_writer(options.output_log_path, options.rinex_nav_path, config, options.start_time, error_message);
+    if (truth_writer == nullptr) {
+        output.close();
+        destroy_navigation_state(runtime.navigation);
+        return false;
+    }
+
     std::uint64_t epoch_count = 0;
     if (!epoch_count_for_duration(config.duration_ns, config.sampling_rate_hz, &epoch_count)) {
         set_error(error_message, "cannot compute simulator epoch count");
+        destroy_truth_writer(truth_writer);
         destroy_navigation_state(runtime.navigation);
         return false;
     }
@@ -796,7 +811,8 @@ bool run_simulator(const SimConfig& config, const SimulatorRunOptions& options, 
             break;
         }
         ScenarioEpochState scenario{};
-        if (!update_scenario_engine(&scenario_engine, current_time, &scenario, error_message)) {
+        if (!update_scenario_engine(&scenario_engine, current_time, &scenario, error_message) ||
+            !truth_writer_write_scenario_events(truth_writer, scenario, scenario_startup_mode(config), error_message)) {
             ok = false;
             break;
         }
@@ -833,7 +849,7 @@ bool run_simulator(const SimConfig& config, const SimulatorRunOptions& options, 
 
         int tracked_satellites = 0;
         if (!update_tracking_and_measurements(&runtime, config, scenario, &measurements, &tracked_satellites,
-                                              error_message) ||
+                                              truth_writer, error_message) ||
             !process_receiver_nav(&runtime, config, current_time, &output, &result, error_message)) {
             ok = false;
             break;
@@ -847,6 +863,7 @@ bool run_simulator(const SimConfig& config, const SimulatorRunOptions& options, 
         if (!solve_receiver_epoch(receiver_navigation_store(runtime.navigation), current_time, data,
                                   static_cast<int>(measurements.size()), config.elevation_mask_deg,
                                   config.atmosphere_mode, &runtime.solution_state, &solution, error_message) ||
+            !truth_writer_write_solution(truth_writer, solution, tracked_satellites, error_message) ||
             !emit_epoch_logs(config, scenario, measurements, tracked_satellites, solution, &output, &result,
                              error_message)) {
             ok = false;
@@ -866,6 +883,11 @@ bool run_simulator(const SimConfig& config, const SimulatorRunOptions& options, 
         ok = false;
     }
     output.close();
+    if (ok && !finalize_truth_writer(truth_writer, result, simulator_version(), simulator_commit_sha(),
+                                     rtklib_commit_sha(), error_message)) {
+        ok = false;
+    }
+    destroy_truth_writer(truth_writer);
     destroy_navigation_state(runtime.navigation);
     if (!ok) {
         return false;
@@ -876,6 +898,10 @@ bool run_simulator(const SimConfig& config, const SimulatorRunOptions& options, 
 
 const char* simulator_version() {
     return "0.1.0-dev";
+}
+
+const char* simulator_commit_sha() {
+    return GNSS_SIM_SOURCE_COMMIT;
 }
 
 const char* rtklib_commit_sha() {

--- a/src/model/measurement_model.cpp
+++ b/src/model/measurement_model.cpp
@@ -246,6 +246,14 @@ bool generate_zero_noise_measurement(const RtklibNavStore* nav_store, const Sate
     result.range_rate_mps = geometry.range_rate_mps;
     result.satellite_clock_bias_m = kSpeedOfLightMps * geometry.satellite_state.clock_bias_sec;
     result.satellite_clock_drift_mps = kSpeedOfLightMps * geometry.satellite_state.clock_drift_sec_per_sec;
+    result.broadcast_message_family = bias_data.message_family;
+    for (int index = 0; index < 4; ++index) {
+        result.tgd_sec[index] = bias_data.tgd_sec[index];
+    }
+    for (int index = 0; index < 6; ++index) {
+        result.isc_sec[index] = bias_data.isc_sec[index];
+    }
+    result.glonass_dtaun_sec = bias_data.glonass_dtaun_sec;
     result.ionosphere_code_delay_m = atmosphere.ionosphere_code_delay_m;
     result.troposphere_delay_m = atmosphere.troposphere_delay_m;
     result.cn0_dbhz = tracker.cn0_dbhz;

--- a/src/model/measurement_model.h
+++ b/src/model/measurement_model.h
@@ -35,6 +35,10 @@ struct MeasurementObservation {
     double range_rate_mps;
     double satellite_clock_bias_m;
     double satellite_clock_drift_mps;
+    RtklibBroadcastMessageFamily broadcast_message_family;
+    double tgd_sec[4];
+    double isc_sec[6];
+    double glonass_dtaun_sec;
     double code_bias_m;
     double ionosphere_code_delay_m;
     double troposphere_delay_m;

--- a/src/output/truth_writer.cpp
+++ b/src/output/truth_writer.cpp
@@ -1,1 +1,527 @@
-// Truth/manifest writer is introduced by issue #16.
+#include "output/truth_writer.h"
+
+#include "gnss/rtklib_adapter.h"
+#include "gnss/signal_definitions.h"
+#include "gnss_sim/sim_time.h"
+#include "gnss_sim/simulator.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <locale>
+#include <new>
+#include <sstream>
+#include <string>
+
+namespace gnss_sim {
+
+struct TruthWriter {
+    std::filesystem::path output_directory;
+    std::ofstream event_stream;
+    std::ofstream observation_stream;
+    std::ofstream solution_stream;
+    SimConfig config;
+    SimTime start_time;
+    std::string rinex_nav_name;
+    std::string rinex_nav_hash;
+    std::uint64_t rinex_nav_size;
+    bool have_observation_time;
+    SimTime last_observation_time;
+    std::uint64_t observation_index;
+    bool finalized;
+};
+
+namespace {
+
+constexpr std::uint64_t kFnv1aOffsetBasis = 14695981039346656037ULL;
+constexpr std::uint64_t kFnv1aPrime = 1099511628211ULL;
+constexpr double kRadiansToDegrees = 180.0 / 3.141592653589793238462643383279502884;
+
+void set_error(std::string* error_message, const std::string& message) {
+    if (error_message != nullptr) {
+        *error_message = message;
+    }
+}
+
+const char* bool_json(bool value) {
+    return value ? "true" : "false";
+}
+
+const char* constellation_name(GnssConstellation constellation) {
+    switch (constellation) {
+        case GnssConstellation::kGps:
+            return "GPS";
+        case GnssConstellation::kGlonass:
+            return "GLONASS";
+        case GnssConstellation::kGalileo:
+            return "GALILEO";
+        case GnssConstellation::kBeidou:
+            return "BEIDOU";
+        case GnssConstellation::kQzss:
+            return "QZSS";
+    }
+    return "UNKNOWN";
+}
+
+const char* nav_kind_name(RtklibNavRecordKind kind) {
+    switch (kind) {
+        case RtklibNavRecordKind::kEphemeris:
+            return "EPHEMERIS";
+        case RtklibNavRecordKind::kGlonassEphemeris:
+            return "GLONASS_EPHEMERIS";
+        case RtklibNavRecordKind::kIonosphere:
+            return "IONOSPHERE";
+    }
+    return "UNKNOWN";
+}
+
+std::string json_escape(const char* text) {
+    if (text == nullptr) {
+        return std::string();
+    }
+    std::ostringstream escaped;
+    for (const unsigned char character : std::string(text)) {
+        switch (character) {
+            case '"':
+                escaped << "\\\"";
+                break;
+            case '\\':
+                escaped << "\\\\";
+                break;
+            case '\b':
+                escaped << "\\b";
+                break;
+            case '\f':
+                escaped << "\\f";
+                break;
+            case '\n':
+                escaped << "\\n";
+                break;
+            case '\r':
+                escaped << "\\r";
+                break;
+            case '\t':
+                escaped << "\\t";
+                break;
+            default:
+                if (character < 0x20U) {
+                    escaped << "\\u" << std::hex << std::setw(4) << std::setfill('0')
+                            << static_cast<unsigned int>(character) << std::dec << std::setfill(' ');
+                } else {
+                    escaped << static_cast<char>(character);
+                }
+                break;
+        }
+    }
+    return escaped.str();
+}
+
+std::string csv_escape(const char* text) {
+    const std::string source = text != nullptr ? std::string(text) : std::string();
+    if (source.find_first_of(",\"\r\n") == std::string::npos) {
+        return source;
+    }
+    std::string result = "\"";
+    for (char character : source) {
+        if (character == '"') {
+            result += "\"\"";
+        } else {
+            result += character;
+        }
+    }
+    result += '"';
+    return result;
+}
+
+std::string config_json(const SimConfig& config, int indent) {
+    const std::string pad(static_cast<std::size_t>(indent), ' ');
+    const std::string inner(static_cast<std::size_t>(indent + 2), ' ');
+    std::ostringstream output;
+    output.imbue(std::locale::classic());
+    output << std::setprecision(17);
+    output << "{\n";
+    output << inner << "\"schema_version\": " << config.schema_version << ",\n";
+    output << inner << "\"scenario\": \"" << scenario_type_name(config.scenario) << "\",\n";
+    output << inner << "\"duration_ns\": " << config.duration_ns << ",\n";
+    output << inner << "\"sampling_rate_hz\": " << config.sampling_rate_hz << ",\n";
+    output << inner << "\"elevation_mask_deg\": " << config.elevation_mask_deg << ",\n";
+    output << inner << "\"output_eph\": " << bool_json(config.output_eph) << ",\n";
+    output << inner << "\"output_ion\": " << bool_json(config.output_ion) << ",\n";
+    output << inner << "\"measurement_noise_enabled\": " << bool_json(config.measurement_noise_enabled) << ",\n";
+    output << inner << "\"multipath_enabled\": " << bool_json(config.multipath_enabled) << ",\n";
+    output << inner << "\"receiver_clock_bias_m\": " << config.receiver_clock_bias_m << ",\n";
+    output << inner << "\"receiver_clock_drift_mps\": " << config.receiver_clock_drift_mps << ",\n";
+    output << inner << "\"atmosphere_mode\": \"" << atmosphere_mode_name(config.atmosphere_mode) << "\",\n";
+    output << inner << "\"receiver\": {\n";
+    output << inner << "  \"latitude_deg\": " << config.receiver.latitude_deg << ",\n";
+    output << inner << "  \"longitude_deg\": " << config.receiver.longitude_deg << ",\n";
+    output << inner << "  \"height_m\": " << config.receiver.height_m << "\n";
+    output << inner << "},\n";
+    output << inner << "\"ttff\": {\n";
+    output << inner << "  \"startup_mode\": \"" << startup_mode_name(config.ttff.startup_mode) << "\",\n";
+    output << inner << "  \"power_on_ns\": " << config.ttff.power_on_ns << ",\n";
+    output << inner << "  \"power_off_ns\": " << config.ttff.power_off_ns << "\n";
+    output << inner << "},\n";
+    output << inner << "\"rea\": {\n";
+    output << inner << "  \"signal_on_ns\": " << config.rea.signal_on_ns << ",\n";
+    output << inner << "  \"signal_off_ns\": " << config.rea.signal_off_ns << "\n";
+    output << inner << "},\n";
+    output << inner << "\"seed\": " << config.seed << "\n";
+    output << pad << '}';
+    return output.str();
+}
+
+bool write_text_file(const std::filesystem::path& path, const std::string& content, std::string* error_message) {
+    std::ofstream output(path, std::ios::binary | std::ios::trunc);
+    if (!output) {
+        set_error(error_message, std::string("cannot open truth output: ") + path.generic_string());
+        return false;
+    }
+    output.write(content.data(), static_cast<std::streamsize>(content.size()));
+    output.flush();
+    if (!output) {
+        set_error(error_message, std::string("failed to write truth output: ") + path.generic_string());
+        return false;
+    }
+    return true;
+}
+
+bool input_identity(const char* path, std::string* name, std::string* hash, std::uint64_t* size,
+                    std::string* error_message) {
+    if (path == nullptr || name == nullptr || hash == nullptr || size == nullptr) {
+        set_error(error_message, "truth input identity request has invalid arguments");
+        return false;
+    }
+    std::ifstream input(path, std::ios::binary);
+    if (!input) {
+        set_error(error_message, std::string("cannot open RINEX NAV for hashing: ") + path);
+        return false;
+    }
+    std::uint64_t value = kFnv1aOffsetBasis;
+    std::uint64_t byte_count = 0;
+    char buffer[65536];
+    while (input) {
+        input.read(buffer, static_cast<std::streamsize>(sizeof(buffer)));
+        const std::streamsize count = input.gcount();
+        for (std::streamsize index = 0; index < count; ++index) {
+            value ^= static_cast<unsigned char>(buffer[index]);
+            value *= kFnv1aPrime;
+        }
+        byte_count += static_cast<std::uint64_t>(count);
+    }
+    if (!input.eof()) {
+        set_error(error_message, "failed while hashing RINEX NAV input");
+        return false;
+    }
+    std::ostringstream hash_stream;
+    hash_stream << std::hex << std::nouppercase << std::setw(16) << std::setfill('0') << value;
+    *hash = hash_stream.str();
+    *size = byte_count;
+    *name = std::filesystem::path(path).filename().generic_string();
+    return true;
+}
+
+bool open_csv(std::ofstream* stream, const std::filesystem::path& path, const char* header, std::string* error_message) {
+    stream->open(path, std::ios::binary | std::ios::trunc);
+    if (!*stream) {
+        set_error(error_message, std::string("cannot open truth CSV: ") + path.generic_string());
+        return false;
+    }
+    stream->imbue(std::locale::classic());
+    *stream << header << '\n';
+    if (!*stream) {
+        set_error(error_message, std::string("cannot write truth CSV header: ") + path.generic_string());
+        return false;
+    }
+    return true;
+}
+
+bool stream_ok(std::ofstream& stream, const char* name, std::string* error_message) {
+    if (stream) {
+        return true;
+    }
+    set_error(error_message, std::string("failed to write ") + name);
+    return false;
+}
+
+void write_time_prefix(std::ofstream& stream, const SimTime& time) {
+    stream << time.gps_week << ',' << time.tow_ns << ',' << std::fixed << std::setprecision(9)
+           << sim_time_sow_sec(time);
+}
+
+int satellite_prn(int satellite_number) {
+    char satellite_id[4]{};
+    if (!rtklib_satellite_number_to_id(satellite_number, satellite_id)) {
+        return 0;
+    }
+    return std::atoi(satellite_id + 1);
+}
+
+bool write_event_row(TruthWriter* writer, const SimTime& time, const char* event_type,
+                     const ScenarioEpochState* scenario, StartupMode startup_mode, const NavigationUpdateEvent* nav_event,
+                     std::string* error_message) {
+    write_time_prefix(writer->event_stream, time);
+    writer->event_stream << ',' << event_type << ',';
+    if (scenario != nullptr) {
+        writer->event_stream << scenario->cycle_index << ',' << (scenario->receiver_powered ? 1 : 0) << ','
+                             << (scenario->signal_available ? 1 : 0) << ',' << startup_mode_name(startup_mode) << ',';
+    } else {
+        writer->event_stream << ",,,,";
+    }
+    if (nav_event != nullptr) {
+        writer->event_stream << nav_event->truth_record_index << ',' << nav_event->receiver_record_index << ','
+                             << nav_kind_name(nav_event->kind) << ',' << nav_event->satellite_number << ','
+                             << nav_event->iode << ',' << nav_event->iodc;
+    } else {
+        writer->event_stream << ",,,,,";
+    }
+    writer->event_stream << '\n';
+    return stream_ok(writer->event_stream, "event_truth.csv", error_message);
+}
+
+} // namespace
+
+TruthWriter* create_truth_writer(const char* receiver_log_path, const char* rinex_nav_path, const SimConfig& config,
+                                 const SimTime& start_time, std::string* error_message) {
+    if (receiver_log_path == nullptr || receiver_log_path[0] == '\0' || rinex_nav_path == nullptr ||
+        rinex_nav_path[0] == '\0') {
+        set_error(error_message, "truth writer request has invalid paths");
+        return nullptr;
+    }
+
+    TruthWriter* writer = new (std::nothrow) TruthWriter{};
+    if (writer == nullptr) {
+        set_error(error_message, "cannot allocate truth writer");
+        return nullptr;
+    }
+    writer->config = config;
+    writer->start_time = start_time;
+    std::filesystem::path receiver_path(receiver_log_path);
+    writer->output_directory = receiver_path.parent_path();
+    if (writer->output_directory.empty()) {
+        writer->output_directory = ".";
+    }
+    if (!input_identity(rinex_nav_path, &writer->rinex_nav_name, &writer->rinex_nav_hash, &writer->rinex_nav_size,
+                        error_message)) {
+        delete writer;
+        return nullptr;
+    }
+
+    const char* event_header =
+        "gps_week,tow_ns,sow_sec,event_type,cycle_index,receiver_powered,signal_available,startup_mode,"
+        "truth_record_index,receiver_record_index,nav_kind,satellite_number,iode,iodc";
+    const char* observation_header =
+        "gps_week,tow_ns,sow_sec,observation_index,system,prn,satellite_number,signal_id,signal_name,"
+        "receiver_x_m,receiver_y_m,receiver_z_m,receiver_vx_mps,receiver_vy_mps,receiver_vz_mps,"
+        "transmit_week,transmit_tow_ns,transmit_sow_sec,satellite_x_m,satellite_y_m,satellite_z_m,"
+        "satellite_vx_mps,satellite_vy_mps,satellite_vz_mps,azimuth_deg,elevation_deg,geometric_range_m,"
+        "range_rate_mps,satellite_clock_bias_m,satellite_clock_drift_mps,receiver_clock_bias_m,"
+        "receiver_clock_drift_mps,ionosphere_m,troposphere_m,code_bias_m,code_bias_status,cn0_dbhz,"
+        "tracking_phase,lock_time_ns,pseudorange_valid,doppler_valid,adr_valid,ambiguity_cycles,"
+        "ambiguity_epoch_week,ambiguity_epoch_tow_ns,cycle_slip,pseudorange_m,doppler_hz,adr_cycles";
+    const char* solution_header =
+        "gps_week,tow_ns,sow_sec,tracked_satellites,position_valid,position_status,position_type,"
+        "latitude_deg,longitude_deg,height_m,position_x_m,position_y_m,position_z_m,latitude_std_m,"
+        "longitude_std_m,height_std_m,receiver_clock_bias_m,position_used_satellites,position_diagnostic,"
+        "velocity_valid,velocity_status,velocity_type,velocity_x_mps,velocity_y_mps,velocity_z_mps,"
+        "horizontal_speed_mps,track_over_ground_deg,vertical_speed_mps,receiver_clock_drift_mps,"
+        "velocity_used_satellites,velocity_diagnostic";
+
+    if (!open_csv(&writer->event_stream, writer->output_directory / "event_truth.csv", event_header, error_message) ||
+        !open_csv(&writer->observation_stream, writer->output_directory / "observation_truth.csv", observation_header,
+                  error_message) ||
+        !open_csv(&writer->solution_stream, writer->output_directory / "solution_truth.csv", solution_header,
+                  error_message)) {
+        delete writer;
+        return nullptr;
+    }
+
+    std::ostringstream scenario;
+    scenario.imbue(std::locale::classic());
+    scenario << "{\n"
+             << "  \"truth_schema_version\": " << TRUTH_OUTPUT_SCHEMA_VERSION << ",\n"
+             << "  \"start_time\": {\"gps_week\": " << start_time.gps_week << ", \"tow_ns\": "
+             << start_time.tow_ns << "},\n"
+             << "  \"resolved_config\": " << config_json(config, 2) << "\n"
+             << "}\n";
+    if (!write_text_file(writer->output_directory / "scenario.json", scenario.str(), error_message)) {
+        delete writer;
+        return nullptr;
+    }
+    return writer;
+}
+
+void destroy_truth_writer(TruthWriter* writer) {
+    delete writer;
+}
+
+bool truth_writer_write_scenario_events(TruthWriter* writer, const ScenarioEpochState& scenario,
+                                        StartupMode startup_mode, std::string* error_message) {
+    if (writer == nullptr || writer->finalized) {
+        set_error(error_message, "truth scenario event writer is unavailable");
+        return false;
+    }
+    if (scenario.power_on_transition &&
+        !write_event_row(writer, scenario.time, "POWER_ON", &scenario, startup_mode, nullptr, error_message)) {
+        return false;
+    }
+    if (scenario.power_off_transition &&
+        !write_event_row(writer, scenario.time, "POWER_OFF", &scenario, startup_mode, nullptr, error_message)) {
+        return false;
+    }
+    if (scenario.signal_on_transition &&
+        !write_event_row(writer, scenario.time, "SIGNAL_ON", &scenario, startup_mode, nullptr, error_message)) {
+        return false;
+    }
+    if (scenario.signal_off_transition &&
+        !write_event_row(writer, scenario.time, "SIGNAL_OFF", &scenario, startup_mode, nullptr, error_message)) {
+        return false;
+    }
+    return true;
+}
+
+bool truth_writer_write_nav_event(TruthWriter* writer, const NavigationUpdateEvent& event,
+                                  std::string* error_message) {
+    if (writer == nullptr || writer->finalized) {
+        set_error(error_message, "truth NAV event writer is unavailable");
+        return false;
+    }
+    return write_event_row(writer, event.availability_time, "NAV_UPDATE", nullptr, StartupMode::HOT, &event,
+                           error_message);
+}
+
+bool truth_writer_write_observation(TruthWriter* writer, const ReceiverTruth& receiver,
+                                    const SatelliteGeometry& geometry, const SignalTracker& tracker,
+                                    const MeasurementObservation& observation, std::string* error_message) {
+    if (writer == nullptr || writer->finalized) {
+        set_error(error_message, "truth observation writer is unavailable");
+        return false;
+    }
+    const SignalDefinition* definition = find_signal_definition(observation.signal_id);
+    if (definition == nullptr || geometry.satellite_number != observation.satellite_number) {
+        set_error(error_message, "truth observation has inconsistent signal/geometry metadata");
+        return false;
+    }
+    if (!writer->have_observation_time || compare_sim_time(writer->last_observation_time, geometry.receive_time) != 0) {
+        writer->have_observation_time = true;
+        writer->last_observation_time = geometry.receive_time;
+        writer->observation_index = 0;
+    }
+
+    SimTime transmit_time{};
+    if (!sim_time_from_week_sow(geometry.transmit_gps_week, geometry.transmit_sow_sec, &transmit_time)) {
+        set_error(error_message, "truth observation transmit time cannot be normalized");
+        return false;
+    }
+
+    std::ofstream& output = writer->observation_stream;
+    write_time_prefix(output, geometry.receive_time);
+    output << ',' << writer->observation_index++ << ',' << constellation_name(definition->constellation) << ','
+           << satellite_prn(observation.satellite_number) << ',' << observation.satellite_number << ','
+           << static_cast<int>(observation.signal_id) << ',' << csv_escape(definition->name) << ',' << std::scientific
+           << std::setprecision(17) << receiver.position_ecef_m[0] << ',' << receiver.position_ecef_m[1] << ','
+           << receiver.position_ecef_m[2] << ',' << receiver.velocity_ecef_mps[0] << ',' << receiver.velocity_ecef_mps[1]
+           << ',' << receiver.velocity_ecef_mps[2] << ',' << transmit_time.gps_week << ',' << transmit_time.tow_ns << ','
+           << std::fixed << std::setprecision(9) << geometry.transmit_sow_sec << ',' << std::scientific
+           << std::setprecision(17) << geometry.satellite_state.position_ecef_m[0] << ','
+           << geometry.satellite_state.position_ecef_m[1] << ',' << geometry.satellite_state.position_ecef_m[2] << ','
+           << geometry.satellite_state.velocity_ecef_mps[0] << ',' << geometry.satellite_state.velocity_ecef_mps[1]
+           << ',' << geometry.satellite_state.velocity_ecef_mps[2] << ',' << geometry.azimuth_rad * kRadiansToDegrees
+           << ',' << geometry.elevation_rad * kRadiansToDegrees << ',' << observation.geometric_range_m << ','
+           << observation.range_rate_mps << ',' << observation.satellite_clock_bias_m << ','
+           << observation.satellite_clock_drift_mps << ',' << writer->config.receiver_clock_bias_m << ','
+           << writer->config.receiver_clock_drift_mps << ',' << observation.ionosphere_code_delay_m << ','
+           << observation.troposphere_delay_m << ',' << observation.code_bias_m << ','
+           << broadcast_code_bias_status_name(observation.code_bias_status) << ',' << observation.cn0_dbhz << ','
+           << signal_tracking_phase_name(tracker.phase) << ',' << observation.lock_time_ns << ','
+           << (observation.pseudorange_valid ? 1 : 0) << ',' << (observation.doppler_valid ? 1 : 0) << ','
+           << (observation.adr_valid ? 1 : 0) << ',' << observation.ambiguity_cycles << ','
+           << tracker.tracking_start_time.gps_week << ',' << tracker.tracking_start_time.tow_ns << ",0,"
+           << observation.pseudorange_m << ',' << observation.doppler_hz << ',' << observation.adr_cycles << '\n';
+    return stream_ok(output, "observation_truth.csv", error_message);
+}
+
+bool truth_writer_write_solution(TruthWriter* writer, const SolutionEpoch& solution, int tracked_satellites,
+                                 std::string* error_message) {
+    if (writer == nullptr || writer->finalized || tracked_satellites < 0) {
+        set_error(error_message, "truth solution writer request has invalid arguments");
+        return false;
+    }
+    const PositionSolution& position = solution.position;
+    const VelocitySolution& velocity = solution.velocity;
+    std::ofstream& output = writer->solution_stream;
+    write_time_prefix(output, solution.time);
+    output << ',' << tracked_satellites << ',' << (position.valid ? 1 : 0) << ','
+           << receiver_solution_status_name(position.status) << ',' << receiver_solution_type_name(position.type) << ','
+           << std::scientific << std::setprecision(17) << position.latitude_deg << ',' << position.longitude_deg << ','
+           << position.height_m << ',' << position.position_ecef_m[0] << ',' << position.position_ecef_m[1] << ','
+           << position.position_ecef_m[2] << ',' << position.latitude_std_m << ',' << position.longitude_std_m << ','
+           << position.height_std_m << ',' << position.receiver_clock_bias_m << ',' << position.used_satellites << ','
+           << csv_escape(position.diagnostic) << ',' << (velocity.valid ? 1 : 0) << ','
+           << receiver_solution_status_name(velocity.status) << ',' << receiver_solution_type_name(velocity.type) << ','
+           << velocity.velocity_ecef_mps[0] << ',' << velocity.velocity_ecef_mps[1] << ','
+           << velocity.velocity_ecef_mps[2] << ',' << velocity.horizontal_speed_mps << ','
+           << velocity.track_over_ground_deg << ',' << velocity.vertical_speed_mps << ','
+           << velocity.receiver_clock_drift_mps << ',' << velocity.used_satellites << ','
+           << csv_escape(velocity.diagnostic) << '\n';
+    return stream_ok(output, "solution_truth.csv", error_message);
+}
+
+bool finalize_truth_writer(TruthWriter* writer, const SimulatorRunSummary& summary, const char* version,
+                           const char* commit_sha, const char* rtklib_sha, std::string* error_message) {
+    if (writer == nullptr || writer->finalized || version == nullptr || commit_sha == nullptr || rtklib_sha == nullptr) {
+        set_error(error_message, "truth writer finalization request has invalid arguments");
+        return false;
+    }
+    writer->event_stream.flush();
+    writer->observation_stream.flush();
+    writer->solution_stream.flush();
+    if (!writer->event_stream || !writer->observation_stream || !writer->solution_stream) {
+        set_error(error_message, "failed to flush streamed truth CSV output");
+        return false;
+    }
+    writer->event_stream.close();
+    writer->observation_stream.close();
+    writer->solution_stream.close();
+
+    std::ostringstream manifest;
+    manifest.imbue(std::locale::classic());
+    manifest << "{\n"
+             << "  \"output_format_version\": " << TRUTH_OUTPUT_SCHEMA_VERSION << ",\n"
+             << "  \"simulator_version\": \"" << json_escape(version) << "\",\n"
+             << "  \"simulator_commit_sha\": \"" << json_escape(commit_sha) << "\",\n"
+             << "  \"rtklib_commit_sha\": \"" << json_escape(rtklib_sha) << "\",\n"
+             << "  \"rinex_nav\": {\n"
+             << "    \"name\": \"" << json_escape(writer->rinex_nav_name.c_str()) << "\",\n"
+             << "    \"hash_algorithm\": \"fnv1a64\",\n"
+             << "    \"hash\": \"" << writer->rinex_nav_hash << "\",\n"
+             << "    \"size_bytes\": " << writer->rinex_nav_size << "\n"
+             << "  },\n"
+             << "  \"start_time\": {\"gps_week\": " << writer->start_time.gps_week << ", \"tow_ns\": "
+             << writer->start_time.tow_ns << "},\n"
+             << "  \"random_seed\": " << writer->config.seed << ",\n"
+             << "  \"resolved_config\": " << config_json(writer->config, 2) << ",\n"
+             << "  \"run_summary\": {\n"
+             << "    \"scheduled_epochs\": " << summary.scheduled_epochs << ",\n"
+             << "    \"powered_epochs\": " << summary.powered_epochs << ",\n"
+             << "    \"signal_on_epochs\": " << summary.signal_on_epochs << ",\n"
+             << "    \"signal_off_epochs\": " << summary.signal_off_epochs << ",\n"
+             << "    \"range_messages\": " << summary.range_messages << ",\n"
+             << "    \"psrpos_messages\": " << summary.psrpos_messages << ",\n"
+             << "    \"psrvel_messages\": " << summary.psrvel_messages << ",\n"
+             << "    \"nav_messages\": " << summary.nav_messages << ",\n"
+             << "    \"valid_position_epochs\": " << summary.valid_position_epochs << ",\n"
+             << "    \"valid_velocity_epochs\": " << summary.valid_velocity_epochs << ",\n"
+             << "    \"max_observations_per_epoch\": " << summary.max_observations_per_epoch << "\n"
+             << "  }\n"
+             << "}\n";
+    if (!write_text_file(writer->output_directory / "run_manifest.json", manifest.str(), error_message)) {
+        return false;
+    }
+    writer->finalized = true;
+    return true;
+}
+
+} // namespace gnss_sim

--- a/src/output/truth_writer.cpp
+++ b/src/output/truth_writer.cpp
@@ -344,8 +344,8 @@ TruthWriter* create_truth_writer(const char* receiver_log_path, const char* rine
     scenario.imbue(std::locale::classic());
     scenario << "{\n"
              << "  \"truth_schema_version\": " << TRUTH_OUTPUT_SCHEMA_VERSION << ",\n"
-             << "  \"start_time\": {\"gps_week\": " << start_time.gps_week << ", \"tow_ns\": "
-             << start_time.tow_ns << "},\n"
+             << "  \"start_time\": {\"gps_week\": " << start_time.gps_week << ", \"tow_ns\": " << start_time.tow_ns
+             << "},\n"
              << "  \"resolved_config\": " << config_json(config, 2) << "\n"
              << "}\n";
     if (!write_text_file(writer->output_directory / "scenario.json", scenario.str(), error_message)) {
@@ -417,8 +417,8 @@ bool truth_writer_write_observation(TruthWriter* writer, const ReceiverTruth& re
            << ',' << receiver.position_ecef_m[0] << ',' << receiver.position_ecef_m[1] << ','
            << receiver.position_ecef_m[2] << ',' << receiver.velocity_ecef_mps[0] << ','
            << receiver.velocity_ecef_mps[1] << ',' << receiver.velocity_ecef_mps[2] << ',' << transmit_time.gps_week
-           << ',' << transmit_time.tow_ns << ',' << std::fixed << std::setprecision(9) << geometry.transmit_sow_sec << ','
-           << std::scientific << std::setprecision(17) << geometry.satellite_state.position_ecef_m[0] << ','
+           << ',' << transmit_time.tow_ns << ',' << std::fixed << std::setprecision(9) << geometry.transmit_sow_sec
+           << ',' << std::scientific << std::setprecision(17) << geometry.satellite_state.position_ecef_m[0] << ','
            << geometry.satellite_state.position_ecef_m[1] << ',' << geometry.satellite_state.position_ecef_m[2] << ','
            << geometry.satellite_state.velocity_ecef_mps[0] << ',' << geometry.satellite_state.velocity_ecef_mps[1]
            << ',' << geometry.satellite_state.velocity_ecef_mps[2] << ',' << geometry.azimuth_rad * kRadiansToDegrees
@@ -427,8 +427,8 @@ bool truth_writer_write_observation(TruthWriter* writer, const ReceiverTruth& re
            << observation.satellite_clock_drift_mps << ',' << writer->config.receiver_clock_bias_m << ','
            << writer->config.receiver_clock_drift_mps << ',' << observation.ionosphere_code_delay_m << ','
            << observation.troposphere_delay_m << ','
-           << broadcast_message_family_name(observation.broadcast_message_family) << ',' << observation.tgd_sec[0] << ','
-           << observation.tgd_sec[1] << ',' << observation.tgd_sec[2] << ',' << observation.tgd_sec[3] << ','
+           << broadcast_message_family_name(observation.broadcast_message_family) << ',' << observation.tgd_sec[0]
+           << ',' << observation.tgd_sec[1] << ',' << observation.tgd_sec[2] << ',' << observation.tgd_sec[3] << ','
            << observation.isc_sec[0] << ',' << observation.isc_sec[1] << ',' << observation.isc_sec[2] << ','
            << observation.isc_sec[3] << ',' << observation.isc_sec[4] << ',' << observation.isc_sec[5] << ','
            << observation.glonass_dtaun_sec << ',' << observation.code_bias_m << ','

--- a/src/output/truth_writer.cpp
+++ b/src/output/truth_writer.cpp
@@ -65,14 +65,28 @@ const char* constellation_name(GnssConstellation constellation) {
     return "UNKNOWN";
 }
 
-const char* nav_kind_name(RtklibNavRecordKind kind) {
-    switch (kind) {
-        case RtklibNavRecordKind::kEphemeris:
-            return "EPHEMERIS";
-        case RtklibNavRecordKind::kGlonassEphemeris:
-            return "GLONASS_EPHEMERIS";
-        case RtklibNavRecordKind::kIonosphere:
-            return "IONOSPHERE";
+const char* broadcast_message_family_name(RtklibBroadcastMessageFamily family) {
+    switch (family) {
+        case RtklibBroadcastMessageFamily::kUnknown:
+            return "UNKNOWN";
+        case RtklibBroadcastMessageFamily::kLegacy:
+            return "LEGACY";
+        case RtklibBroadcastMessageFamily::kCnav:
+            return "CNAV";
+        case RtklibBroadcastMessageFamily::kCnav2:
+            return "CNAV2";
+        case RtklibBroadcastMessageFamily::kGalileoInav:
+            return "GALILEO_INAV";
+        case RtklibBroadcastMessageFamily::kGalileoFnav:
+            return "GALILEO_FNAV";
+        case RtklibBroadcastMessageFamily::kBeidouBcnav1:
+            return "BEIDOU_BCNAV1";
+        case RtklibBroadcastMessageFamily::kBeidouBcnav2:
+            return "BEIDOU_BCNAV2";
+        case RtklibBroadcastMessageFamily::kBeidouBcnav3:
+            return "BEIDOU_BCNAV3";
+        case RtklibBroadcastMessageFamily::kGlonassFdma:
+            return "GLONASS_FDMA";
     }
     return "UNKNOWN";
 }
@@ -223,7 +237,8 @@ bool input_identity(const char* path, std::string* name, std::string* hash, std:
     return true;
 }
 
-bool open_csv(std::ofstream* stream, const std::filesystem::path& path, const char* header, std::string* error_message) {
+bool open_csv(std::ofstream* stream, const std::filesystem::path& path, const char* header,
+              std::string* error_message) {
     stream->open(path, std::ios::binary | std::ios::trunc);
     if (!*stream) {
         set_error(error_message, std::string("cannot open truth CSV: ") + path.generic_string());
@@ -260,24 +275,11 @@ int satellite_prn(int satellite_number) {
 }
 
 bool write_event_row(TruthWriter* writer, const SimTime& time, const char* event_type,
-                     const ScenarioEpochState* scenario, StartupMode startup_mode, const NavigationUpdateEvent* nav_event,
-                     std::string* error_message) {
+                     const ScenarioEpochState& scenario, StartupMode startup_mode, std::string* error_message) {
     write_time_prefix(writer->event_stream, time);
-    writer->event_stream << ',' << event_type << ',';
-    if (scenario != nullptr) {
-        writer->event_stream << scenario->cycle_index << ',' << (scenario->receiver_powered ? 1 : 0) << ','
-                             << (scenario->signal_available ? 1 : 0) << ',' << startup_mode_name(startup_mode) << ',';
-    } else {
-        writer->event_stream << ",,,,";
-    }
-    if (nav_event != nullptr) {
-        writer->event_stream << nav_event->truth_record_index << ',' << nav_event->receiver_record_index << ','
-                             << nav_kind_name(nav_event->kind) << ',' << nav_event->satellite_number << ','
-                             << nav_event->iode << ',' << nav_event->iodc;
-    } else {
-        writer->event_stream << ",,,,,";
-    }
-    writer->event_stream << '\n';
+    writer->event_stream << ',' << event_type << ',' << scenario.cycle_index << ','
+                         << (scenario.receiver_powered ? 1 : 0) << ',' << (scenario.signal_available ? 1 : 0) << ','
+                         << startup_mode_name(startup_mode) << '\n';
     return stream_ok(writer->event_stream, "event_truth.csv", error_message);
 }
 
@@ -310,17 +312,17 @@ TruthWriter* create_truth_writer(const char* receiver_log_path, const char* rine
     }
 
     const char* event_header =
-        "gps_week,tow_ns,sow_sec,event_type,cycle_index,receiver_powered,signal_available,startup_mode,"
-        "truth_record_index,receiver_record_index,nav_kind,satellite_number,iode,iodc";
+        "gps_week,tow_ns,sow_sec,event_type,cycle_index,receiver_powered,signal_available,startup_mode";
     const char* observation_header =
-        "gps_week,tow_ns,sow_sec,observation_index,system,prn,satellite_number,signal_id,signal_name,"
-        "receiver_x_m,receiver_y_m,receiver_z_m,receiver_vx_mps,receiver_vy_mps,receiver_vz_mps,"
+        "gps_week,tow_ns,sow_sec,observation_index,system,prn,satellite_number,signal_id,signal_name,glonass_fcn,"
+        "wavelength_m,receiver_x_m,receiver_y_m,receiver_z_m,receiver_vx_mps,receiver_vy_mps,receiver_vz_mps,"
         "transmit_week,transmit_tow_ns,transmit_sow_sec,satellite_x_m,satellite_y_m,satellite_z_m,"
         "satellite_vx_mps,satellite_vy_mps,satellite_vz_mps,azimuth_deg,elevation_deg,geometric_range_m,"
         "range_rate_mps,satellite_clock_bias_m,satellite_clock_drift_mps,receiver_clock_bias_m,"
-        "receiver_clock_drift_mps,ionosphere_m,troposphere_m,code_bias_m,code_bias_status,cn0_dbhz,"
-        "tracking_phase,lock_time_ns,pseudorange_valid,doppler_valid,adr_valid,ambiguity_cycles,"
-        "ambiguity_epoch_week,ambiguity_epoch_tow_ns,cycle_slip,pseudorange_m,doppler_hz,adr_cycles";
+        "receiver_clock_drift_mps,ionosphere_m,troposphere_m,broadcast_message_family,tgd_sec_0,tgd_sec_1,"
+        "tgd_sec_2,tgd_sec_3,isc_sec_0,isc_sec_1,isc_sec_2,isc_sec_3,isc_sec_4,isc_sec_5,glonass_dtaun_sec,"
+        "code_bias_m,code_bias_status,cn0_dbhz,tracking_phase,lock_time_ns,pseudorange_valid,doppler_valid,adr_valid,"
+        "ambiguity_cycles,ambiguity_epoch_week,ambiguity_epoch_tow_ns,cycle_slip,pseudorange_m,doppler_hz,adr_cycles";
     const char* solution_header =
         "gps_week,tow_ns,sow_sec,tracked_satellites,position_valid,position_status,position_type,"
         "latitude_deg,longitude_deg,height_m,position_x_m,position_y_m,position_z_m,latitude_std_m,"
@@ -364,32 +366,22 @@ bool truth_writer_write_scenario_events(TruthWriter* writer, const ScenarioEpoch
         return false;
     }
     if (scenario.power_on_transition &&
-        !write_event_row(writer, scenario.time, "POWER_ON", &scenario, startup_mode, nullptr, error_message)) {
+        !write_event_row(writer, scenario.time, "POWER_ON", scenario, startup_mode, error_message)) {
         return false;
     }
     if (scenario.power_off_transition &&
-        !write_event_row(writer, scenario.time, "POWER_OFF", &scenario, startup_mode, nullptr, error_message)) {
+        !write_event_row(writer, scenario.time, "POWER_OFF", scenario, startup_mode, error_message)) {
         return false;
     }
     if (scenario.signal_on_transition &&
-        !write_event_row(writer, scenario.time, "SIGNAL_ON", &scenario, startup_mode, nullptr, error_message)) {
+        !write_event_row(writer, scenario.time, "SIGNAL_ON", scenario, startup_mode, error_message)) {
         return false;
     }
     if (scenario.signal_off_transition &&
-        !write_event_row(writer, scenario.time, "SIGNAL_OFF", &scenario, startup_mode, nullptr, error_message)) {
+        !write_event_row(writer, scenario.time, "SIGNAL_OFF", scenario, startup_mode, error_message)) {
         return false;
     }
     return true;
-}
-
-bool truth_writer_write_nav_event(TruthWriter* writer, const NavigationUpdateEvent& event,
-                                  std::string* error_message) {
-    if (writer == nullptr || writer->finalized) {
-        set_error(error_message, "truth NAV event writer is unavailable");
-        return false;
-    }
-    return write_event_row(writer, event.availability_time, "NAV_UPDATE", nullptr, StartupMode::HOT, &event,
-                           error_message);
 }
 
 bool truth_writer_write_observation(TruthWriter* writer, const ReceiverTruth& receiver,
@@ -420,12 +412,13 @@ bool truth_writer_write_observation(TruthWriter* writer, const ReceiverTruth& re
     write_time_prefix(output, geometry.receive_time);
     output << ',' << writer->observation_index++ << ',' << constellation_name(definition->constellation) << ','
            << satellite_prn(observation.satellite_number) << ',' << observation.satellite_number << ','
-           << static_cast<int>(observation.signal_id) << ',' << csv_escape(definition->name) << ',' << std::scientific
-           << std::setprecision(17) << receiver.position_ecef_m[0] << ',' << receiver.position_ecef_m[1] << ','
-           << receiver.position_ecef_m[2] << ',' << receiver.velocity_ecef_mps[0] << ',' << receiver.velocity_ecef_mps[1]
-           << ',' << receiver.velocity_ecef_mps[2] << ',' << transmit_time.gps_week << ',' << transmit_time.tow_ns << ','
-           << std::fixed << std::setprecision(9) << geometry.transmit_sow_sec << ',' << std::scientific
-           << std::setprecision(17) << geometry.satellite_state.position_ecef_m[0] << ','
+           << static_cast<int>(observation.signal_id) << ',' << csv_escape(definition->name) << ','
+           << observation.glonass_fcn << ',' << std::scientific << std::setprecision(17) << observation.wavelength_m
+           << ',' << receiver.position_ecef_m[0] << ',' << receiver.position_ecef_m[1] << ','
+           << receiver.position_ecef_m[2] << ',' << receiver.velocity_ecef_mps[0] << ','
+           << receiver.velocity_ecef_mps[1] << ',' << receiver.velocity_ecef_mps[2] << ',' << transmit_time.gps_week
+           << ',' << transmit_time.tow_ns << ',' << std::fixed << std::setprecision(9) << geometry.transmit_sow_sec << ','
+           << std::scientific << std::setprecision(17) << geometry.satellite_state.position_ecef_m[0] << ','
            << geometry.satellite_state.position_ecef_m[1] << ',' << geometry.satellite_state.position_ecef_m[2] << ','
            << geometry.satellite_state.velocity_ecef_mps[0] << ',' << geometry.satellite_state.velocity_ecef_mps[1]
            << ',' << geometry.satellite_state.velocity_ecef_mps[2] << ',' << geometry.azimuth_rad * kRadiansToDegrees
@@ -433,7 +426,12 @@ bool truth_writer_write_observation(TruthWriter* writer, const ReceiverTruth& re
            << observation.range_rate_mps << ',' << observation.satellite_clock_bias_m << ','
            << observation.satellite_clock_drift_mps << ',' << writer->config.receiver_clock_bias_m << ','
            << writer->config.receiver_clock_drift_mps << ',' << observation.ionosphere_code_delay_m << ','
-           << observation.troposphere_delay_m << ',' << observation.code_bias_m << ','
+           << observation.troposphere_delay_m << ','
+           << broadcast_message_family_name(observation.broadcast_message_family) << ',' << observation.tgd_sec[0] << ','
+           << observation.tgd_sec[1] << ',' << observation.tgd_sec[2] << ',' << observation.tgd_sec[3] << ','
+           << observation.isc_sec[0] << ',' << observation.isc_sec[1] << ',' << observation.isc_sec[2] << ','
+           << observation.isc_sec[3] << ',' << observation.isc_sec[4] << ',' << observation.isc_sec[5] << ','
+           << observation.glonass_dtaun_sec << ',' << observation.code_bias_m << ','
            << broadcast_code_bias_status_name(observation.code_bias_status) << ',' << observation.cn0_dbhz << ','
            << signal_tracking_phase_name(tracker.phase) << ',' << observation.lock_time_ns << ','
            << (observation.pseudorange_valid ? 1 : 0) << ',' << (observation.doppler_valid ? 1 : 0) << ','
@@ -471,7 +469,8 @@ bool truth_writer_write_solution(TruthWriter* writer, const SolutionEpoch& solut
 
 bool finalize_truth_writer(TruthWriter* writer, const SimulatorRunSummary& summary, const char* version,
                            const char* commit_sha, const char* rtklib_sha, std::string* error_message) {
-    if (writer == nullptr || writer->finalized || version == nullptr || commit_sha == nullptr || rtklib_sha == nullptr) {
+    if (writer == nullptr || writer->finalized || version == nullptr || commit_sha == nullptr ||
+        rtklib_sha == nullptr) {
         set_error(error_message, "truth writer finalization request has invalid arguments");
         return false;
     }
@@ -499,8 +498,8 @@ bool finalize_truth_writer(TruthWriter* writer, const SimulatorRunSummary& summa
              << "    \"hash\": \"" << writer->rinex_nav_hash << "\",\n"
              << "    \"size_bytes\": " << writer->rinex_nav_size << "\n"
              << "  },\n"
-             << "  \"start_time\": {\"gps_week\": " << writer->start_time.gps_week << ", \"tow_ns\": "
-             << writer->start_time.tow_ns << "},\n"
+             << "  \"start_time\": {\"gps_week\": " << writer->start_time.gps_week
+             << ", \"tow_ns\": " << writer->start_time.tow_ns << "},\n"
              << "  \"random_seed\": " << writer->config.seed << ",\n"
              << "  \"resolved_config\": " << config_json(writer->config, 2) << ",\n"
              << "  \"run_summary\": {\n"

--- a/src/output/truth_writer.h
+++ b/src/output/truth_writer.h
@@ -1,0 +1,43 @@
+#ifndef GNSS_SIM_SRC_OUTPUT_TRUTH_WRITER_H_
+#define GNSS_SIM_SRC_OUTPUT_TRUTH_WRITER_H_
+
+#include "gnss/navigation_state.h"
+#include "gnss/satellite_engine.h"
+#include "gnss_sim/sim_config.h"
+#include "gnss_sim/sim_types.h"
+#include "model/measurement_model.h"
+#include "model/receiver_truth.h"
+#include "model/signal_tracking.h"
+#include "scenario/scenario_engine.h"
+#include "solution/solution_engine.h"
+
+#include <string>
+
+namespace gnss_sim {
+
+struct SimulatorRunSummary;
+struct TruthWriter;
+
+constexpr int TRUTH_OUTPUT_SCHEMA_VERSION = 1;
+
+TruthWriter* create_truth_writer(const char* receiver_log_path, const char* rinex_nav_path, const SimConfig& config,
+                                 const SimTime& start_time, std::string* error_message);
+void destroy_truth_writer(TruthWriter* writer);
+
+bool truth_writer_write_scenario_events(TruthWriter* writer, const ScenarioEpochState& scenario,
+                                        StartupMode startup_mode, std::string* error_message);
+bool truth_writer_write_nav_event(TruthWriter* writer, const NavigationUpdateEvent& event,
+                                  std::string* error_message);
+bool truth_writer_write_observation(TruthWriter* writer, const ReceiverTruth& receiver,
+                                    const SatelliteGeometry& geometry, const SignalTracker& tracker,
+                                    const MeasurementObservation& observation, std::string* error_message);
+bool truth_writer_write_solution(TruthWriter* writer, const SolutionEpoch& solution, int tracked_satellites,
+                                 std::string* error_message);
+
+bool finalize_truth_writer(TruthWriter* writer, const SimulatorRunSummary& summary, const char* simulator_version,
+                           const char* simulator_commit_sha, const char* rtklib_commit_sha,
+                           std::string* error_message);
+
+} // namespace gnss_sim
+
+#endif // GNSS_SIM_SRC_OUTPUT_TRUTH_WRITER_H_

--- a/src/output/truth_writer.h
+++ b/src/output/truth_writer.h
@@ -1,7 +1,6 @@
 #ifndef GNSS_SIM_SRC_OUTPUT_TRUTH_WRITER_H_
 #define GNSS_SIM_SRC_OUTPUT_TRUTH_WRITER_H_
 
-#include "gnss/navigation_state.h"
 #include "gnss/satellite_engine.h"
 #include "gnss_sim/sim_config.h"
 #include "gnss_sim/sim_types.h"
@@ -26,8 +25,6 @@ void destroy_truth_writer(TruthWriter* writer);
 
 bool truth_writer_write_scenario_events(TruthWriter* writer, const ScenarioEpochState& scenario,
                                         StartupMode startup_mode, std::string* error_message);
-bool truth_writer_write_nav_event(TruthWriter* writer, const NavigationUpdateEvent& event,
-                                  std::string* error_message);
 bool truth_writer_write_observation(TruthWriter* writer, const ReceiverTruth& receiver,
                                     const SatelliteGeometry& geometry, const SignalTracker& tracker,
                                     const MeasurementObservation& observation, std::string* error_message);

--- a/src/output/truth_writer.h
+++ b/src/output/truth_writer.h
@@ -32,8 +32,7 @@ bool truth_writer_write_solution(TruthWriter* writer, const SolutionEpoch& solut
                                  std::string* error_message);
 
 bool finalize_truth_writer(TruthWriter* writer, const SimulatorRunSummary& summary, const char* simulator_version,
-                           const char* simulator_commit_sha, const char* rtklib_commit_sha,
-                           std::string* error_message);
+                           const char* simulator_commit_sha, const char* rtklib_commit_sha, std::string* error_message);
 
 } // namespace gnss_sim
 

--- a/tests/integration/test_truth_outputs.cpp
+++ b/tests/integration/test_truth_outputs.cpp
@@ -1,0 +1,128 @@
+#include "gnss_sim/sim_config.h"
+#include "gnss_sim/sim_time.h"
+#include "gnss_sim/simulator.h"
+
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <string>
+
+namespace {
+
+std::string nav_path() {
+    return std::string(GNSS_SIM_TEST_DATA_DIR) + "/gps_loopback_nav.rnx";
+}
+
+gnss_sim::SimTime start_time() {
+    gnss_sim::SimTime time{};
+    EXPECT_TRUE(gnss_sim::sim_time_from_week_sow(2253, 172900.0, &time));
+    return time;
+}
+
+gnss_sim::SimConfig truth_config() {
+    gnss_sim::SimConfig config = gnss_sim::default_sim_config();
+    config.scenario = gnss_sim::ScenarioType::KS;
+    config.atmosphere_mode = gnss_sim::AtmosphereMode::NONE;
+    config.elevation_mask_deg = 0.0;
+    config.sampling_rate_hz = 5;
+    config.duration_ns = 2LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    config.seed = 7U;
+    return config;
+}
+
+std::string read_file(const std::filesystem::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    return std::string((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
+}
+
+std::string first_line(const std::filesystem::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    std::string line;
+    std::getline(input, line);
+    return line;
+}
+
+bool run_in_directory(const std::filesystem::path& directory, gnss_sim::SimulatorRunSummary* summary,
+                      std::string* error_message) {
+    std::error_code error;
+    std::filesystem::remove_all(directory, error);
+    error.clear();
+    if (!std::filesystem::create_directories(directory, error) || error) {
+        if (error_message != nullptr) {
+            *error_message = "cannot create truth-output test directory";
+        }
+        return false;
+    }
+    const std::filesystem::path output_path = directory / "simulated.log";
+    const std::string input_path = nav_path();
+    const std::string output_text = output_path.string();
+    const gnss_sim::SimulatorRunOptions options{input_path.c_str(), output_text.c_str(), start_time()};
+    return gnss_sim::run_simulator(truth_config(), options, summary, error_message);
+}
+
+void cleanup(const std::filesystem::path& path) {
+    std::error_code error;
+    std::filesystem::remove_all(path, error);
+}
+
+TEST(TruthOutputs, HeadersAreVersionedAndExplicit) {
+    const std::filesystem::path directory = "gnss_sim_truth_schema";
+    gnss_sim::SimulatorRunSummary summary{};
+    std::string error_message;
+    ASSERT_TRUE(run_in_directory(directory, &summary, &error_message)) << error_message;
+
+    EXPECT_EQ(first_line(directory / "event_truth.csv"),
+              "gps_week,tow_ns,sow_sec,event_type,cycle_index,receiver_powered,signal_available,startup_mode,"
+              "truth_record_index,receiver_record_index,nav_kind,satellite_number,iode,iodc");
+    EXPECT_EQ(first_line(directory / "observation_truth.csv"),
+              "gps_week,tow_ns,sow_sec,observation_index,system,prn,satellite_number,signal_id,signal_name,"
+              "receiver_x_m,receiver_y_m,receiver_z_m,receiver_vx_mps,receiver_vy_mps,receiver_vz_mps,"
+              "transmit_week,transmit_tow_ns,transmit_sow_sec,satellite_x_m,satellite_y_m,satellite_z_m,"
+              "satellite_vx_mps,satellite_vy_mps,satellite_vz_mps,azimuth_deg,elevation_deg,geometric_range_m,"
+              "range_rate_mps,satellite_clock_bias_m,satellite_clock_drift_mps,receiver_clock_bias_m,"
+              "receiver_clock_drift_mps,ionosphere_m,troposphere_m,code_bias_m,code_bias_status,cn0_dbhz,"
+              "tracking_phase,lock_time_ns,pseudorange_valid,doppler_valid,adr_valid,ambiguity_cycles,"
+              "ambiguity_epoch_week,ambiguity_epoch_tow_ns,cycle_slip,pseudorange_m,doppler_hz,adr_cycles");
+    EXPECT_EQ(first_line(directory / "solution_truth.csv"),
+              "gps_week,tow_ns,sow_sec,tracked_satellites,position_valid,position_status,position_type,"
+              "latitude_deg,longitude_deg,height_m,position_x_m,position_y_m,position_z_m,latitude_std_m,"
+              "longitude_std_m,height_std_m,receiver_clock_bias_m,position_used_satellites,position_diagnostic,"
+              "velocity_valid,velocity_status,velocity_type,velocity_x_mps,velocity_y_mps,velocity_z_mps,"
+              "horizontal_speed_mps,track_over_ground_deg,vertical_speed_mps,receiver_clock_drift_mps,"
+              "velocity_used_satellites,velocity_diagnostic");
+
+    const std::string scenario = read_file(directory / "scenario.json");
+    const std::string manifest = read_file(directory / "run_manifest.json");
+    EXPECT_NE(scenario.find("\"truth_schema_version\": 1"), std::string::npos);
+    EXPECT_NE(scenario.find("\"atmosphere_mode\": \"none\""), std::string::npos);
+    EXPECT_NE(manifest.find("\"output_format_version\": 1"), std::string::npos);
+    EXPECT_NE(manifest.find("\"rtklib_commit_sha\": \"dc596ba725ccaa5ab5963d7e7ec85b52ae743969\""),
+              std::string::npos);
+    EXPECT_NE(manifest.find("\"hash_algorithm\": \"fnv1a64\""), std::string::npos);
+    EXPECT_NE(manifest.find("\"random_seed\": 7"), std::string::npos);
+    EXPECT_NE(read_file(directory / "event_truth.csv").find("POWER_ON"), std::string::npos);
+    EXPECT_GT(read_file(directory / "observation_truth.csv").size(), first_line(directory / "observation_truth.csv").size());
+    EXPECT_GT(read_file(directory / "solution_truth.csv").size(), first_line(directory / "solution_truth.csv").size());
+    cleanup(directory);
+}
+
+TEST(TruthOutputs, SameInputConfigAndSeedAreByteIdenticalAcrossOutputDirectories) {
+    const std::filesystem::path first_directory = "gnss_sim_truth_repeat_a";
+    const std::filesystem::path second_directory = "gnss_sim_truth_repeat_b";
+    gnss_sim::SimulatorRunSummary first_summary{};
+    gnss_sim::SimulatorRunSummary second_summary{};
+    std::string error_message;
+    ASSERT_TRUE(run_in_directory(first_directory, &first_summary, &error_message)) << error_message;
+    ASSERT_TRUE(run_in_directory(second_directory, &second_summary, &error_message)) << error_message;
+
+    for (const char* file_name : {"scenario.json", "event_truth.csv", "observation_truth.csv", "solution_truth.csv",
+                                  "run_manifest.json"}) {
+        EXPECT_EQ(read_file(first_directory / file_name), read_file(second_directory / file_name)) << file_name;
+    }
+    EXPECT_EQ(first_summary.scheduled_epochs, second_summary.scheduled_epochs);
+    EXPECT_EQ(first_summary.max_observations_per_epoch, second_summary.max_observations_per_epoch);
+    cleanup(first_directory);
+    cleanup(second_directory);
+}
+
+} // namespace

--- a/tests/integration/test_truth_outputs.cpp
+++ b/tests/integration/test_truth_outputs.cpp
@@ -72,17 +72,17 @@ TEST(TruthOutputs, HeadersAreVersionedAndExplicit) {
     ASSERT_TRUE(run_in_directory(directory, &summary, &error_message)) << error_message;
 
     EXPECT_EQ(first_line(directory / "event_truth.csv"),
-              "gps_week,tow_ns,sow_sec,event_type,cycle_index,receiver_powered,signal_available,startup_mode,"
-              "truth_record_index,receiver_record_index,nav_kind,satellite_number,iode,iodc");
+              "gps_week,tow_ns,sow_sec,event_type,cycle_index,receiver_powered,signal_available,startup_mode");
     EXPECT_EQ(first_line(directory / "observation_truth.csv"),
-              "gps_week,tow_ns,sow_sec,observation_index,system,prn,satellite_number,signal_id,signal_name,"
-              "receiver_x_m,receiver_y_m,receiver_z_m,receiver_vx_mps,receiver_vy_mps,receiver_vz_mps,"
+              "gps_week,tow_ns,sow_sec,observation_index,system,prn,satellite_number,signal_id,signal_name,glonass_fcn,"
+              "wavelength_m,receiver_x_m,receiver_y_m,receiver_z_m,receiver_vx_mps,receiver_vy_mps,receiver_vz_mps,"
               "transmit_week,transmit_tow_ns,transmit_sow_sec,satellite_x_m,satellite_y_m,satellite_z_m,"
               "satellite_vx_mps,satellite_vy_mps,satellite_vz_mps,azimuth_deg,elevation_deg,geometric_range_m,"
               "range_rate_mps,satellite_clock_bias_m,satellite_clock_drift_mps,receiver_clock_bias_m,"
-              "receiver_clock_drift_mps,ionosphere_m,troposphere_m,code_bias_m,code_bias_status,cn0_dbhz,"
-              "tracking_phase,lock_time_ns,pseudorange_valid,doppler_valid,adr_valid,ambiguity_cycles,"
-              "ambiguity_epoch_week,ambiguity_epoch_tow_ns,cycle_slip,pseudorange_m,doppler_hz,adr_cycles");
+              "receiver_clock_drift_mps,ionosphere_m,troposphere_m,broadcast_message_family,tgd_sec_0,tgd_sec_1,"
+              "tgd_sec_2,tgd_sec_3,isc_sec_0,isc_sec_1,isc_sec_2,isc_sec_3,isc_sec_4,isc_sec_5,glonass_dtaun_sec,"
+              "code_bias_m,code_bias_status,cn0_dbhz,tracking_phase,lock_time_ns,pseudorange_valid,doppler_valid,adr_valid,"
+              "ambiguity_cycles,ambiguity_epoch_week,ambiguity_epoch_tow_ns,cycle_slip,pseudorange_m,doppler_hz,adr_cycles");
     EXPECT_EQ(first_line(directory / "solution_truth.csv"),
               "gps_week,tow_ns,sow_sec,tracked_satellites,position_valid,position_status,position_type,"
               "latitude_deg,longitude_deg,height_m,position_x_m,position_y_m,position_z_m,latitude_std_m,"
@@ -93,6 +93,7 @@ TEST(TruthOutputs, HeadersAreVersionedAndExplicit) {
 
     const std::string scenario = read_file(directory / "scenario.json");
     const std::string manifest = read_file(directory / "run_manifest.json");
+    const std::string observations = read_file(directory / "observation_truth.csv");
     EXPECT_NE(scenario.find("\"truth_schema_version\": 1"), std::string::npos);
     EXPECT_NE(scenario.find("\"atmosphere_mode\": \"none\""), std::string::npos);
     EXPECT_NE(manifest.find("\"output_format_version\": 1"), std::string::npos);
@@ -101,7 +102,8 @@ TEST(TruthOutputs, HeadersAreVersionedAndExplicit) {
     EXPECT_NE(manifest.find("\"hash_algorithm\": \"fnv1a64\""), std::string::npos);
     EXPECT_NE(manifest.find("\"random_seed\": 7"), std::string::npos);
     EXPECT_NE(read_file(directory / "event_truth.csv").find("POWER_ON"), std::string::npos);
-    EXPECT_GT(read_file(directory / "observation_truth.csv").size(), first_line(directory / "observation_truth.csv").size());
+    EXPECT_NE(observations.find(",LEGACY,"), std::string::npos);
+    EXPECT_GT(observations.size(), first_line(directory / "observation_truth.csv").size());
     EXPECT_GT(read_file(directory / "solution_truth.csv").size(), first_line(directory / "solution_truth.csv").size());
     cleanup(directory);
 }
@@ -115,8 +117,8 @@ TEST(TruthOutputs, SameInputConfigAndSeedAreByteIdenticalAcrossOutputDirectories
     ASSERT_TRUE(run_in_directory(first_directory, &first_summary, &error_message)) << error_message;
     ASSERT_TRUE(run_in_directory(second_directory, &second_summary, &error_message)) << error_message;
 
-    for (const char* file_name : {"scenario.json", "event_truth.csv", "observation_truth.csv", "solution_truth.csv",
-                                  "run_manifest.json"}) {
+    for (const char* file_name :
+         {"scenario.json", "event_truth.csv", "observation_truth.csv", "solution_truth.csv", "run_manifest.json"}) {
         EXPECT_EQ(read_file(first_directory / file_name), read_file(second_directory / file_name)) << file_name;
     }
     EXPECT_EQ(first_summary.scheduled_epochs, second_summary.scheduled_epochs);

--- a/tests/integration/test_truth_outputs.cpp
+++ b/tests/integration/test_truth_outputs.cpp
@@ -73,16 +73,17 @@ TEST(TruthOutputs, HeadersAreVersionedAndExplicit) {
 
     EXPECT_EQ(first_line(directory / "event_truth.csv"),
               "gps_week,tow_ns,sow_sec,event_type,cycle_index,receiver_powered,signal_available,startup_mode");
-    EXPECT_EQ(first_line(directory / "observation_truth.csv"),
-              "gps_week,tow_ns,sow_sec,observation_index,system,prn,satellite_number,signal_id,signal_name,glonass_fcn,"
-              "wavelength_m,receiver_x_m,receiver_y_m,receiver_z_m,receiver_vx_mps,receiver_vy_mps,receiver_vz_mps,"
-              "transmit_week,transmit_tow_ns,transmit_sow_sec,satellite_x_m,satellite_y_m,satellite_z_m,"
-              "satellite_vx_mps,satellite_vy_mps,satellite_vz_mps,azimuth_deg,elevation_deg,geometric_range_m,"
-              "range_rate_mps,satellite_clock_bias_m,satellite_clock_drift_mps,receiver_clock_bias_m,"
-              "receiver_clock_drift_mps,ionosphere_m,troposphere_m,broadcast_message_family,tgd_sec_0,tgd_sec_1,"
-              "tgd_sec_2,tgd_sec_3,isc_sec_0,isc_sec_1,isc_sec_2,isc_sec_3,isc_sec_4,isc_sec_5,glonass_dtaun_sec,"
-              "code_bias_m,code_bias_status,cn0_dbhz,tracking_phase,lock_time_ns,pseudorange_valid,doppler_valid,adr_valid,"
-              "ambiguity_cycles,ambiguity_epoch_week,ambiguity_epoch_tow_ns,cycle_slip,pseudorange_m,doppler_hz,adr_cycles");
+    EXPECT_EQ(
+        first_line(directory / "observation_truth.csv"),
+        "gps_week,tow_ns,sow_sec,observation_index,system,prn,satellite_number,signal_id,signal_name,glonass_fcn,"
+        "wavelength_m,receiver_x_m,receiver_y_m,receiver_z_m,receiver_vx_mps,receiver_vy_mps,receiver_vz_mps,"
+        "transmit_week,transmit_tow_ns,transmit_sow_sec,satellite_x_m,satellite_y_m,satellite_z_m,"
+        "satellite_vx_mps,satellite_vy_mps,satellite_vz_mps,azimuth_deg,elevation_deg,geometric_range_m,"
+        "range_rate_mps,satellite_clock_bias_m,satellite_clock_drift_mps,receiver_clock_bias_m,"
+        "receiver_clock_drift_mps,ionosphere_m,troposphere_m,broadcast_message_family,tgd_sec_0,tgd_sec_1,"
+        "tgd_sec_2,tgd_sec_3,isc_sec_0,isc_sec_1,isc_sec_2,isc_sec_3,isc_sec_4,isc_sec_5,glonass_dtaun_sec,"
+        "code_bias_m,code_bias_status,cn0_dbhz,tracking_phase,lock_time_ns,pseudorange_valid,doppler_valid,adr_valid,"
+        "ambiguity_cycles,ambiguity_epoch_week,ambiguity_epoch_tow_ns,cycle_slip,pseudorange_m,doppler_hz,adr_cycles");
     EXPECT_EQ(first_line(directory / "solution_truth.csv"),
               "gps_week,tow_ns,sow_sec,tracked_satellites,position_valid,position_status,position_type,"
               "latitude_deg,longitude_deg,height_m,position_x_m,position_y_m,position_z_m,latitude_std_m,"
@@ -97,8 +98,7 @@ TEST(TruthOutputs, HeadersAreVersionedAndExplicit) {
     EXPECT_NE(scenario.find("\"truth_schema_version\": 1"), std::string::npos);
     EXPECT_NE(scenario.find("\"atmosphere_mode\": \"none\""), std::string::npos);
     EXPECT_NE(manifest.find("\"output_format_version\": 1"), std::string::npos);
-    EXPECT_NE(manifest.find("\"rtklib_commit_sha\": \"dc596ba725ccaa5ab5963d7e7ec85b52ae743969\""),
-              std::string::npos);
+    EXPECT_NE(manifest.find("\"rtklib_commit_sha\": \"dc596ba725ccaa5ab5963d7e7ec85b52ae743969\""), std::string::npos);
     EXPECT_NE(manifest.find("\"hash_algorithm\": \"fnv1a64\""), std::string::npos);
     EXPECT_NE(manifest.find("\"random_seed\": 7"), std::string::npos);
     EXPECT_NE(read_file(directory / "event_truth.csv").find("POWER_ON"), std::string::npos);


### PR DESCRIPTION
Closes #16.

## Summary
- add streamed `event_truth.csv`, `observation_truth.csv`, and `solution_truth.csv` output beside the receiver log;
- add deterministic `scenario.json` resolved-config snapshot and final `run_manifest.json`;
- expose deterministic observation join keys (GPST + observation index + system/PRN/signal) and the full zero-noise measurement decomposition, including receiver/satellite states, transmit time, geometry/range-rate, clock terms, atmosphere, GLONASS FCN/wavelength, raw broadcast bias provenance, final code bias, CN0, tracking/validity, ambiguity epoch, and final PSR/Doppler/ADR;
- preserve broadcast message family plus raw `tgd_sec[4]`, `isc_sec[6]`, and GLONASS `dtaun` values upstream in `MeasurementObservation` so the truth writer serializes existing model state instead of re-querying/recomputing navigation physics;
- keep `event_truth.csv` scoped to scenario power/signal transitions; remove the previously unconnected NAV-event API/columns rather than widening #16 into Receiver-NAV orchestration;
- include simulator version/source commit, exact pinned RTKLIB SHA, content-level RINEX identity (FNV-1a 64-bit + size + basename), resolved config, random seed, start GPST, output schema version, and deterministic run summary in the manifest;
- keep machine-specific absolute input/output paths out of the manifest;
- add integration tests for exact CSV schema headers, serialized broadcast-family provenance, and byte-identical truth outputs across two different output directories.

## Implementation Notes
Truth output schema version is frozen at `1`. V1 `cycle_slip` is explicitly `0`; REA/power-cycle ambiguity resets are represented by the deterministic ambiguity value plus `ambiguity_epoch_week/tow_ns` rather than inventing an unmodeled within-track slip event.

Truth files are created in the same directory as `simulated.log` using the frozen names `scenario.json`, `event_truth.csv`, `observation_truth.csv`, `solution_truth.csv`, and `run_manifest.json`. This avoids a second path configuration while preserving one-run-per-output-directory semantics.

CSV records are written immediately from the existing streaming orchestration hooks. The truth writer does not recompute satellite geometry, tracking, measurement equations, or receiver solutions. `run_manifest.json` is emitted only after a successful run and successful truth CSV flush.

Receiver-NAV update/isolation behavior remains part of #40 full-system acceptance; #16 records scenario events and observation/solution truth only.

The RINEX content identifier intentionally does not contain an absolute path so the same source file/config/seed produces byte-identical truth artifacts on different machines/directories. Full clang-format + Ubuntu/GCC + Windows/MSVC CI is required before merge.