### PR TITLE
Build deterministic CN0 elevation-bin statistics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,8 @@ target_link_libraries(gnss-data-simulator PRIVATE gnss_sim::core)
 gnss_sim_set_project_warnings(gnss-data-simulator)
 
 add_library(cn0_model_builder_core STATIC
+    tools/build_cn0_model/cn0_builder.cpp
+    tools/build_cn0_model/cn0_statistics.cpp
     tools/build_cn0_model/rinex_obs_stream.cpp
 )
 target_include_directories(cn0_model_builder_core
@@ -163,6 +165,7 @@ if(BUILD_TESTING)
     add_executable(gnss_sim_unit_tests
         tests/unit/test_atmosphere_model.cpp
         tests/unit/test_cn0_model.cpp
+        tests/unit/test_cn0_statistics.cpp
         tests/unit/test_deterministic_rng.cpp
         tests/unit/test_measurement_model.cpp
         tests/unit/test_nav_message_scheduler.cpp

--- a/tests/unit/test_cn0_statistics.cpp
+++ b/tests/unit/test_cn0_statistics.cpp
@@ -1,12 +1,11 @@
 #include "tools/build_cn0_model/cn0_builder.h"
 #include "tools/build_cn0_model/cn0_statistics.h"
 
-#include <gtest/gtest.h>
-
 #include <cmath>
 #include <cstdio>
 #include <filesystem>
 #include <fstream>
+#include <gtest/gtest.h>
 #include <limits>
 #include <string>
 #include <vector>
@@ -15,7 +14,6 @@ namespace {
 
 using gnss_sim::GnssConstellation;
 using gnss_sim::SignalId;
-using gnss_sim::SimTime;
 using gnss_sim::cn0_builder::Cn0AggregationConfig;
 using gnss_sim::cn0_builder::Cn0Ar1Status;
 using gnss_sim::cn0_builder::Cn0BinStatistics;
@@ -28,8 +26,8 @@ using gnss_sim::cn0_builder::RinexCn0Sample;
 
 constexpr double kPi = 3.14159265358979323846;
 
-RinexCn0Sample sample(double cn0_dbhz, double elevation_deg, std::int64_t tow_ns,
-                      int satellite_number = 1, SignalId signal_id = SignalId::kGpsL1Ca) {
+RinexCn0Sample sample(double cn0_dbhz, double elevation_deg, std::int64_t tow_ns, int satellite_number = 1,
+                      SignalId signal_id = SignalId::kGpsL1Ca) {
     RinexCn0Sample result{};
     result.time = {2253, tow_ns};
     result.constellation = GnssConstellation::kGps;
@@ -66,7 +64,6 @@ std::string read_file(const std::filesystem::path& path) {
 
 TEST(Cn0Statistics, Type7QuantilesMeanPopulationStddevAndMadAreGolden) {
     Cn0AggregationConfig config{};
-    config.elevation_min_deg = 0.0;
     config.elevation_max_deg = 10.0;
     config.elevation_bin_width_deg = 10.0;
     config.min_samples_per_bin = 4;
@@ -74,7 +71,6 @@ TEST(Cn0Statistics, Type7QuantilesMeanPopulationStddevAndMadAreGolden) {
     std::string error;
     ASSERT_TRUE(accumulator.valid(&error)) << error;
     ASSERT_TRUE(accumulator.begin_source(1.0, &error)) << error;
-
     ASSERT_TRUE(accumulator.add_sample(sample(10.0, 5.0, 0), &error)) << error;
     ASSERT_TRUE(accumulator.add_sample(sample(20.0, 5.0, 1000000000LL), &error)) << error;
     ASSERT_TRUE(accumulator.add_sample(sample(30.0, 5.0, 2000000000LL), &error)) << error;
@@ -100,7 +96,6 @@ TEST(Cn0Statistics, Type7QuantilesMeanPopulationStddevAndMadAreGolden) {
 
 TEST(Cn0Statistics, ElevationEdgesAreHalfOpenExceptFinalMaximum) {
     Cn0AggregationConfig config{};
-    config.elevation_min_deg = 0.0;
     config.elevation_max_deg = 10.0;
     config.elevation_bin_width_deg = 5.0;
     config.min_samples_per_bin = 1;
@@ -129,7 +124,6 @@ TEST(Cn0Statistics, ElevationEdgesAreHalfOpenExceptFinalMaximum) {
 
 TEST(Cn0Statistics, InvalidAndOffGridSamplesCannotContaminateBins) {
     Cn0AggregationConfig config{};
-    config.elevation_min_deg = 0.0;
     config.elevation_max_deg = 10.0;
     config.elevation_bin_width_deg = 10.0;
     config.min_samples_per_bin = 2;
@@ -147,7 +141,8 @@ TEST(Cn0Statistics, InvalidAndOffGridSamplesCannotContaminateBins) {
     ASSERT_TRUE(accumulator.add_sample(sample(32.0, 5.0, 3000000000LL), &error)) << error;
     accumulator.end_source();
 
-    const Cn0BinStatistics* bin = find_bin(accumulator.finalize(), SignalId::kGpsL1Ca, 0.0);
+    const std::vector<Cn0BinStatistics> bins = accumulator.finalize();
+    const Cn0BinStatistics* bin = find_bin(bins, SignalId::kGpsL1Ca, 0.0);
     ASSERT_NE(bin, nullptr);
     EXPECT_EQ(bin->count, 1U);
     EXPECT_EQ(bin->status, Cn0BinStatus::kSparse);
@@ -158,7 +153,6 @@ TEST(Cn0Statistics, InvalidAndOffGridSamplesCannotContaminateBins) {
 
 TEST(Cn0Statistics, TemporalStatisticsRespectGapBinAndSourceBoundaries) {
     Cn0AggregationConfig config{};
-    config.elevation_min_deg = 0.0;
     config.elevation_max_deg = 20.0;
     config.elevation_bin_width_deg = 10.0;
     config.min_samples_per_bin = 1;
@@ -173,12 +167,12 @@ TEST(Cn0Statistics, TemporalStatisticsRespectGapBinAndSourceBoundaries) {
     ASSERT_TRUE(accumulator.add_sample(sample(34.0, 5.0, 5000000000LL), &error)) << error;
     ASSERT_TRUE(accumulator.add_sample(sample(35.0, 15.0, 6000000000LL), &error)) << error;
     accumulator.end_source();
-
     ASSERT_TRUE(accumulator.begin_source(1.0, &error)) << error;
     ASSERT_TRUE(accumulator.add_sample(sample(36.0, 5.0, 7000000000LL), &error)) << error;
     accumulator.end_source();
 
-    const Cn0BinStatistics* bin = find_bin(accumulator.finalize(), SignalId::kGpsL1Ca, 0.0);
+    const std::vector<Cn0BinStatistics> bins = accumulator.finalize();
+    const Cn0BinStatistics* bin = find_bin(bins, SignalId::kGpsL1Ca, 0.0);
     ASSERT_NE(bin, nullptr);
     EXPECT_EQ(bin->delta_count, 3U);
     EXPECT_DOUBLE_EQ(bin->delta_p50_dbhz, 1.0);
@@ -194,13 +188,13 @@ TEST(Cn0Statistics, TemporalStatisticsRespectGapBinAndSourceBoundaries) {
 
 TEST(Cn0Statistics, MissingIntervalAndZeroVarianceAreExplicit) {
     Cn0AggregationConfig config{};
-    config.elevation_min_deg = 0.0;
     config.elevation_max_deg = 10.0;
     config.elevation_bin_width_deg = 10.0;
     config.min_samples_per_bin = 1;
     config.min_temporal_pairs = 2;
-    Cn0StatisticsAccumulator accumulator(config);
     std::string error;
+
+    Cn0StatisticsAccumulator accumulator(config);
     ASSERT_TRUE(accumulator.begin_source(std::numeric_limits<double>::quiet_NaN(), &error)) << error;
     ASSERT_TRUE(accumulator.add_sample(sample(30.0, 5.0, 0), &error)) << error;
     ASSERT_TRUE(accumulator.add_sample(sample(30.0, 5.0, 1000000000LL), &error)) << error;
@@ -213,7 +207,8 @@ TEST(Cn0Statistics, MissingIntervalAndZeroVarianceAreExplicit) {
     ASSERT_TRUE(constant_accumulator.add_sample(sample(30.0, 5.0, 1000000000LL), &error)) << error;
     ASSERT_TRUE(constant_accumulator.add_sample(sample(30.0, 5.0, 2000000000LL), &error)) << error;
     constant_accumulator.end_source();
-    const Cn0BinStatistics* bin = find_bin(constant_accumulator.finalize(), SignalId::kGpsL1Ca, 0.0);
+    const std::vector<Cn0BinStatistics> bins = constant_accumulator.finalize();
+    const Cn0BinStatistics* bin = find_bin(bins, SignalId::kGpsL1Ca, 0.0);
     ASSERT_NE(bin, nullptr);
     EXPECT_EQ(bin->ar1_status, Cn0Ar1Status::kZeroVariance);
     EXPECT_FALSE(std::isfinite(bin->ar1));
@@ -252,8 +247,8 @@ TEST(Cn0Statistics, BuilderModelAndMetadataAreByteIdenticalForFixedSources) {
     const std::filesystem::path model_b = directory / "gnss_sim_cn0_model_b.csv";
     const std::filesystem::path meta_a = directory / "gnss_sim_cn0_meta_a.json";
     const std::filesystem::path meta_b = directory / "gnss_sim_cn0_meta_b.json";
-    ASSERT_TRUE(gnss_sim::cn0_builder::write_cn0_model_csv(model_a.string(), config, first.aggregation_summary, first.bins,
-                                                           &error))
+    ASSERT_TRUE(gnss_sim::cn0_builder::write_cn0_model_csv(model_a.string(), config, first.aggregation_summary,
+                                                           first.bins, &error))
         << error;
     ASSERT_TRUE(gnss_sim::cn0_builder::write_cn0_model_csv(model_b.string(), config, second.aggregation_summary,
                                                            second.bins, &error))

--- a/tests/unit/test_cn0_statistics.cpp
+++ b/tests/unit/test_cn0_statistics.cpp
@@ -1,0 +1,274 @@
+#include "tools/build_cn0_model/cn0_builder.h"
+#include "tools/build_cn0_model/cn0_statistics.h"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace {
+
+using gnss_sim::GnssConstellation;
+using gnss_sim::SignalId;
+using gnss_sim::SimTime;
+using gnss_sim::cn0_builder::Cn0AggregationConfig;
+using gnss_sim::cn0_builder::Cn0Ar1Status;
+using gnss_sim::cn0_builder::Cn0BinStatistics;
+using gnss_sim::cn0_builder::Cn0BinStatus;
+using gnss_sim::cn0_builder::Cn0BuildResult;
+using gnss_sim::cn0_builder::Cn0InputSource;
+using gnss_sim::cn0_builder::Cn0SampleValidity;
+using gnss_sim::cn0_builder::Cn0StatisticsAccumulator;
+using gnss_sim::cn0_builder::RinexCn0Sample;
+
+constexpr double kPi = 3.14159265358979323846;
+
+RinexCn0Sample sample(double cn0_dbhz, double elevation_deg, std::int64_t tow_ns,
+                      int satellite_number = 1, SignalId signal_id = SignalId::kGpsL1Ca) {
+    RinexCn0Sample result{};
+    result.time = {2253, tow_ns};
+    result.constellation = GnssConstellation::kGps;
+    result.satellite_number = satellite_number;
+    result.prn = satellite_number;
+    result.signal_id = signal_id;
+    result.rinex_signal_code = "1C";
+    result.signal_strength_value = cn0_dbhz;
+    result.cn0_dbhz = cn0_dbhz;
+    result.elevation_rad = elevation_deg * kPi / 180.0;
+    result.azimuth_rad = 0.0;
+    result.validity = Cn0SampleValidity::kValidDbHz;
+    return result;
+}
+
+const Cn0BinStatistics* find_bin(const std::vector<Cn0BinStatistics>& bins, SignalId signal_id,
+                                 double elevation_min_deg) {
+    for (const Cn0BinStatistics& bin : bins) {
+        if (bin.signal_id == signal_id && std::fabs(bin.elevation_min_deg - elevation_min_deg) < 1e-12) {
+            return &bin;
+        }
+    }
+    return nullptr;
+}
+
+std::string test_data(const char* file_name) {
+    return std::string(GNSS_SIM_TEST_DATA_DIR) + "/" + file_name;
+}
+
+std::string read_file(const std::filesystem::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    return std::string(std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>());
+}
+
+TEST(Cn0Statistics, Type7QuantilesMeanPopulationStddevAndMadAreGolden) {
+    Cn0AggregationConfig config{};
+    config.elevation_min_deg = 0.0;
+    config.elevation_max_deg = 10.0;
+    config.elevation_bin_width_deg = 10.0;
+    config.min_samples_per_bin = 4;
+    Cn0StatisticsAccumulator accumulator(config);
+    std::string error;
+    ASSERT_TRUE(accumulator.valid(&error)) << error;
+    ASSERT_TRUE(accumulator.begin_source(1.0, &error)) << error;
+
+    ASSERT_TRUE(accumulator.add_sample(sample(10.0, 5.0, 0), &error)) << error;
+    ASSERT_TRUE(accumulator.add_sample(sample(20.0, 5.0, 1000000000LL), &error)) << error;
+    ASSERT_TRUE(accumulator.add_sample(sample(30.0, 5.0, 2000000000LL), &error)) << error;
+    ASSERT_TRUE(accumulator.add_sample(sample(40.0, 5.0, 3000000000LL), &error)) << error;
+    accumulator.end_source();
+
+    const std::vector<Cn0BinStatistics> bins = accumulator.finalize();
+    const Cn0BinStatistics* bin = find_bin(bins, SignalId::kGpsL1Ca, 0.0);
+    ASSERT_NE(bin, nullptr);
+    EXPECT_EQ(bin->status, Cn0BinStatus::kReady);
+    EXPECT_EQ(bin->count, 4U);
+    EXPECT_DOUBLE_EQ(bin->p05_dbhz, 11.5);
+    EXPECT_DOUBLE_EQ(bin->p10_dbhz, 13.0);
+    EXPECT_DOUBLE_EQ(bin->p25_dbhz, 17.5);
+    EXPECT_DOUBLE_EQ(bin->p50_dbhz, 25.0);
+    EXPECT_DOUBLE_EQ(bin->p75_dbhz, 32.5);
+    EXPECT_DOUBLE_EQ(bin->p90_dbhz, 37.0);
+    EXPECT_DOUBLE_EQ(bin->p95_dbhz, 38.5);
+    EXPECT_DOUBLE_EQ(bin->mean_dbhz, 25.0);
+    EXPECT_NEAR(bin->stddev_dbhz, std::sqrt(125.0), 1e-12);
+    EXPECT_DOUBLE_EQ(bin->mad_dbhz, 10.0);
+}
+
+TEST(Cn0Statistics, ElevationEdgesAreHalfOpenExceptFinalMaximum) {
+    Cn0AggregationConfig config{};
+    config.elevation_min_deg = 0.0;
+    config.elevation_max_deg = 10.0;
+    config.elevation_bin_width_deg = 5.0;
+    config.min_samples_per_bin = 1;
+    Cn0StatisticsAccumulator accumulator(config);
+    std::string error;
+    ASSERT_TRUE(accumulator.begin_source(1.0, &error)) << error;
+    ASSERT_TRUE(accumulator.add_sample(sample(30.0, 0.0, 0), &error)) << error;
+    ASSERT_TRUE(accumulator.add_sample(sample(31.0, 4.999, 1000000000LL), &error)) << error;
+    ASSERT_TRUE(accumulator.add_sample(sample(32.0, 5.0, 2000000000LL), &error)) << error;
+    ASSERT_TRUE(accumulator.add_sample(sample(33.0, 10.0, 3000000000LL), &error)) << error;
+    ASSERT_TRUE(accumulator.add_sample(sample(34.0, -0.01, 4000000000LL), &error)) << error;
+    ASSERT_TRUE(accumulator.add_sample(sample(35.0, 10.01, 5000000000LL), &error)) << error;
+    accumulator.end_source();
+
+    const std::vector<Cn0BinStatistics> bins = accumulator.finalize();
+    const Cn0BinStatistics* lower = find_bin(bins, SignalId::kGpsL1Ca, 0.0);
+    const Cn0BinStatistics* upper = find_bin(bins, SignalId::kGpsL1Ca, 5.0);
+    ASSERT_NE(lower, nullptr);
+    ASSERT_NE(upper, nullptr);
+    EXPECT_EQ(lower->count, 2U);
+    EXPECT_EQ(upper->count, 2U);
+    EXPECT_FALSE(lower->includes_upper_edge);
+    EXPECT_TRUE(upper->includes_upper_edge);
+    EXPECT_EQ(accumulator.summary().rejected_elevation_range, 2U);
+}
+
+TEST(Cn0Statistics, InvalidAndOffGridSamplesCannotContaminateBins) {
+    Cn0AggregationConfig config{};
+    config.elevation_min_deg = 0.0;
+    config.elevation_max_deg = 10.0;
+    config.elevation_bin_width_deg = 10.0;
+    config.min_samples_per_bin = 2;
+    Cn0StatisticsAccumulator accumulator(config);
+    std::string error;
+    ASSERT_TRUE(accumulator.begin_source(1.0, &error)) << error;
+
+    RinexCn0Sample invalid = sample(30.0, 5.0, 0);
+    invalid.validity = Cn0SampleValidity::kGeometryUnavailable;
+    ASSERT_TRUE(accumulator.add_sample(invalid, &error)) << error;
+    RinexCn0Sample nonfinite = sample(31.0, 5.0, 1000000000LL);
+    nonfinite.cn0_dbhz = std::numeric_limits<double>::quiet_NaN();
+    ASSERT_TRUE(accumulator.add_sample(nonfinite, &error)) << error;
+    ASSERT_TRUE(accumulator.add_sample(sample(31.1, 5.0, 2000000000LL), &error)) << error;
+    ASSERT_TRUE(accumulator.add_sample(sample(32.0, 5.0, 3000000000LL), &error)) << error;
+    accumulator.end_source();
+
+    const Cn0BinStatistics* bin = find_bin(accumulator.finalize(), SignalId::kGpsL1Ca, 0.0);
+    ASSERT_NE(bin, nullptr);
+    EXPECT_EQ(bin->count, 1U);
+    EXPECT_EQ(bin->status, Cn0BinStatus::kSparse);
+    EXPECT_EQ(accumulator.summary().rejected_validity, 1U);
+    EXPECT_EQ(accumulator.summary().rejected_nonfinite, 1U);
+    EXPECT_EQ(accumulator.summary().rejected_cn0_grid, 1U);
+}
+
+TEST(Cn0Statistics, TemporalStatisticsRespectGapBinAndSourceBoundaries) {
+    Cn0AggregationConfig config{};
+    config.elevation_min_deg = 0.0;
+    config.elevation_max_deg = 20.0;
+    config.elevation_bin_width_deg = 10.0;
+    config.min_samples_per_bin = 1;
+    config.min_temporal_pairs = 3;
+    Cn0StatisticsAccumulator accumulator(config);
+    std::string error;
+    ASSERT_TRUE(accumulator.begin_source(1.0, &error)) << error;
+    ASSERT_TRUE(accumulator.add_sample(sample(30.0, 5.0, 0), &error)) << error;
+    ASSERT_TRUE(accumulator.add_sample(sample(31.0, 5.0, 1000000000LL), &error)) << error;
+    ASSERT_TRUE(accumulator.add_sample(sample(33.0, 5.0, 2000000000LL), &error)) << error;
+    ASSERT_TRUE(accumulator.add_sample(sample(32.0, 5.0, 3000000000LL), &error)) << error;
+    ASSERT_TRUE(accumulator.add_sample(sample(34.0, 5.0, 5000000000LL), &error)) << error;
+    ASSERT_TRUE(accumulator.add_sample(sample(35.0, 15.0, 6000000000LL), &error)) << error;
+    accumulator.end_source();
+
+    ASSERT_TRUE(accumulator.begin_source(1.0, &error)) << error;
+    ASSERT_TRUE(accumulator.add_sample(sample(36.0, 5.0, 7000000000LL), &error)) << error;
+    accumulator.end_source();
+
+    const Cn0BinStatistics* bin = find_bin(accumulator.finalize(), SignalId::kGpsL1Ca, 0.0);
+    ASSERT_NE(bin, nullptr);
+    EXPECT_EQ(bin->delta_count, 3U);
+    EXPECT_DOUBLE_EQ(bin->delta_p50_dbhz, 1.0);
+    EXPECT_DOUBLE_EQ(bin->delta_p90_dbhz, 1.8);
+    EXPECT_DOUBLE_EQ(bin->delta_p99_dbhz, 1.98);
+    EXPECT_EQ(bin->ar1_status, Cn0Ar1Status::kAvailable);
+    EXPECT_TRUE(std::isfinite(bin->ar1));
+    EXPECT_EQ(accumulator.summary().temporal_pairs, 3U);
+    EXPECT_EQ(accumulator.summary().temporal_rejected_gap, 1U);
+    EXPECT_EQ(accumulator.summary().temporal_rejected_bin_change, 1U);
+    EXPECT_EQ(accumulator.summary().sources, 2U);
+}
+
+TEST(Cn0Statistics, MissingIntervalAndZeroVarianceAreExplicit) {
+    Cn0AggregationConfig config{};
+    config.elevation_min_deg = 0.0;
+    config.elevation_max_deg = 10.0;
+    config.elevation_bin_width_deg = 10.0;
+    config.min_samples_per_bin = 1;
+    config.min_temporal_pairs = 2;
+    Cn0StatisticsAccumulator accumulator(config);
+    std::string error;
+    ASSERT_TRUE(accumulator.begin_source(std::numeric_limits<double>::quiet_NaN(), &error)) << error;
+    ASSERT_TRUE(accumulator.add_sample(sample(30.0, 5.0, 0), &error)) << error;
+    ASSERT_TRUE(accumulator.add_sample(sample(30.0, 5.0, 1000000000LL), &error)) << error;
+    accumulator.end_source();
+    EXPECT_EQ(accumulator.summary().temporal_rejected_no_interval, 1U);
+
+    Cn0StatisticsAccumulator constant_accumulator(config);
+    ASSERT_TRUE(constant_accumulator.begin_source(1.0, &error)) << error;
+    ASSERT_TRUE(constant_accumulator.add_sample(sample(30.0, 5.0, 0), &error)) << error;
+    ASSERT_TRUE(constant_accumulator.add_sample(sample(30.0, 5.0, 1000000000LL), &error)) << error;
+    ASSERT_TRUE(constant_accumulator.add_sample(sample(30.0, 5.0, 2000000000LL), &error)) << error;
+    constant_accumulator.end_source();
+    const Cn0BinStatistics* bin = find_bin(constant_accumulator.finalize(), SignalId::kGpsL1Ca, 0.0);
+    ASSERT_NE(bin, nullptr);
+    EXPECT_EQ(bin->ar1_status, Cn0Ar1Status::kZeroVariance);
+    EXPECT_FALSE(std::isfinite(bin->ar1));
+}
+
+TEST(Cn0Statistics, HistogramMemoryIsIndependentOfSampleCount) {
+    Cn0AggregationConfig config{};
+    Cn0StatisticsAccumulator accumulator(config);
+    std::string error;
+    ASSERT_TRUE(accumulator.begin_source(1.0, &error)) << error;
+    const std::size_t cells_before = accumulator.bounded_histogram_cells();
+    for (int index = 0; index < 10000; ++index) {
+        ASSERT_TRUE(accumulator.add_sample(sample(30.0 + static_cast<double>(index % 20) * 0.25, 45.0,
+                                                  static_cast<std::int64_t>(index) * 1000000000LL),
+                                           &error))
+            << error;
+    }
+    accumulator.end_source();
+    EXPECT_EQ(accumulator.bounded_histogram_cells(), cells_before);
+    EXPECT_EQ(accumulator.summary().accepted_samples, 10000U);
+}
+
+TEST(Cn0Statistics, BuilderModelAndMetadataAreByteIdenticalForFixedSources) {
+    const std::vector<Cn0InputSource> sources = {
+        {test_data("cn0_stream_acceptance_obs.rnx"), test_data("multi_gnss_acceptance_nav.rnx")}};
+    Cn0AggregationConfig config{};
+    config.min_samples_per_bin = 1;
+    Cn0BuildResult first{};
+    Cn0BuildResult second{};
+    std::string error;
+    ASSERT_TRUE(gnss_sim::cn0_builder::build_cn0_model(sources, config, &first, &error)) << error;
+    ASSERT_TRUE(gnss_sim::cn0_builder::build_cn0_model(sources, config, &second, &error)) << error;
+
+    const std::filesystem::path directory = std::filesystem::temp_directory_path();
+    const std::filesystem::path model_a = directory / "gnss_sim_cn0_model_a.csv";
+    const std::filesystem::path model_b = directory / "gnss_sim_cn0_model_b.csv";
+    const std::filesystem::path meta_a = directory / "gnss_sim_cn0_meta_a.json";
+    const std::filesystem::path meta_b = directory / "gnss_sim_cn0_meta_b.json";
+    ASSERT_TRUE(gnss_sim::cn0_builder::write_cn0_model_csv(model_a.string(), config, first.aggregation_summary, first.bins,
+                                                           &error))
+        << error;
+    ASSERT_TRUE(gnss_sim::cn0_builder::write_cn0_model_csv(model_b.string(), config, second.aggregation_summary,
+                                                           second.bins, &error))
+        << error;
+    ASSERT_TRUE(gnss_sim::cn0_builder::write_cn0_metadata_json(meta_a.string(), config, first, &error)) << error;
+    ASSERT_TRUE(gnss_sim::cn0_builder::write_cn0_metadata_json(meta_b.string(), config, second, &error)) << error;
+    EXPECT_EQ(read_file(model_a), read_file(model_b));
+    EXPECT_EQ(read_file(meta_a), read_file(meta_b));
+    EXPECT_EQ(first.bins.size(), 21U * 18U);
+    EXPECT_EQ(first.aggregation_summary.accepted_samples, 30U);
+
+    std::remove(model_a.string().c_str());
+    std::remove(model_b.string().c_str());
+    std::remove(meta_a.string().c_str());
+    std::remove(meta_b.string().c_str());
+}
+
+} // namespace

--- a/tools/build_cn0_model/README.md
+++ b/tools/build_cn0_model/README.md
@@ -1,6 +1,6 @@
 # CN0 model builder
 
-This directory is the offline data-preparation path for the simulator CN0 model. Issue #37 provides only the streaming RINEX OBS ingestion layer; elevation-bin statistics/model fitting belong to #38 and runtime model loading belongs to #39.
+This directory is the offline data-preparation path for the simulator CN0 model. Issue #37 provides the streaming RINEX OBS ingestion layer, #38 adds deterministic elevation-bin aggregation, and #39 connects the generated compact model to runtime simulation.
 
 ## RINEX OBS boundary
 
@@ -12,9 +12,9 @@ Signal identities always resolve through `src/gnss/signal_definitions.*`; unsupp
 
 ## Signal-strength semantics
 
-A RINEX `Snn` observable is accepted as comparable CN0 only when the observation header contains an unambiguous `SIGNAL STRENGTH UNIT` value of `DBHZ` (case-insensitive). The raw decoded signal-strength value is still exposed for missing, unsupported, or conflicting unit declarations, but `cn0_dbhz` remains unavailable and the sample is classified as `AMBIGUOUS_SIGNAL_STRENGTH_UNIT`.
+A RINEX `Snn` observable is accepted as comparable CN0 only when the observation header contains an unambiguous `SIGNAL STRENGTH UNIT` value of `DBHZ` (case-insensitive). The raw RTKLIB-decoded signal-strength value is still exposed for missing, unsupported, or conflicting unit declarations, but `cn0_dbhz` remains unavailable and the sample is classified as `AMBIGUOUS_SIGNAL_STRENGTH_UNIT`.
 
-A zero, blank, or non-numeric S field is treated as missing and is not emitted as a sample. This preserves the pinned RTKLIB decoding semantics rather than inventing a replacement value.
+RTKLIB stores the decoded S value in a one-byte `obsd_t.SNR` field with 0.25 dB-Hz resolution. A zero, blank, or non-numeric S field is treated as missing and is not emitted as a sample.
 
 Observation epochs are normalized to simulator GPST. UTC/GLONASS epochs use RTKLIB `utc2gpst()`, BeiDou BDT uses `bdt2gpst()`, and GPS/Galileo/QZSS use their GPST-aligned coarse epoch timeline. Out-of-order normalized epochs are rejected deterministically.
 
@@ -22,14 +22,40 @@ Observation epochs are normalized to simulator GPST. UTC/GLONASS epochs use RTKL
 
 Station coordinates come from `APPROX POSITION XYZ`. Associated NAV is loaded through the normal simulator RTKLIB adapter, and azimuth/elevation is computed with `compute_satellite_geometry()` using the same transmit-time iteration, ECEF geometry and elevation convention as simulation. The unit regression compares the builder result with a direct simulator geometry call to `1e-12` rad.
 
-If navigation geometry is unavailable, a DBHZ value can still be preserved in `cn0_dbhz`, but the sample is classified as `GEOMETRY_UNAVAILABLE` and cannot be used by the later elevation-model fitting stage.
+If navigation geometry is unavailable, a DBHZ value can still be preserved in `cn0_dbhz`, but the sample is classified as `GEOMETRY_UNAVAILABLE` and is rejected by the elevation aggregation stage.
+
+## Elevation-bin statistics
+
+The default model covers 0 through 90 degrees in 5-degree bins. Bins are half-open `[lower, upper)`; only the final bin includes 90 degrees exactly. Empty and under-supported bins remain explicit `EMPTY` or `SPARSE` rows and are never extrapolated during model construction.
+
+Because accepted CN0 is already on RTKLIB's 0.25 dB-Hz grid, each constellation/signal/elevation bin uses fixed 256-entry histograms rather than storing every observation. The same fixed grid is used for absolute consecutive Delta-CN0. Memory therefore scales with the number of model keys, not with OBS duration.
+
+Per-bin statistics are defined as follows:
+
+- P05/P10/P25/P50/P75/P90/P95 use R type-7 linear quantiles, `h=(n-1)*p`.
+- Mean and standard deviation use the population definition (`ddof=0`).
+- MAD is the type-7 median of `abs(CN0 - P50)`.
+- Delta-CN0 is the absolute difference between consecutive accepted samples.
+- Delta pairs and optional AR(1) never cross source, satellite, signal, elevation-bin or observation-gap boundaries. A temporal pair is valid only when the source has a positive RINEX `INTERVAL` and the normalized GPST gap agrees with it within the configured tolerance.
+- AR(1) is reported only when the configured pair support is met and both lagged series have non-zero variance; otherwise metadata states `INSUFFICIENT_SUPPORT` or `ZERO_VARIANCE`.
+
+Model rows are emitted in the central frozen signal-definition order and ascending elevation-bin order. Numeric formatting is locale-independent and fixed to six decimals.
+
+## Reproducibility metadata
+
+`cn0_model.meta.json` records the model/statistics schema versions, bin/filter rules, all aggregation rejection counters, RINEX/station/receiver/antenna information and per-source stream diagnostics. Source identity is basename + byte size + streaming FNV-1a64. Absolute source paths, wall-clock timestamps and output paths are intentionally excluded so relocating the same files does not change the generated metadata bytes.
 
 ## CLI
 
 ```text
-build-cn0-model --obs <rinex.obs> --nav <rinex.nav> --output <samples.csv>
+build-cn0-model \
+  --source <rinex.obs> <rinex.nav> \
+  [--source <rinex.obs> <rinex.nav> ...] \
+  --output <cn0_model.csv> \
+  --metadata <cn0_model.meta.json> \
+  [--bin-width-deg 5] \
+  [--min-bin-count 20] \
+  [--min-temporal-pairs 20]
 ```
 
-The CLI writes the streaming sample records to CSV. It does not compute elevation bins or fit a model.
-
-The canonical source for real calibration OBS/NAV material is the Wuhan University IGS Data Center (`igs.gnsswhu.cn`). CI must use compact, checked-in deterministic fixtures rather than downloading live data.
+The canonical source for real calibration OBS/NAV material is the Wuhan University IGS Data Center (`igs.gnsswhu.cn`). CI uses compact checked-in deterministic fixtures rather than downloading live data. Real open-sky WHU/IGS observation files are calibration inputs for offline model production, not normal CI dependencies.

--- a/tools/build_cn0_model/cn0_builder.cpp
+++ b/tools/build_cn0_model/cn0_builder.cpp
@@ -217,6 +217,13 @@ bool build_cn0_model(const std::vector<Cn0InputSource>& sources, const Cn0Aggreg
 
     build.aggregation_summary = accumulator.summary();
     build.bins = accumulator.finalize();
+    for (Cn0BinStatistics& bin : build.bins) {
+        if (bin.delta_count < config.min_temporal_pairs) {
+            bin.delta_p50_dbhz = std::numeric_limits<double>::quiet_NaN();
+            bin.delta_p90_dbhz = std::numeric_limits<double>::quiet_NaN();
+            bin.delta_p99_dbhz = std::numeric_limits<double>::quiet_NaN();
+        }
+    }
     *result = std::move(build);
     return true;
 }

--- a/tools/build_cn0_model/cn0_builder.cpp
+++ b/tools/build_cn0_model/cn0_builder.cpp
@@ -7,7 +7,6 @@
 #include <iomanip>
 #include <limits>
 #include <locale>
-#include <set>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -88,6 +87,10 @@ bool scan_observation_interval(const std::string& path, double* interval_sec, bo
             value_stream >> value;
             if (!value_stream || !std::isfinite(value) || value <= 0.0) {
                 set_error(error_message, "RINEX observation INTERVAL record is invalid: " + path);
+                return false;
+            }
+            if (*available && std::fabs(*interval_sec - value) > 1e-12) {
+                set_error(error_message, "RINEX observation header has conflicting INTERVAL records: " + path);
                 return false;
             }
             *available = true;
@@ -188,9 +191,8 @@ bool build_cn0_model(const std::vector<Cn0InputSource>& sources, const Cn0Aggreg
                                        &metadata.observation_interval_available, error_message)) {
             return false;
         }
-        const double interval = metadata.observation_interval_available
-                                    ? metadata.observation_interval_sec
-                                    : std::numeric_limits<double>::quiet_NaN();
+        const double interval = metadata.observation_interval_available ? metadata.observation_interval_sec
+                                                                        : std::numeric_limits<double>::quiet_NaN();
         if (!accumulator.begin_source(interval, error_message)) {
             return false;
         }
@@ -235,32 +237,35 @@ bool write_cn0_metadata_json(const std::string& output_path, const Cn0Aggregatio
     output << "  \"statistics\":{\"quantile\":\"R7_linear_h=(n-1)*p\",\"stddev\":\"population\","
               "\"mad\":\"median_absolute_deviation_from_p50\",\"delta_cn0\":\"absolute_consecutive_difference\","
               "\"cn0_grid_dbhz\":0.250000},\n";
-    output << "  \"elevation_bins\":{\"min_deg\":" << config.elevation_min_deg << ",\"max_deg\":"
-           << config.elevation_max_deg << ",\"width_deg\":" << config.elevation_bin_width_deg
+    output << "  \"elevation_bins\":{\"min_deg\":" << config.elevation_min_deg
+           << ",\"max_deg\":" << config.elevation_max_deg << ",\"width_deg\":" << config.elevation_bin_width_deg
            << ",\"rule\":\"[lower,upper), final bin includes max\"},\n";
     output << "  \"filtering\":{\"min_samples_per_bin\":" << config.min_samples_per_bin
-           << ",\"min_temporal_pairs\":" << config.min_temporal_pairs << ",\"temporal_gap_tolerance_sec\":"
-           << config.temporal_gap_tolerance_sec
+           << ",\"min_temporal_pairs\":" << config.min_temporal_pairs
+           << ",\"temporal_gap_tolerance_sec\":" << config.temporal_gap_tolerance_sec
            << ",\"temporal_rule\":\"same source,satellite,signal,elevation bin and declared INTERVAL\"},\n";
     const Cn0AggregationSummary& summary = result.aggregation_summary;
-    output << "  \"summary\":{\"input_samples\":" << summary.input_samples << ",\"accepted_samples\":"
-           << summary.accepted_samples << ",\"rejected_validity\":" << summary.rejected_validity
-           << ",\"rejected_nonfinite\":" << summary.rejected_nonfinite << ",\"rejected_cn0_grid\":"
-           << summary.rejected_cn0_grid << ",\"rejected_elevation_range\":" << summary.rejected_elevation_range
-           << ",\"temporal_pairs\":" << summary.temporal_pairs << ",\"temporal_rejected_no_interval\":"
-           << summary.temporal_rejected_no_interval << ",\"temporal_rejected_gap\":"
-           << summary.temporal_rejected_gap << ",\"temporal_rejected_bin_change\":"
-           << summary.temporal_rejected_bin_change << ",\"sources\":" << summary.sources << "},\n";
+    output << "  \"summary\":{\"input_samples\":" << summary.input_samples
+           << ",\"accepted_samples\":" << summary.accepted_samples
+           << ",\"rejected_validity\":" << summary.rejected_validity
+           << ",\"rejected_nonfinite\":" << summary.rejected_nonfinite
+           << ",\"rejected_cn0_grid\":" << summary.rejected_cn0_grid
+           << ",\"rejected_elevation_range\":" << summary.rejected_elevation_range
+           << ",\"temporal_pairs\":" << summary.temporal_pairs
+           << ",\"temporal_rejected_no_interval\":" << summary.temporal_rejected_no_interval
+           << ",\"temporal_rejected_gap\":" << summary.temporal_rejected_gap
+           << ",\"temporal_rejected_bin_change\":" << summary.temporal_rejected_bin_change
+           << ",\"sources\":" << summary.sources << "},\n";
     output << "  \"sources\":[\n";
     for (std::size_t index = 0; index < result.sources.size(); ++index) {
         const Cn0SourceMetadata& source = result.sources[index];
         output << "    {\"observation\":{\"file_name\":\"" << json_escape(source.observation_file.file_name)
                << "\",\"size_bytes\":" << source.observation_file.size_bytes << ",\"fnv1a64\":\""
                << hex64(source.observation_file.fnv1a64) << "\"},\"navigation\":{\"file_name\":\""
-               << json_escape(source.navigation_file.file_name) << "\",\"size_bytes\":"
-               << source.navigation_file.size_bytes << ",\"fnv1a64\":\"" << hex64(source.navigation_file.fnv1a64)
-               << "\"},\"rinex_version\":" << source.provenance.rinex_version << ",\"station_name\":\""
-               << json_escape(source.provenance.station_name) << "\",\"marker_number\":\""
+               << json_escape(source.navigation_file.file_name)
+               << "\",\"size_bytes\":" << source.navigation_file.size_bytes << ",\"fnv1a64\":\""
+               << hex64(source.navigation_file.fnv1a64) << "\"},\"rinex_version\":" << source.provenance.rinex_version
+               << ",\"station_name\":\"" << json_escape(source.provenance.station_name) << "\",\"marker_number\":\""
                << json_escape(source.provenance.marker_number) << "\",\"receiver_type\":\""
                << json_escape(source.provenance.receiver_type) << "\",\"antenna_type\":\""
                << json_escape(source.provenance.antenna_type) << "\",\"time_system\":\""

--- a/tools/build_cn0_model/cn0_builder.cpp
+++ b/tools/build_cn0_model/cn0_builder.cpp
@@ -1,0 +1,314 @@
+#include "tools/build_cn0_model/cn0_builder.h"
+
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <limits>
+#include <locale>
+#include <set>
+#include <sstream>
+#include <string>
+#include <utility>
+
+namespace gnss_sim::cn0_builder {
+namespace {
+
+constexpr std::uint64_t kFnvOffsetBasis = 14695981039346656037ULL;
+constexpr std::uint64_t kFnvPrime = 1099511628211ULL;
+
+void set_error(std::string* error_message, const std::string& message) {
+    if (error_message != nullptr) {
+        *error_message = message;
+    }
+}
+
+std::string trim(std::string value) {
+    const std::size_t begin = value.find_first_not_of(" \t\r\n");
+    if (begin == std::string::npos) {
+        return {};
+    }
+    const std::size_t end = value.find_last_not_of(" \t\r\n");
+    return value.substr(begin, end - begin + 1);
+}
+
+bool file_identity(const std::string& path, Cn0FileIdentity* identity, std::string* error_message) {
+    if (identity == nullptr) {
+        set_error(error_message, "CN0 source identity output must not be null");
+        return false;
+    }
+    std::ifstream input(path, std::ios::binary);
+    if (!input) {
+        set_error(error_message, "cannot open CN0 source for identity: " + path);
+        return false;
+    }
+    std::uint64_t hash = kFnvOffsetBasis;
+    std::uint64_t size = 0;
+    char buffer[65536];
+    while (input) {
+        input.read(buffer, sizeof(buffer));
+        const std::streamsize count = input.gcount();
+        for (std::streamsize index = 0; index < count; ++index) {
+            hash ^= static_cast<unsigned char>(buffer[index]);
+            hash *= kFnvPrime;
+        }
+        size += static_cast<std::uint64_t>(count);
+    }
+    if (!input.eof()) {
+        set_error(error_message, "failed while hashing CN0 source: " + path);
+        return false;
+    }
+    identity->file_name = std::filesystem::path(path).filename().string();
+    identity->size_bytes = size;
+    identity->fnv1a64 = hash;
+    return true;
+}
+
+bool scan_observation_interval(const std::string& path, double* interval_sec, bool* available,
+                               std::string* error_message) {
+    if (interval_sec == nullptr || available == nullptr) {
+        set_error(error_message, "RINEX interval outputs must not be null");
+        return false;
+    }
+    *available = false;
+    *interval_sec = std::numeric_limits<double>::quiet_NaN();
+    std::ifstream input(path);
+    if (!input) {
+        set_error(error_message, "cannot open RINEX observation file for interval inspection: " + path);
+        return false;
+    }
+    std::string line;
+    while (std::getline(input, line)) {
+        const std::string label = line.size() > 60 ? trim(line.substr(60)) : std::string{};
+        if (label.find("INTERVAL") != std::string::npos) {
+            std::istringstream value_stream(line.substr(0, std::min<std::size_t>(10, line.size())));
+            value_stream.imbue(std::locale::classic());
+            double value = 0.0;
+            value_stream >> value;
+            if (!value_stream || !std::isfinite(value) || value <= 0.0) {
+                set_error(error_message, "RINEX observation INTERVAL record is invalid: " + path);
+                return false;
+            }
+            *available = true;
+            *interval_sec = value;
+        }
+        if (label.find("END OF HEADER") != std::string::npos) {
+            return true;
+        }
+    }
+    set_error(error_message, "RINEX observation header has no END OF HEADER record: " + path);
+    return false;
+}
+
+std::string json_escape(const std::string& value) {
+    std::ostringstream output;
+    for (const unsigned char character : value) {
+        switch (character) {
+            case '\"':
+                output << "\\\"";
+                break;
+            case '\\':
+                output << "\\\\";
+                break;
+            case '\b':
+                output << "\\b";
+                break;
+            case '\f':
+                output << "\\f";
+                break;
+            case '\n':
+                output << "\\n";
+                break;
+            case '\r':
+                output << "\\r";
+                break;
+            case '\t':
+                output << "\\t";
+                break;
+            default:
+                if (character < 0x20U) {
+                    output << "\\u00" << std::hex << std::setw(2) << std::setfill('0')
+                           << static_cast<unsigned int>(character) << std::dec << std::setfill(' ');
+                } else {
+                    output << static_cast<char>(character);
+                }
+                break;
+        }
+    }
+    return output.str();
+}
+
+std::string hex64(std::uint64_t value) {
+    std::ostringstream output;
+    output.imbue(std::locale::classic());
+    output << std::hex << std::setfill('0') << std::setw(16) << value;
+    return output.str();
+}
+
+void write_sim_time_json(std::ostream& output, const SimTime& time) {
+    output << "{\"gps_week\":" << time.gps_week << ",\"tow_ns\":" << time.tow_ns << '}';
+}
+
+void write_string_array(std::ostream& output, const std::vector<std::string>& values) {
+    output << '[';
+    for (std::size_t index = 0; index < values.size(); ++index) {
+        if (index > 0) {
+            output << ',';
+        }
+        output << '\"' << json_escape(values[index]) << '\"';
+    }
+    output << ']';
+}
+
+} // namespace
+
+bool build_cn0_model(const std::vector<Cn0InputSource>& sources, const Cn0AggregationConfig& config,
+                     Cn0BuildResult* result, std::string* error_message) {
+    if (result == nullptr || sources.empty()) {
+        set_error(error_message, "CN0 model build requires at least one source and a result output");
+        return false;
+    }
+    Cn0StatisticsAccumulator accumulator(config);
+    if (!accumulator.valid(error_message)) {
+        return false;
+    }
+
+    Cn0BuildResult build{};
+    build.sources.reserve(sources.size());
+    for (const Cn0InputSource& source : sources) {
+        if (source.observation_path.empty() || source.navigation_path.empty()) {
+            set_error(error_message, "CN0 source OBS/NAV paths must not be empty");
+            return false;
+        }
+        Cn0SourceMetadata metadata{};
+        if (!file_identity(source.observation_path, &metadata.observation_file, error_message) ||
+            !file_identity(source.navigation_path, &metadata.navigation_file, error_message) ||
+            !scan_observation_interval(source.observation_path, &metadata.observation_interval_sec,
+                                       &metadata.observation_interval_available, error_message)) {
+            return false;
+        }
+        const double interval = metadata.observation_interval_available
+                                    ? metadata.observation_interval_sec
+                                    : std::numeric_limits<double>::quiet_NaN();
+        if (!accumulator.begin_source(interval, error_message)) {
+            return false;
+        }
+
+        const bool streamed = stream_rinex_cn0_samples(
+            source.observation_path, source.navigation_path,
+            [&](const RinexCn0Sample& sample) {
+                if (!metadata.sample_time_available) {
+                    metadata.first_sample_time = sample.time;
+                    metadata.sample_time_available = true;
+                }
+                metadata.last_sample_time = sample.time;
+                return accumulator.add_sample(sample, error_message);
+            },
+            &metadata.provenance, &metadata.stream_summary, error_message);
+        accumulator.end_source();
+        if (!streamed) {
+            return false;
+        }
+        build.sources.push_back(std::move(metadata));
+    }
+
+    build.aggregation_summary = accumulator.summary();
+    build.bins = accumulator.finalize();
+    *result = std::move(build);
+    return true;
+}
+
+bool write_cn0_metadata_json(const std::string& output_path, const Cn0AggregationConfig& config,
+                             const Cn0BuildResult& result, std::string* error_message) {
+    std::ofstream output(output_path, std::ios::binary);
+    if (!output) {
+        set_error(error_message, "cannot open CN0 metadata JSON for writing: " + output_path);
+        return false;
+    }
+    output.imbue(std::locale::classic());
+    output << std::fixed << std::setprecision(6);
+    output << "{\n";
+    output << "  \"schema_version\":\"gnss-cn0-metadata-v1\",\n";
+    output << "  \"builder_version\":\"gnss-cn0-builder-v1\",\n";
+    output << "  \"model_schema_version\":\"gnss-cn0-model-v1\",\n";
+    output << "  \"statistics\":{\"quantile\":\"R7_linear_h=(n-1)*p\",\"stddev\":\"population\","
+              "\"mad\":\"median_absolute_deviation_from_p50\",\"delta_cn0\":\"absolute_consecutive_difference\","
+              "\"cn0_grid_dbhz\":0.250000},\n";
+    output << "  \"elevation_bins\":{\"min_deg\":" << config.elevation_min_deg << ",\"max_deg\":"
+           << config.elevation_max_deg << ",\"width_deg\":" << config.elevation_bin_width_deg
+           << ",\"rule\":\"[lower,upper), final bin includes max\"},\n";
+    output << "  \"filtering\":{\"min_samples_per_bin\":" << config.min_samples_per_bin
+           << ",\"min_temporal_pairs\":" << config.min_temporal_pairs << ",\"temporal_gap_tolerance_sec\":"
+           << config.temporal_gap_tolerance_sec
+           << ",\"temporal_rule\":\"same source,satellite,signal,elevation bin and declared INTERVAL\"},\n";
+    const Cn0AggregationSummary& summary = result.aggregation_summary;
+    output << "  \"summary\":{\"input_samples\":" << summary.input_samples << ",\"accepted_samples\":"
+           << summary.accepted_samples << ",\"rejected_validity\":" << summary.rejected_validity
+           << ",\"rejected_nonfinite\":" << summary.rejected_nonfinite << ",\"rejected_cn0_grid\":"
+           << summary.rejected_cn0_grid << ",\"rejected_elevation_range\":" << summary.rejected_elevation_range
+           << ",\"temporal_pairs\":" << summary.temporal_pairs << ",\"temporal_rejected_no_interval\":"
+           << summary.temporal_rejected_no_interval << ",\"temporal_rejected_gap\":"
+           << summary.temporal_rejected_gap << ",\"temporal_rejected_bin_change\":"
+           << summary.temporal_rejected_bin_change << ",\"sources\":" << summary.sources << "},\n";
+    output << "  \"sources\":[\n";
+    for (std::size_t index = 0; index < result.sources.size(); ++index) {
+        const Cn0SourceMetadata& source = result.sources[index];
+        output << "    {\"observation\":{\"file_name\":\"" << json_escape(source.observation_file.file_name)
+               << "\",\"size_bytes\":" << source.observation_file.size_bytes << ",\"fnv1a64\":\""
+               << hex64(source.observation_file.fnv1a64) << "\"},\"navigation\":{\"file_name\":\""
+               << json_escape(source.navigation_file.file_name) << "\",\"size_bytes\":"
+               << source.navigation_file.size_bytes << ",\"fnv1a64\":\"" << hex64(source.navigation_file.fnv1a64)
+               << "\"},\"rinex_version\":" << source.provenance.rinex_version << ",\"station_name\":\""
+               << json_escape(source.provenance.station_name) << "\",\"marker_number\":\""
+               << json_escape(source.provenance.marker_number) << "\",\"receiver_type\":\""
+               << json_escape(source.provenance.receiver_type) << "\",\"antenna_type\":\""
+               << json_escape(source.provenance.antenna_type) << "\",\"time_system\":\""
+               << json_escape(source.provenance.observation_time_system) << "\",\"signal_strength_unit\":\""
+               << json_escape(source.provenance.signal_strength_unit) << "\",\"signal_strength_unit_status\":\""
+               << signal_strength_unit_status_name(source.provenance.signal_strength_unit_status)
+               << "\",\"station_ecef_m\":[" << source.provenance.station_ecef_m[0] << ','
+               << source.provenance.station_ecef_m[1] << ',' << source.provenance.station_ecef_m[2]
+               << "],\"observation_interval_sec\":";
+        if (source.observation_interval_available) {
+            output << source.observation_interval_sec;
+        } else {
+            output << "null";
+        }
+        output << ",\"first_sample_time\":";
+        if (source.sample_time_available) {
+            write_sim_time_json(output, source.first_sample_time);
+        } else {
+            output << "null";
+        }
+        output << ",\"last_sample_time\":";
+        if (source.sample_time_available) {
+            write_sim_time_json(output, source.last_sample_time);
+        } else {
+            output << "null";
+        }
+        output << ",\"stream_summary\":{\"epochs\":" << source.stream_summary.epochs
+               << ",\"observation_records\":" << source.stream_summary.observation_records
+               << ",\"emitted_samples\":" << source.stream_summary.emitted_samples
+               << ",\"valid_dbhz_samples\":" << source.stream_summary.valid_dbhz_samples
+               << ",\"ambiguous_unit_samples\":" << source.stream_summary.ambiguous_unit_samples
+               << ",\"missing_signal_strength\":" << source.stream_summary.missing_signal_strength
+               << ",\"unsupported_signal_observables\":" << source.stream_summary.unsupported_signal_observables
+               << ",\"unmapped_snr_slots\":" << source.stream_summary.unmapped_snr_slots
+               << ",\"geometry_failures\":" << source.stream_summary.geometry_failures
+               << ",\"out_of_order_epochs\":" << source.stream_summary.out_of_order_epochs
+               << ",\"peak_epoch_observations\":" << source.stream_summary.peak_epoch_observations
+               << ",\"unsupported_observables\":";
+        write_string_array(output, source.stream_summary.unsupported_observables);
+        output << "}}" << (index + 1 == result.sources.size() ? "\n" : ",\n");
+    }
+    output << "  ]\n";
+    output << "}\n";
+    if (!output) {
+        set_error(error_message, "failed while writing CN0 metadata JSON: " + output_path);
+        return false;
+    }
+    return true;
+}
+
+} // namespace gnss_sim::cn0_builder

--- a/tools/build_cn0_model/cn0_builder.h
+++ b/tools/build_cn0_model/cn0_builder.h
@@ -1,0 +1,49 @@
+#ifndef GNSS_SIM_TOOLS_BUILD_CN0_MODEL_CN0_BUILDER_H_
+#define GNSS_SIM_TOOLS_BUILD_CN0_MODEL_CN0_BUILDER_H_
+
+#include "tools/build_cn0_model/cn0_statistics.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace gnss_sim::cn0_builder {
+
+struct Cn0InputSource {
+    std::string observation_path;
+    std::string navigation_path;
+};
+
+struct Cn0FileIdentity {
+    std::string file_name;
+    std::uint64_t size_bytes{};
+    std::uint64_t fnv1a64{};
+};
+
+struct Cn0SourceMetadata {
+    Cn0FileIdentity observation_file;
+    Cn0FileIdentity navigation_file;
+    RinexObsProvenance provenance;
+    RinexObsStreamSummary stream_summary;
+    bool observation_interval_available{};
+    double observation_interval_sec{};
+    bool sample_time_available{};
+    SimTime first_sample_time{};
+    SimTime last_sample_time{};
+};
+
+struct Cn0BuildResult {
+    Cn0AggregationSummary aggregation_summary;
+    std::vector<Cn0BinStatistics> bins;
+    std::vector<Cn0SourceMetadata> sources;
+};
+
+bool build_cn0_model(const std::vector<Cn0InputSource>& sources, const Cn0AggregationConfig& config,
+                     Cn0BuildResult* result, std::string* error_message);
+
+bool write_cn0_metadata_json(const std::string& output_path, const Cn0AggregationConfig& config,
+                             const Cn0BuildResult& result, std::string* error_message);
+
+} // namespace gnss_sim::cn0_builder
+
+#endif // GNSS_SIM_TOOLS_BUILD_CN0_MODEL_CN0_BUILDER_H_

--- a/tools/build_cn0_model/cn0_statistics.cpp
+++ b/tools/build_cn0_model/cn0_statistics.cpp
@@ -69,8 +69,7 @@ bool validate_config(const Cn0AggregationConfig& config, int* bin_count, std::st
         set_error(error_message, "CN0 elevation model bounds must remain within [-90, 90] degrees");
         return false;
     }
-    const double exact_bins =
-        (config.elevation_max_deg - config.elevation_min_deg) / config.elevation_bin_width_deg;
+    const double exact_bins = (config.elevation_max_deg - config.elevation_min_deg) / config.elevation_bin_width_deg;
     const double rounded_bins = std::round(exact_bins);
     if (std::fabs(exact_bins - rounded_bins) > kConfigTolerance || rounded_bins < 1.0 || rounded_bins > 180.0) {
         set_error(error_message, "CN0 elevation span must be an integer number of bins");
@@ -193,12 +192,10 @@ double histogram_mad(const std::array<std::uint64_t, kCn0QuarterBuckets>& histog
         if (bucket_count == 0) {
             continue;
         }
-        deviations.push_back(
-            {std::fabs(static_cast<double>(bucket) * kQuarterDbHz - median), bucket_count});
+        deviations.push_back({std::fabs(static_cast<double>(bucket) * kQuarterDbHz - median), bucket_count});
     }
-    std::sort(deviations.begin(), deviations.end(), [](const WeightedValue& left, const WeightedValue& right) {
-        return left.value < right.value;
-    });
+    std::sort(deviations.begin(), deviations.end(),
+              [](const WeightedValue& left, const WeightedValue& right) { return left.value < right.value; });
     return weighted_quantile(deviations, count, 0.5);
 }
 
@@ -227,14 +224,12 @@ std::uint64_t previous_key(int satellite_number, SignalId signal_id) {
 }
 
 double sim_time_difference_sec(const SimTime& current, const SimTime& previous) {
-    const double week_seconds =
-        static_cast<double>(current.gps_week - previous.gps_week) * 604800.0;
+    const double week_seconds = static_cast<double>(current.gps_week - previous.gps_week) * 604800.0;
     const double tow_seconds = static_cast<double>(current.tow_ns - previous.tow_ns) / 1000000000.0;
     return week_seconds + tow_seconds;
 }
 
-bool temporal_ar1(const TemporalMoments& moments, std::uint64_t minimum_pairs, double* ar1,
-                  Cn0Ar1Status* status) {
+bool temporal_ar1(const TemporalMoments& moments, std::uint64_t minimum_pairs, double* ar1, Cn0Ar1Status* status) {
     if (ar1 == nullptr || status == nullptr) {
         return false;
     }
@@ -313,10 +308,9 @@ bool Cn0StatisticsAccumulator::begin_source(double observation_interval_sec, std
     }
     impl_->previous.clear();
     impl_->source_active = true;
-    impl_->source_interval_sec =
-        std::isfinite(observation_interval_sec) && observation_interval_sec > 0.0
-            ? observation_interval_sec
-            : std::numeric_limits<double>::quiet_NaN();
+    impl_->source_interval_sec = std::isfinite(observation_interval_sec) && observation_interval_sec > 0.0
+                                     ? observation_interval_sec
+                                     : std::numeric_limits<double>::quiet_NaN();
     ++impl_->summary.sources;
     return true;
 }
@@ -415,14 +409,14 @@ std::vector<Cn0BinStatistics> Cn0StatisticsAccumulator::finalize() const {
     for (std::size_t signal_index = 0; signal_index < impl_->signals.size(); ++signal_index) {
         const SignalDefinition& signal = *impl_->signals[signal_index];
         for (int bin_index = 0; bin_index < impl_->bin_count; ++bin_index) {
-            const BinCell& cell =
-                impl_->cells[signal_index * static_cast<std::size_t>(impl_->bin_count) + static_cast<std::size_t>(bin_index)];
+            const BinCell& cell = impl_->cells[signal_index * static_cast<std::size_t>(impl_->bin_count) +
+                                               static_cast<std::size_t>(bin_index)];
             Cn0BinStatistics statistics{};
             statistics.constellation = signal.constellation;
             statistics.signal_id = signal.signal_id;
             statistics.rinex_signal_code = signal.rinex_signal_code;
-            statistics.elevation_min_deg =
-                impl_->config.elevation_min_deg + static_cast<double>(bin_index) * impl_->config.elevation_bin_width_deg;
+            statistics.elevation_min_deg = impl_->config.elevation_min_deg +
+                                           static_cast<double>(bin_index) * impl_->config.elevation_bin_width_deg;
             statistics.elevation_max_deg = statistics.elevation_min_deg + impl_->config.elevation_bin_width_deg;
             statistics.includes_upper_edge = bin_index == impl_->bin_count - 1;
             statistics.count = histogram_count(cell.cn0_hist);
@@ -517,9 +511,10 @@ bool write_cn0_model_csv(const std::string& output_path, const Cn0AggregationCon
     }
     output.imbue(std::locale::classic());
     output << std::fixed << std::setprecision(6);
-    output << "schema_version,constellation,signal,elevation_min_deg,elevation_max_deg,upper_edge_inclusive,status,count,"
-              "p05_dbhz,p10_dbhz,p25_dbhz,p50_dbhz,p75_dbhz,p90_dbhz,p95_dbhz,mean_dbhz,stddev_dbhz,mad_dbhz,"
-              "delta_count,delta_p50_dbhz,delta_p90_dbhz,delta_p99_dbhz,ar1_status,ar1\n";
+    output
+        << "schema_version,constellation,signal,elevation_min_deg,elevation_max_deg,upper_edge_inclusive,status,count,"
+           "p05_dbhz,p10_dbhz,p25_dbhz,p50_dbhz,p75_dbhz,p90_dbhz,p95_dbhz,mean_dbhz,stddev_dbhz,mad_dbhz,"
+           "delta_count,delta_p50_dbhz,delta_p90_dbhz,delta_p99_dbhz,ar1_status,ar1\n";
     for (const Cn0BinStatistics& bin : bins) {
         output << "gnss-cn0-model-v1," << constellation_name(bin.constellation) << ',' << bin.rinex_signal_code << ','
                << bin.elevation_min_deg << ',' << bin.elevation_max_deg << ',' << (bin.includes_upper_edge ? 1 : 0)

--- a/tools/build_cn0_model/cn0_statistics.cpp
+++ b/tools/build_cn0_model/cn0_statistics.cpp
@@ -1,0 +1,567 @@
+#include "tools/build_cn0_model/cn0_statistics.h"
+
+#include "gnss/signal_definitions.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <fstream>
+#include <iomanip>
+#include <limits>
+#include <locale>
+#include <sstream>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace gnss_sim::cn0_builder {
+namespace {
+
+constexpr int kCn0QuarterBuckets = 256;
+constexpr double kQuarterDbHz = 0.25;
+constexpr double kConfigTolerance = 1e-9;
+
+struct TemporalMoments {
+    std::uint64_t count{};
+    std::uint64_t sum_x{};
+    std::uint64_t sum_y{};
+    std::uint64_t sum_x2{};
+    std::uint64_t sum_y2{};
+    std::uint64_t sum_xy{};
+};
+
+struct BinCell {
+    std::array<std::uint64_t, kCn0QuarterBuckets> cn0_hist{};
+    std::array<std::uint64_t, kCn0QuarterBuckets> delta_hist{};
+    TemporalMoments temporal{};
+};
+
+struct PreviousSample {
+    SimTime time{};
+    int elevation_bin{-1};
+    int cn0_quarters{};
+};
+
+struct WeightedValue {
+    double value{};
+    std::uint64_t count{};
+};
+
+void set_error(std::string* error_message, const std::string& message) {
+    if (error_message != nullptr) {
+        *error_message = message;
+    }
+}
+
+bool finite_config(const Cn0AggregationConfig& config) {
+    return std::isfinite(config.elevation_min_deg) && std::isfinite(config.elevation_max_deg) &&
+           std::isfinite(config.elevation_bin_width_deg) && std::isfinite(config.temporal_gap_tolerance_sec);
+}
+
+bool validate_config(const Cn0AggregationConfig& config, int* bin_count, std::string* error_message) {
+    if (!finite_config(config) || config.elevation_bin_width_deg <= 0.0 ||
+        config.elevation_max_deg <= config.elevation_min_deg || config.temporal_gap_tolerance_sec < 0.0) {
+        set_error(error_message, "CN0 aggregation config has invalid numeric bounds");
+        return false;
+    }
+    if (config.elevation_min_deg < -90.0 || config.elevation_max_deg > 90.0) {
+        set_error(error_message, "CN0 elevation model bounds must remain within [-90, 90] degrees");
+        return false;
+    }
+    const double exact_bins =
+        (config.elevation_max_deg - config.elevation_min_deg) / config.elevation_bin_width_deg;
+    const double rounded_bins = std::round(exact_bins);
+    if (std::fabs(exact_bins - rounded_bins) > kConfigTolerance || rounded_bins < 1.0 || rounded_bins > 180.0) {
+        set_error(error_message, "CN0 elevation span must be an integer number of bins");
+        return false;
+    }
+    if (bin_count != nullptr) {
+        *bin_count = static_cast<int>(rounded_bins);
+    }
+    return true;
+}
+
+int find_signal_index(const std::vector<const SignalDefinition*>& signals, SignalId signal_id) {
+    for (std::size_t index = 0; index < signals.size(); ++index) {
+        if (signals[index]->signal_id == signal_id) {
+            return static_cast<int>(index);
+        }
+    }
+    return -1;
+}
+
+bool cn0_to_quarters(double cn0_dbhz, int* quarters) {
+    if (quarters == nullptr || !std::isfinite(cn0_dbhz)) {
+        return false;
+    }
+    const double scaled = cn0_dbhz / kQuarterDbHz;
+    const double rounded = std::round(scaled);
+    if (std::fabs(scaled - rounded) > 1e-8 || rounded < 0.0 || rounded >= kCn0QuarterBuckets) {
+        return false;
+    }
+    *quarters = static_cast<int>(rounded);
+    return true;
+}
+
+int elevation_bin_index(const Cn0AggregationConfig& config, int bin_count, double elevation_deg) {
+    if (!std::isfinite(elevation_deg) || elevation_deg < config.elevation_min_deg - kConfigTolerance ||
+        elevation_deg > config.elevation_max_deg + kConfigTolerance) {
+        return -1;
+    }
+    if (std::fabs(elevation_deg - config.elevation_max_deg) <= kConfigTolerance) {
+        return bin_count - 1;
+    }
+    if (elevation_deg < config.elevation_min_deg) {
+        elevation_deg = config.elevation_min_deg;
+    }
+    const double relative = (elevation_deg - config.elevation_min_deg) / config.elevation_bin_width_deg;
+    const int index = static_cast<int>(std::floor(relative + kConfigTolerance));
+    return index >= 0 && index < bin_count ? index : -1;
+}
+
+std::uint64_t histogram_count(const std::array<std::uint64_t, kCn0QuarterBuckets>& histogram) {
+    std::uint64_t count = 0;
+    for (const std::uint64_t value : histogram) {
+        count += value;
+    }
+    return count;
+}
+
+double histogram_order_stat(const std::array<std::uint64_t, kCn0QuarterBuckets>& histogram, std::uint64_t rank) {
+    std::uint64_t cumulative = 0;
+    for (int bucket = 0; bucket < kCn0QuarterBuckets; ++bucket) {
+        cumulative += histogram[static_cast<std::size_t>(bucket)];
+        if (rank < cumulative) {
+            return static_cast<double>(bucket) * kQuarterDbHz;
+        }
+    }
+    return std::numeric_limits<double>::quiet_NaN();
+}
+
+double histogram_quantile(const std::array<std::uint64_t, kCn0QuarterBuckets>& histogram, double probability) {
+    const std::uint64_t count = histogram_count(histogram);
+    if (count == 0 || !std::isfinite(probability) || probability < 0.0 || probability > 1.0) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    if (count == 1) {
+        return histogram_order_stat(histogram, 0);
+    }
+    const double h = static_cast<double>(count - 1) * probability;
+    const std::uint64_t lower_rank = static_cast<std::uint64_t>(std::floor(h));
+    const std::uint64_t upper_rank = static_cast<std::uint64_t>(std::ceil(h));
+    const double lower = histogram_order_stat(histogram, lower_rank);
+    const double upper = histogram_order_stat(histogram, upper_rank);
+    return lower + (h - static_cast<double>(lower_rank)) * (upper - lower);
+}
+
+double weighted_order_stat(const std::vector<WeightedValue>& values, std::uint64_t rank) {
+    std::uint64_t cumulative = 0;
+    for (const WeightedValue& item : values) {
+        cumulative += item.count;
+        if (rank < cumulative) {
+            return item.value;
+        }
+    }
+    return std::numeric_limits<double>::quiet_NaN();
+}
+
+double weighted_quantile(const std::vector<WeightedValue>& values, std::uint64_t count, double probability) {
+    if (count == 0 || values.empty()) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    if (count == 1) {
+        return weighted_order_stat(values, 0);
+    }
+    const double h = static_cast<double>(count - 1) * probability;
+    const std::uint64_t lower_rank = static_cast<std::uint64_t>(std::floor(h));
+    const std::uint64_t upper_rank = static_cast<std::uint64_t>(std::ceil(h));
+    const double lower = weighted_order_stat(values, lower_rank);
+    const double upper = weighted_order_stat(values, upper_rank);
+    return lower + (h - static_cast<double>(lower_rank)) * (upper - lower);
+}
+
+double histogram_mad(const std::array<std::uint64_t, kCn0QuarterBuckets>& histogram, double median) {
+    const std::uint64_t count = histogram_count(histogram);
+    if (count == 0 || !std::isfinite(median)) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    std::vector<WeightedValue> deviations;
+    deviations.reserve(kCn0QuarterBuckets);
+    for (int bucket = 0; bucket < kCn0QuarterBuckets; ++bucket) {
+        const std::uint64_t bucket_count = histogram[static_cast<std::size_t>(bucket)];
+        if (bucket_count == 0) {
+            continue;
+        }
+        deviations.push_back(
+            {std::fabs(static_cast<double>(bucket) * kQuarterDbHz - median), bucket_count});
+    }
+    std::sort(deviations.begin(), deviations.end(), [](const WeightedValue& left, const WeightedValue& right) {
+        return left.value < right.value;
+    });
+    return weighted_quantile(deviations, count, 0.5);
+}
+
+void histogram_mean_stddev(const std::array<std::uint64_t, kCn0QuarterBuckets>& histogram, double* mean,
+                           double* stddev) {
+    const std::uint64_t count = histogram_count(histogram);
+    if (mean == nullptr || stddev == nullptr || count == 0) {
+        return;
+    }
+    double sum = 0.0;
+    double sum_square = 0.0;
+    for (int bucket = 0; bucket < kCn0QuarterBuckets; ++bucket) {
+        const double value = static_cast<double>(bucket) * kQuarterDbHz;
+        const double weight = static_cast<double>(histogram[static_cast<std::size_t>(bucket)]);
+        sum += value * weight;
+        sum_square += value * value * weight;
+    }
+    *mean = sum / static_cast<double>(count);
+    const double variance = std::max(0.0, sum_square / static_cast<double>(count) - (*mean) * (*mean));
+    *stddev = std::sqrt(variance);
+}
+
+std::uint64_t previous_key(int satellite_number, SignalId signal_id) {
+    return (static_cast<std::uint64_t>(static_cast<std::uint32_t>(satellite_number)) << 32U) |
+           static_cast<std::uint32_t>(signal_id);
+}
+
+double sim_time_difference_sec(const SimTime& current, const SimTime& previous) {
+    const double week_seconds =
+        static_cast<double>(current.gps_week - previous.gps_week) * 604800.0;
+    const double tow_seconds = static_cast<double>(current.tow_ns - previous.tow_ns) / 1000000000.0;
+    return week_seconds + tow_seconds;
+}
+
+bool temporal_ar1(const TemporalMoments& moments, std::uint64_t minimum_pairs, double* ar1,
+                  Cn0Ar1Status* status) {
+    if (ar1 == nullptr || status == nullptr) {
+        return false;
+    }
+    if (moments.count < minimum_pairs || moments.count < 2) {
+        *status = Cn0Ar1Status::kInsufficientSupport;
+        *ar1 = std::numeric_limits<double>::quiet_NaN();
+        return true;
+    }
+    const double n = static_cast<double>(moments.count);
+    const double sum_x = static_cast<double>(moments.sum_x);
+    const double sum_y = static_cast<double>(moments.sum_y);
+    const double numerator = n * static_cast<double>(moments.sum_xy) - sum_x * sum_y;
+    const double variance_x = n * static_cast<double>(moments.sum_x2) - sum_x * sum_x;
+    const double variance_y = n * static_cast<double>(moments.sum_y2) - sum_y * sum_y;
+    if (variance_x <= 0.0 || variance_y <= 0.0) {
+        *status = Cn0Ar1Status::kZeroVariance;
+        *ar1 = std::numeric_limits<double>::quiet_NaN();
+        return true;
+    }
+    *status = Cn0Ar1Status::kAvailable;
+    *ar1 = numerator / std::sqrt(variance_x * variance_y);
+    return true;
+}
+
+void write_optional(std::ostream& output, bool available, double value) {
+    if (available && std::isfinite(value)) {
+        output << value;
+    }
+}
+
+} // namespace
+
+struct Cn0StatisticsAccumulator::Impl {
+    explicit Impl(const Cn0AggregationConfig& input_config) : config(input_config) {
+        config_valid = validate_config(config, &bin_count, &config_error);
+        std::size_t signal_count = 0;
+        const SignalDefinition* definitions = signal_definitions(&signal_count);
+        signals.reserve(signal_count);
+        for (std::size_t index = 0; index < signal_count; ++index) {
+            signals.push_back(definitions + index);
+        }
+        if (config_valid) {
+            cells.resize(signals.size() * static_cast<std::size_t>(bin_count));
+        }
+    }
+
+    Cn0AggregationConfig config{};
+    Cn0AggregationSummary summary{};
+    bool config_valid{};
+    std::string config_error;
+    int bin_count{};
+    std::vector<const SignalDefinition*> signals;
+    std::vector<BinCell> cells;
+    bool source_active{};
+    double source_interval_sec{std::numeric_limits<double>::quiet_NaN()};
+    std::unordered_map<std::uint64_t, PreviousSample> previous;
+};
+
+Cn0StatisticsAccumulator::Cn0StatisticsAccumulator(const Cn0AggregationConfig& config) : impl_(new Impl(config)) {}
+
+Cn0StatisticsAccumulator::~Cn0StatisticsAccumulator() {
+    delete impl_;
+}
+
+bool Cn0StatisticsAccumulator::valid(std::string* error_message) const {
+    if (impl_ == nullptr || !impl_->config_valid) {
+        set_error(error_message, impl_ != nullptr ? impl_->config_error : "CN0 accumulator is not initialized");
+        return false;
+    }
+    return true;
+}
+
+bool Cn0StatisticsAccumulator::begin_source(double observation_interval_sec, std::string* error_message) {
+    if (!valid(error_message)) {
+        return false;
+    }
+    impl_->previous.clear();
+    impl_->source_active = true;
+    impl_->source_interval_sec =
+        std::isfinite(observation_interval_sec) && observation_interval_sec > 0.0
+            ? observation_interval_sec
+            : std::numeric_limits<double>::quiet_NaN();
+    ++impl_->summary.sources;
+    return true;
+}
+
+bool Cn0StatisticsAccumulator::add_sample(const RinexCn0Sample& sample, std::string* error_message) {
+    if (!valid(error_message)) {
+        return false;
+    }
+    if (!impl_->source_active) {
+        set_error(error_message, "begin_source() must be called before CN0 samples are aggregated");
+        return false;
+    }
+    ++impl_->summary.input_samples;
+    if (sample.validity != Cn0SampleValidity::kValidDbHz) {
+        ++impl_->summary.rejected_validity;
+        return true;
+    }
+    if (!std::isfinite(sample.cn0_dbhz) || !std::isfinite(sample.elevation_rad)) {
+        ++impl_->summary.rejected_nonfinite;
+        return true;
+    }
+
+    int cn0_quarters = 0;
+    if (!cn0_to_quarters(sample.cn0_dbhz, &cn0_quarters)) {
+        ++impl_->summary.rejected_cn0_grid;
+        return true;
+    }
+    const double elevation_deg = sample.elevation_rad * 180.0 / 3.14159265358979323846;
+    const int bin_index = elevation_bin_index(impl_->config, impl_->bin_count, elevation_deg);
+    if (bin_index < 0) {
+        ++impl_->summary.rejected_elevation_range;
+        return true;
+    }
+    const int signal_index = find_signal_index(impl_->signals, sample.signal_id);
+    if (signal_index < 0) {
+        set_error(error_message, "CN0 sample uses a signal that is absent from the central signal-definition table");
+        return false;
+    }
+
+    BinCell& cell = impl_->cells[static_cast<std::size_t>(signal_index * impl_->bin_count + bin_index)];
+    ++cell.cn0_hist[static_cast<std::size_t>(cn0_quarters)];
+    ++impl_->summary.accepted_samples;
+
+    const std::uint64_t key = previous_key(sample.satellite_number, sample.signal_id);
+    const auto previous_it = impl_->previous.find(key);
+    if (previous_it != impl_->previous.end()) {
+        const PreviousSample& previous = previous_it->second;
+        if (!std::isfinite(impl_->source_interval_sec)) {
+            ++impl_->summary.temporal_rejected_no_interval;
+        } else {
+            const double gap_sec = sim_time_difference_sec(sample.time, previous.time);
+            if (std::fabs(gap_sec - impl_->source_interval_sec) > impl_->config.temporal_gap_tolerance_sec) {
+                ++impl_->summary.temporal_rejected_gap;
+            } else if (previous.elevation_bin != bin_index) {
+                ++impl_->summary.temporal_rejected_bin_change;
+            } else {
+                const int delta_quarters = std::abs(cn0_quarters - previous.cn0_quarters);
+                ++cell.delta_hist[static_cast<std::size_t>(delta_quarters)];
+                ++cell.temporal.count;
+                cell.temporal.sum_x += static_cast<std::uint64_t>(previous.cn0_quarters);
+                cell.temporal.sum_y += static_cast<std::uint64_t>(cn0_quarters);
+                cell.temporal.sum_x2 += static_cast<std::uint64_t>(previous.cn0_quarters * previous.cn0_quarters);
+                cell.temporal.sum_y2 += static_cast<std::uint64_t>(cn0_quarters * cn0_quarters);
+                cell.temporal.sum_xy += static_cast<std::uint64_t>(previous.cn0_quarters * cn0_quarters);
+                ++impl_->summary.temporal_pairs;
+            }
+        }
+    }
+    impl_->previous[key] = {sample.time, bin_index, cn0_quarters};
+    return true;
+}
+
+void Cn0StatisticsAccumulator::end_source() {
+    if (impl_ == nullptr) {
+        return;
+    }
+    impl_->previous.clear();
+    impl_->source_active = false;
+    impl_->source_interval_sec = std::numeric_limits<double>::quiet_NaN();
+}
+
+const Cn0AggregationConfig& Cn0StatisticsAccumulator::config() const {
+    return impl_->config;
+}
+
+const Cn0AggregationSummary& Cn0StatisticsAccumulator::summary() const {
+    return impl_->summary;
+}
+
+std::vector<Cn0BinStatistics> Cn0StatisticsAccumulator::finalize() const {
+    std::vector<Cn0BinStatistics> output;
+    if (impl_ == nullptr || !impl_->config_valid) {
+        return output;
+    }
+    output.reserve(impl_->cells.size());
+    for (std::size_t signal_index = 0; signal_index < impl_->signals.size(); ++signal_index) {
+        const SignalDefinition& signal = *impl_->signals[signal_index];
+        for (int bin_index = 0; bin_index < impl_->bin_count; ++bin_index) {
+            const BinCell& cell =
+                impl_->cells[signal_index * static_cast<std::size_t>(impl_->bin_count) + static_cast<std::size_t>(bin_index)];
+            Cn0BinStatistics statistics{};
+            statistics.constellation = signal.constellation;
+            statistics.signal_id = signal.signal_id;
+            statistics.rinex_signal_code = signal.rinex_signal_code;
+            statistics.elevation_min_deg =
+                impl_->config.elevation_min_deg + static_cast<double>(bin_index) * impl_->config.elevation_bin_width_deg;
+            statistics.elevation_max_deg = statistics.elevation_min_deg + impl_->config.elevation_bin_width_deg;
+            statistics.includes_upper_edge = bin_index == impl_->bin_count - 1;
+            statistics.count = histogram_count(cell.cn0_hist);
+            if (statistics.count == 0) {
+                statistics.status = Cn0BinStatus::kEmpty;
+            } else if (statistics.count < impl_->config.min_samples_per_bin) {
+                statistics.status = Cn0BinStatus::kSparse;
+            } else {
+                statistics.status = Cn0BinStatus::kReady;
+            }
+
+            if (statistics.count > 0) {
+                statistics.p05_dbhz = histogram_quantile(cell.cn0_hist, 0.05);
+                statistics.p10_dbhz = histogram_quantile(cell.cn0_hist, 0.10);
+                statistics.p25_dbhz = histogram_quantile(cell.cn0_hist, 0.25);
+                statistics.p50_dbhz = histogram_quantile(cell.cn0_hist, 0.50);
+                statistics.p75_dbhz = histogram_quantile(cell.cn0_hist, 0.75);
+                statistics.p90_dbhz = histogram_quantile(cell.cn0_hist, 0.90);
+                statistics.p95_dbhz = histogram_quantile(cell.cn0_hist, 0.95);
+                histogram_mean_stddev(cell.cn0_hist, &statistics.mean_dbhz, &statistics.stddev_dbhz);
+                statistics.mad_dbhz = histogram_mad(cell.cn0_hist, statistics.p50_dbhz);
+            } else {
+                const double unavailable = std::numeric_limits<double>::quiet_NaN();
+                statistics.p05_dbhz = unavailable;
+                statistics.p10_dbhz = unavailable;
+                statistics.p25_dbhz = unavailable;
+                statistics.p50_dbhz = unavailable;
+                statistics.p75_dbhz = unavailable;
+                statistics.p90_dbhz = unavailable;
+                statistics.p95_dbhz = unavailable;
+                statistics.mean_dbhz = unavailable;
+                statistics.stddev_dbhz = unavailable;
+                statistics.mad_dbhz = unavailable;
+            }
+
+            statistics.delta_count = histogram_count(cell.delta_hist);
+            if (statistics.delta_count > 0) {
+                statistics.delta_p50_dbhz = histogram_quantile(cell.delta_hist, 0.50);
+                statistics.delta_p90_dbhz = histogram_quantile(cell.delta_hist, 0.90);
+                statistics.delta_p99_dbhz = histogram_quantile(cell.delta_hist, 0.99);
+            } else {
+                const double unavailable = std::numeric_limits<double>::quiet_NaN();
+                statistics.delta_p50_dbhz = unavailable;
+                statistics.delta_p90_dbhz = unavailable;
+                statistics.delta_p99_dbhz = unavailable;
+            }
+            temporal_ar1(cell.temporal, impl_->config.min_temporal_pairs, &statistics.ar1, &statistics.ar1_status);
+            output.push_back(std::move(statistics));
+        }
+    }
+    return output;
+}
+
+std::size_t Cn0StatisticsAccumulator::bounded_histogram_cells() const {
+    if (impl_ == nullptr) {
+        return 0;
+    }
+    return impl_->cells.size() * static_cast<std::size_t>(kCn0QuarterBuckets) * 2U;
+}
+
+const char* cn0_bin_status_name(Cn0BinStatus status) {
+    switch (status) {
+        case Cn0BinStatus::kEmpty:
+            return "EMPTY";
+        case Cn0BinStatus::kSparse:
+            return "SPARSE";
+        case Cn0BinStatus::kReady:
+            return "READY";
+    }
+    return "UNKNOWN";
+}
+
+const char* cn0_ar1_status_name(Cn0Ar1Status status) {
+    switch (status) {
+        case Cn0Ar1Status::kAvailable:
+            return "AVAILABLE";
+        case Cn0Ar1Status::kInsufficientSupport:
+            return "INSUFFICIENT_SUPPORT";
+        case Cn0Ar1Status::kZeroVariance:
+            return "ZERO_VARIANCE";
+    }
+    return "UNKNOWN";
+}
+
+bool write_cn0_model_csv(const std::string& output_path, const Cn0AggregationConfig& config,
+                         const Cn0AggregationSummary& summary, const std::vector<Cn0BinStatistics>& bins,
+                         std::string* error_message) {
+    std::ofstream output(output_path, std::ios::binary);
+    if (!output) {
+        set_error(error_message, "cannot open CN0 model CSV for writing: " + output_path);
+        return false;
+    }
+    output.imbue(std::locale::classic());
+    output << std::fixed << std::setprecision(6);
+    output << "schema_version,constellation,signal,elevation_min_deg,elevation_max_deg,upper_edge_inclusive,status,count,"
+              "p05_dbhz,p10_dbhz,p25_dbhz,p50_dbhz,p75_dbhz,p90_dbhz,p95_dbhz,mean_dbhz,stddev_dbhz,mad_dbhz,"
+              "delta_count,delta_p50_dbhz,delta_p90_dbhz,delta_p99_dbhz,ar1_status,ar1\n";
+    for (const Cn0BinStatistics& bin : bins) {
+        output << "gnss-cn0-model-v1," << constellation_name(bin.constellation) << ',' << bin.rinex_signal_code << ','
+               << bin.elevation_min_deg << ',' << bin.elevation_max_deg << ',' << (bin.includes_upper_edge ? 1 : 0)
+               << ',' << cn0_bin_status_name(bin.status) << ',' << bin.count << ',';
+        const bool has_samples = bin.count > 0;
+        write_optional(output, has_samples, bin.p05_dbhz);
+        output << ',';
+        write_optional(output, has_samples, bin.p10_dbhz);
+        output << ',';
+        write_optional(output, has_samples, bin.p25_dbhz);
+        output << ',';
+        write_optional(output, has_samples, bin.p50_dbhz);
+        output << ',';
+        write_optional(output, has_samples, bin.p75_dbhz);
+        output << ',';
+        write_optional(output, has_samples, bin.p90_dbhz);
+        output << ',';
+        write_optional(output, has_samples, bin.p95_dbhz);
+        output << ',';
+        write_optional(output, has_samples, bin.mean_dbhz);
+        output << ',';
+        write_optional(output, has_samples, bin.stddev_dbhz);
+        output << ',';
+        write_optional(output, has_samples, bin.mad_dbhz);
+        output << ',' << bin.delta_count << ',';
+        const bool has_delta = bin.delta_count > 0;
+        write_optional(output, has_delta, bin.delta_p50_dbhz);
+        output << ',';
+        write_optional(output, has_delta, bin.delta_p90_dbhz);
+        output << ',';
+        write_optional(output, has_delta, bin.delta_p99_dbhz);
+        output << ',' << cn0_ar1_status_name(bin.ar1_status) << ',';
+        write_optional(output, bin.ar1_status == Cn0Ar1Status::kAvailable, bin.ar1);
+        output << '\n';
+    }
+    if (!output) {
+        set_error(error_message, "failed while writing CN0 model CSV: " + output_path);
+        return false;
+    }
+    (void)config;
+    (void)summary;
+    return true;
+}
+
+} // namespace gnss_sim::cn0_builder

--- a/tools/build_cn0_model/cn0_statistics.h
+++ b/tools/build_cn0_model/cn0_statistics.h
@@ -1,0 +1,107 @@
+#ifndef GNSS_SIM_TOOLS_BUILD_CN0_MODEL_CN0_STATISTICS_H_
+#define GNSS_SIM_TOOLS_BUILD_CN0_MODEL_CN0_STATISTICS_H_
+
+#include "tools/build_cn0_model/rinex_obs_stream.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace gnss_sim::cn0_builder {
+
+struct Cn0AggregationConfig {
+    double elevation_min_deg{0.0};
+    double elevation_max_deg{90.0};
+    double elevation_bin_width_deg{5.0};
+    std::uint64_t min_samples_per_bin{20};
+    std::uint64_t min_temporal_pairs{20};
+    double temporal_gap_tolerance_sec{0.005};
+};
+
+enum class Cn0BinStatus {
+    kEmpty,
+    kSparse,
+    kReady,
+};
+
+enum class Cn0Ar1Status {
+    kAvailable,
+    kInsufficientSupport,
+    kZeroVariance,
+};
+
+struct Cn0BinStatistics {
+    GnssConstellation constellation{GnssConstellation::kGps};
+    SignalId signal_id{SignalId::kGpsL1Ca};
+    std::string rinex_signal_code;
+    double elevation_min_deg{};
+    double elevation_max_deg{};
+    bool includes_upper_edge{};
+    Cn0BinStatus status{Cn0BinStatus::kEmpty};
+    std::uint64_t count{};
+    double p05_dbhz{};
+    double p10_dbhz{};
+    double p25_dbhz{};
+    double p50_dbhz{};
+    double p75_dbhz{};
+    double p90_dbhz{};
+    double p95_dbhz{};
+    double mean_dbhz{};
+    double stddev_dbhz{};
+    double mad_dbhz{};
+    std::uint64_t delta_count{};
+    double delta_p50_dbhz{};
+    double delta_p90_dbhz{};
+    double delta_p99_dbhz{};
+    Cn0Ar1Status ar1_status{Cn0Ar1Status::kInsufficientSupport};
+    double ar1{};
+};
+
+struct Cn0AggregationSummary {
+    std::uint64_t input_samples{};
+    std::uint64_t accepted_samples{};
+    std::uint64_t rejected_validity{};
+    std::uint64_t rejected_nonfinite{};
+    std::uint64_t rejected_cn0_grid{};
+    std::uint64_t rejected_elevation_range{};
+    std::uint64_t temporal_pairs{};
+    std::uint64_t temporal_rejected_no_interval{};
+    std::uint64_t temporal_rejected_gap{};
+    std::uint64_t temporal_rejected_bin_change{};
+    std::uint64_t sources{};
+};
+
+class Cn0StatisticsAccumulator {
+  public:
+    explicit Cn0StatisticsAccumulator(const Cn0AggregationConfig& config);
+    ~Cn0StatisticsAccumulator();
+
+    Cn0StatisticsAccumulator(const Cn0StatisticsAccumulator&) = delete;
+    Cn0StatisticsAccumulator& operator=(const Cn0StatisticsAccumulator&) = delete;
+
+    bool valid(std::string* error_message) const;
+    bool begin_source(double observation_interval_sec, std::string* error_message);
+    bool add_sample(const RinexCn0Sample& sample, std::string* error_message);
+    void end_source();
+
+    const Cn0AggregationConfig& config() const;
+    const Cn0AggregationSummary& summary() const;
+    std::vector<Cn0BinStatistics> finalize() const;
+    std::size_t bounded_histogram_cells() const;
+
+  private:
+    struct Impl;
+    Impl* impl_;
+};
+
+const char* cn0_bin_status_name(Cn0BinStatus status);
+const char* cn0_ar1_status_name(Cn0Ar1Status status);
+
+bool write_cn0_model_csv(const std::string& output_path, const Cn0AggregationConfig& config,
+                         const Cn0AggregationSummary& summary, const std::vector<Cn0BinStatistics>& bins,
+                         std::string* error_message);
+
+} // namespace gnss_sim::cn0_builder
+
+#endif // GNSS_SIM_TOOLS_BUILD_CN0_MODEL_CN0_STATISTICS_H_

--- a/tools/build_cn0_model/main.cpp
+++ b/tools/build_cn0_model/main.cpp
@@ -1,116 +1,112 @@
-#include "tools/build_cn0_model/rinex_obs_stream.h"
+#include "tools/build_cn0_model/cn0_builder.h"
 
-#include <cmath>
-#include <fstream>
-#include <iomanip>
+#include <cerrno>
+#include <cstdlib>
 #include <iostream>
+#include <limits>
 #include <string>
+#include <vector>
 
 namespace {
 
-std::string csv_escape(const std::string& value) {
-    if (value.find_first_of(",\"\r\n") == std::string::npos) {
-        return value;
+bool parse_double(const char* text, double* value) {
+    if (text == nullptr || value == nullptr) {
+        return false;
     }
-    std::string result = "\"";
-    for (const char character : value) {
-        if (character == '\"') {
-            result += "\"\"";
-        } else {
-            result += character;
-        }
+    errno = 0;
+    char* end = nullptr;
+    const double parsed = std::strtod(text, &end);
+    if (errno != 0 || end == text || *end != '\0') {
+        return false;
     }
-    result += '\"';
-    return result;
+    *value = parsed;
+    return true;
+}
+
+bool parse_u64(const char* text, std::uint64_t* value) {
+    if (text == nullptr || value == nullptr || text[0] == '-') {
+        return false;
+    }
+    errno = 0;
+    char* end = nullptr;
+    const unsigned long long parsed = std::strtoull(text, &end, 10);
+    if (errno != 0 || end == text || *end != '\0') {
+        return false;
+    }
+    *value = static_cast<std::uint64_t>(parsed);
+    return true;
 }
 
 void usage(const char* program) {
-    std::cerr << "Usage: " << program << " --obs <rinex.obs> --nav <rinex.nav> --output <samples.csv>\n";
+    std::cerr << "Usage: " << program
+              << " --source <rinex.obs> <rinex.nav> [--source <rinex.obs> <rinex.nav> ...]"
+                 " --output <cn0_model.csv> --metadata <cn0_model.meta.json>"
+                 " [--bin-width-deg <deg>] [--min-bin-count <n>] [--min-temporal-pairs <n>]\n";
 }
 
 } // namespace
 
 int main(int argc, char** argv) {
-    std::string observation_path;
-    std::string navigation_path;
+    std::vector<gnss_sim::cn0_builder::Cn0InputSource> sources;
+    gnss_sim::cn0_builder::Cn0AggregationConfig config{};
     std::string output_path;
+    std::string metadata_path;
+
     for (int index = 1; index < argc; ++index) {
         const std::string argument = argv[index];
-        if ((argument == "--obs" || argument == "--nav" || argument == "--output") && index + 1 < argc) {
-            const std::string value = argv[++index];
-            if (argument == "--obs") {
-                observation_path = value;
-            } else if (argument == "--nav") {
-                navigation_path = value;
-            } else {
-                output_path = value;
+        if (argument == "--source" && index + 2 < argc) {
+            sources.push_back({argv[index + 1], argv[index + 2]});
+            index += 2;
+        } else if (argument == "--output" && index + 1 < argc) {
+            output_path = argv[++index];
+        } else if (argument == "--metadata" && index + 1 < argc) {
+            metadata_path = argv[++index];
+        } else if (argument == "--bin-width-deg" && index + 1 < argc) {
+            if (!parse_double(argv[++index], &config.elevation_bin_width_deg)) {
+                std::cerr << "Invalid --bin-width-deg value\n";
+                return 2;
+            }
+        } else if (argument == "--min-bin-count" && index + 1 < argc) {
+            if (!parse_u64(argv[++index], &config.min_samples_per_bin)) {
+                std::cerr << "Invalid --min-bin-count value\n";
+                return 2;
+            }
+        } else if (argument == "--min-temporal-pairs" && index + 1 < argc) {
+            if (!parse_u64(argv[++index], &config.min_temporal_pairs)) {
+                std::cerr << "Invalid --min-temporal-pairs value\n";
+                return 2;
             }
         } else {
             usage(argv[0]);
             return 2;
         }
     }
-    if (observation_path.empty() || navigation_path.empty() || output_path.empty()) {
+
+    if (sources.empty() || output_path.empty() || metadata_path.empty()) {
         usage(argv[0]);
         return 2;
     }
 
-    std::ofstream output(output_path);
-    if (!output) {
-        std::cerr << "Cannot open output CSV: " << output_path << '\n';
-        return 1;
-    }
-    output << "gps_week,sow_sec,station,constellation,prn,signal,signal_strength,cn0_dbhz,azimuth_rad,"
-              "elevation_rad,validity,signal_strength_unit_status\n";
-    output << std::setprecision(15);
-
-    gnss_sim::cn0_builder::RinexObsProvenance provenance{};
-    gnss_sim::cn0_builder::RinexObsStreamSummary summary{};
+    gnss_sim::cn0_builder::Cn0BuildResult result{};
     std::string error;
-    const bool ok = gnss_sim::cn0_builder::stream_rinex_cn0_samples(
-        observation_path, navigation_path,
-        [&](const gnss_sim::cn0_builder::RinexCn0Sample& sample) {
-            output << sample.time.gps_week << ',' << static_cast<double>(sample.time.tow_ns) / 1000000000.0 << ','
-                   << csv_escape(provenance.station_name) << ','
-                   << gnss_sim::cn0_builder::constellation_name(sample.constellation) << ',' << sample.prn << ','
-                   << sample.rinex_signal_code << ',' << sample.signal_strength_value << ',';
-            if (std::isfinite(sample.cn0_dbhz)) {
-                output << sample.cn0_dbhz;
-            }
-            output << ',';
-            if (std::isfinite(sample.azimuth_rad)) {
-                output << sample.azimuth_rad;
-            }
-            output << ',';
-            if (std::isfinite(sample.elevation_rad)) {
-                output << sample.elevation_rad;
-            }
-            output << ',' << gnss_sim::cn0_builder::cn0_sample_validity_name(sample.validity) << ','
-                   << gnss_sim::cn0_builder::signal_strength_unit_status_name(provenance.signal_strength_unit_status)
-                   << '\n';
-            return static_cast<bool>(output);
-        },
-        &provenance, &summary, &error);
-
-    if (!ok) {
-        std::cerr << "CN0 extraction failed: " << error << '\n';
+    if (!gnss_sim::cn0_builder::build_cn0_model(sources, config, &result, &error)) {
+        std::cerr << "CN0 model build failed: " << error << '\n';
         return 1;
     }
-    output.close();
-    if (!output) {
-        std::cerr << "Failed while writing output CSV: " << output_path << '\n';
+    if (!gnss_sim::cn0_builder::write_cn0_model_csv(output_path, config, result.aggregation_summary, result.bins,
+                                                     &error)) {
+        std::cerr << "CN0 model write failed: " << error << '\n';
+        return 1;
+    }
+    if (!gnss_sim::cn0_builder::write_cn0_metadata_json(metadata_path, config, result, &error)) {
+        std::cerr << "CN0 metadata write failed: " << error << '\n';
         return 1;
     }
 
-    std::cerr << "RINEX " << provenance.rinex_version << ", station=" << provenance.station_name
-              << ", signal-strength-unit="
-              << gnss_sim::cn0_builder::signal_strength_unit_status_name(provenance.signal_strength_unit_status)
-              << ", epochs=" << summary.epochs << ", records=" << summary.observation_records
-              << ", samples=" << summary.emitted_samples << ", valid_dbhz=" << summary.valid_dbhz_samples
-              << ", missing_s=" << summary.missing_signal_strength
-              << ", unsupported=" << summary.unsupported_signal_observables << '\n';
-    for (const std::string& observable : summary.unsupported_observables) {
-        std::cerr << "Unsupported S observable: " << observable << '\n';
-    }
+    std::cerr << "CN0 model built: sources=" << result.aggregation_summary.sources
+              << ", input_samples=" << result.aggregation_summary.input_samples
+              << ", accepted_samples=" << result.aggregation_summary.accepted_samples
+              << ", temporal_pairs=" << result.aggregation_summary.temporal_pairs << ", bins=" << result.bins.size()
+              << '\n';
     return 0;
 }

--- a/tools/build_cn0_model/main.cpp
+++ b/tools/build_cn0_model/main.cpp
@@ -94,7 +94,7 @@ int main(int argc, char** argv) {
         return 1;
     }
     if (!gnss_sim::cn0_builder::write_cn0_model_csv(output_path, config, result.aggregation_summary, result.bins,
-                                                     &error)) {
+                                                    &error)) {
         std::cerr << "CN0 model write failed: " << error << '\n';
         return 1;
     }


### PR DESCRIPTION
Closes #38

## Scope
- consume the validated streaming samples from #37 without reparsing RINEX;
- aggregate constellation/signal/elevation-bin statistics with fixed-size 0.25 dB-Hz histograms;
- emit explicit EMPTY/SPARSE/READY bins with R7 quantiles, population standard deviation and MAD;
- compute absolute consecutive Delta-CN0 and optional lag-1 correlation only across valid same-source/satellite/signal/bin samples at the declared RINEX INTERVAL;
- suppress Delta-CN0 percentile output when temporal-pair support is below the configured minimum;
- produce versioned deterministic `cn0_model.csv` plus provenance metadata JSON;
- support repeatable `--source OBS NAV` inputs in the offline `build-cn0-model` CLI;
- keep memory bounded by signal × elevation-bin aggregation state rather than OBS duration.

## Reproducibility
- model rows use stable central signal-definition order and ascending elevation bins;
- locale-independent fixed numeric formatting;
- metadata contains no wall-clock build timestamp or absolute paths;
- source identity uses basename + byte size + streaming FNV-1a64;
- normal CI uses compact checked-in fixtures; real WHU/IGS observations remain offline calibration inputs.

## Implementation Notes
The accumulator stores two fixed 256-entry histograms per signal/elevation bin: one for the RTKLIB 0.25 dB-Hz CN0 grid and one for absolute Delta-CN0. The only temporal state is the latest accepted sample per satellite/signal key and it is cleared at every source boundary. Quantiles use R type-7 interpolation, standard deviation is population (`ddof=0`), MAD is the median absolute deviation from P50, and AR(1) is emitted only with sufficient pairs and non-zero lagged variance.

## Validation
Final head `2c6952607af0b7e45c1d4a88967492003f8bc0a0`:
- clang-format: PASS
- Ubuntu/GCC build + tests: PASS
- Windows/MSVC build + tests: PASS
- golden R7 quantile/mean/stddev/MAD tests: PASS
- deterministic elevation-edge behavior and EMPTY/SPARSE/READY handling: PASS
- invalid/non-finite/off-grid sample rejection: PASS
- temporal gap/bin/source isolation and insufficient-support handling: PASS
- bounded histogram memory regression: PASS
- fixed-source model + metadata byte reproducibility: PASS