### PR TITLE
Require real RINEX NAV for long-duration validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,14 @@ jobs:
             exit 1
           fi
 
+  tooling-self-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Extended validation harness self-test
+        run: python3 tools/extended_validation/run_extended.py --self-test
+
   build-test:
     strategy:
       fail-fast: false

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -87,13 +87,62 @@ jobs:
       - name: Harness self-test
         run: python3 tools/extended_validation/run_extended.py --self-test
 
-      - name: Run ${{ matrix.case }}
+      - name: Download pinned real RINEX NAV
+        if: matrix.case == 'ks_8h' || matrix.case == 'rea_8h' || matrix.case == 'ttff_8h' || matrix.case == 'stress_50hz_1h'
+        shell: bash
         run: |
-          python3 tools/extended_validation/run_extended.py \
-            --simulator build/gnss-data-simulator \
-            --repo-root . \
-            --case "${{ matrix.case }}" \
+          set -euo pipefail
+          mkdir -p .cache/igs
+
+          compressed=".cache/igs/BRD400DLR_S_20250030000_01D_MN.rnx.gz"
+          nav=".cache/igs/BRD400DLR_S_20250030000_01D_MN.rnx"
+          expected_compressed="fb84d4046b06e905e8e4ec0efb82f0e9ad044bc44d664cc0209cb9b4c92b9512"
+          expected_uncompressed="b11c638eea42978b8bd6aa8b65a5099fe6556dfe527bc037ed481d2b239afc42"
+          sources=(
+            "ftp://igs.gnsswhu.cn/pub/gps/data/daily/2025/brdc/BRD400DLR_S_20250030000_01D_MN.rnx.gz"
+            "http://igs.gnsswhu.cn/pub/gps/data/daily/2025/brdc/BRD400DLR_S_20250030000_01D_MN.rnx.gz"
+          )
+
+          downloaded=0
+          for url in "${sources[@]}"; do
+            echo "Downloading real RINEX NAV from ${url}"
+            rm -f "$compressed" "$nav"
+            if curl --fail --location --retry 3 --retry-delay 2 --connect-timeout 20 --max-time 300 \
+              "$url" --output "$compressed"; then
+              compressed_sha="$(sha256sum "$compressed" | awk '{print $1}')"
+              if [[ "$compressed_sha" != "$expected_compressed" ]]; then
+                echo "Compressed SHA256 mismatch from ${url}: ${compressed_sha}" >&2
+                continue
+              fi
+              gzip -dc "$compressed" > "$nav"
+              uncompressed_sha="$(sha256sum "$nav" | awk '{print $1}')"
+              if [[ "$uncompressed_sha" != "$expected_uncompressed" ]]; then
+                echo "Uncompressed SHA256 mismatch from ${url}: ${uncompressed_sha}" >&2
+                continue
+              fi
+              downloaded=1
+              break
+            fi
+          done
+
+          if [[ "$downloaded" -ne 1 ]]; then
+            echo "Unable to obtain the pinned real WHU RINEX NAV with the expected hashes." >&2
+            exit 1
+          fi
+
+      - name: Run ${{ matrix.case }}
+        shell: bash
+        run: |
+          args=(
+            --simulator build/gnss-data-simulator
+            --repo-root .
+            --case "${{ matrix.case }}"
             --output-dir "extended-results/${{ matrix.case }}"
+          )
+          if [[ -f ".cache/igs/BRD400DLR_S_20250030000_01D_MN.rnx" ]]; then
+            args+=(--real-nav ".cache/igs/BRD400DLR_S_20250030000_01D_MN.rnx")
+          fi
+          python3 tools/extended_validation/run_extended.py "${args[@]}"
 
       - name: Publish step summary
         if: always()

--- a/docs/ENGINEERING_RULES.md
+++ b/docs/ENGINEERING_RULES.md
@@ -14,6 +14,9 @@ This document defines the required repository layout, source-file naming, C/C++ 
 - JSON configuration parsing uses the pinned cJSON dependency through `sim_config`; cJSON types must not leak outside that module boundary.
 - Project code must compile cleanly on both Windows and Linux. Platform-specific code must be isolated behind a narrow adapter and must not leak into the GNSS physics/model layers.
 - Production code must not require a network connection at runtime. Downloading IGS data is a separate tooling concern.
+- Broadcast navigation truth must originate from actual RINEX NAV data. Production code, tests, fixtures, CI helpers, and validation tools must not manufacture ephemeris by changing Toe/Toc, orbit, clock, health, TGD/BGD/ISC, or related navigation fields from another record.
+- If a required simulation or validation interval is not covered by the available RINEX NAV input, obtain a real file with sufficient coverage from WHU/IGS or another documented authoritative GNSS data center. Missing coverage must never be filled with synthetic ephemeris.
+- Downloading, decompressing, copying, concatenating, filtering, or time-windowing real RINEX NAV records is allowed only when the retained navigation values are preserved unchanged and source provenance is recorded.
 
 ## 2. Frozen repository layout
 
@@ -224,7 +227,7 @@ Do not use generic names such as `time`, `range`, `speed`, or `freq` in physics 
 ### 4.6 Error handling
 
 - Invalid configuration: fail before simulation starts with a clear message.
-- Missing required RINEX coverage: fail before simulation starts.
+- Missing required RINEX coverage: fail before simulation starts. Tooling/validation may first obtain a real RINEX NAV file from an authoritative source, but must not synthesize missing navigation coverage.
 - Internal impossible state or violated invariant: fail loudly; do not silently continue and emit plausible-looking data.
 - Expected receiver state such as `INSUFFICIENT_OBS/NONE` is simulation output, not an application error.
 - Output-write failure is fatal for the run.
@@ -329,7 +332,8 @@ It is intended for:
 - deterministic rerun checks;
 - long-duration streaming/memory tests;
 - default 8-hour run;
-- selected 50 Hz runs.
+- selected 50 Hz runs;
+- downloading a pinned real RINEX NAV from an authoritative GNSS data center when the committed fixtures do not cover the requested long-duration interval, with hash verification before use.
 
 Do not make ordinary documentation-only changes consume an 8-hour simulation test.
 
@@ -408,9 +412,11 @@ Normal CI uses short fixtures/durations. Long-duration versions of these tests b
 - Keep only minimal necessary test data in Git.
 - Do not commit multi-GB IGS archives.
 - Every fixture should document its origin and any transformation applied.
-- Prefer synthetic minimal RINEX fixtures for parser boundary tests if they faithfully exercise the target format.
-- Real IGS snippets may be used when needed for reference/compatibility testing and redistribution is appropriate.
-- CI tests must not download test data from the internet during the test itself.
+- Navigation fixtures must come from real RINEX NAV sources. A test or fixture generator must not create new ephemeris by changing Toe/Toc, orbit, clock, health, TGD/BGD/ISC, or other navigation fields.
+- It is acceptable to extract an unchanged subset of real RINEX NAV records for small deterministic tests; retained navigation values must remain field-for-field equivalent to the source.
+- If a long-duration test needs more coverage than committed fixtures provide, download the corresponding real RINEX NAV from WHU/IGS or another documented authoritative source and verify the pinned source hash before use.
+- Synthetic fixtures may still be used for non-navigation parser/error-boundary inputs only when they contain no fabricated ephemeris/navigation truth.
+- Normal PR CI tests must not download test data from the internet during the test itself. Extended validation may perform an explicit pre-validation download of pinned real RINEX data and must fail if download or hash verification fails.
 
 ## 10. Pull request and commit rules
 
@@ -443,6 +449,7 @@ Before merge, verify:
 - units are explicit;
 - no full-run unbounded memory accumulation was introduced;
 - output writers only serialize;
+- no code/test/CI path fabricates or rewrites navigation truth; retained ephemeris records are traceable to real RINEX NAV sources;
 - tests cover the new behavior;
 - Windows and Linux builds remain green;
 - long tests have not leaked into normal PR CI.

--- a/docs/EXTENDED_VALIDATION.md
+++ b/docs/EXTENDED_VALIDATION.md
@@ -1,19 +1,64 @@
 # V1 Extended Validation
 
-Issue #41 owns long-duration and resource validation. Normal pull-request CI remains the short deterministic suite from #40; expensive runs live in `.github/workflows/extended.yml` and use the single harness `tools/extended_validation/run_extended.py`.
+Issue #41 owns long-duration and resource validation. Issue #58 freezes navigation provenance for those tests: extended validation must use real RINEX NAV records and must never manufacture ephemeris. Normal pull-request CI remains the short deterministic suite from #40; expensive runs live in `.github/workflows/extended.yml` and use `tools/extended_validation/run_extended.py`.
 
 ## Cases
 
-| Case | Scenario | Duration / rate | Purpose |
-| --- | --- | --- | --- |
-| `ks_8h` | KS | 8 h @ 10 Hz | Default V1 long static run and exact epoch/message counts. |
-| `rea_8h` | REA | 8 h @ 10 Hz | Long repeated signal-off/reacquisition transitions. |
-| `ttff_8h` | TTFF HOT | 8 h @ 10 Hz | Long repeated power cycling and restart transitions. |
-| `stress_50hz_1h` | KS | 1 h @ 50 Hz | Sustained high-rate streaming/resource stress with continuous deterministic GPS NAV. |
-| `determinism_50hz_10m` | KS | 10 min @ 50 Hz, repeated twice | Streamed SHA256 equality for receiver log and all required truth/manifest outputs using the compact real RINEX 4 fixture. |
-| `memory_trend_50hz` | KS | 60 s vs 15 min @ 50 Hz | Detect observation/solution history that grows with run duration using the compact real RINEX 4 fixture. |
+| Case | Scenario | Duration / rate | NAV input | Purpose |
+| --- | --- | --- | --- | --- |
+| `ks_8h` | KS | 8 h @ 10 Hz | Real full-day WHU `BRD400DLR` | Default V1 long static run and exact epoch/message counts. |
+| `rea_8h` | REA | 8 h @ 10 Hz | Real full-day WHU `BRD400DLR` | Long repeated signal-off/reacquisition transitions. |
+| `ttff_8h` | TTFF HOT | 8 h @ 10 Hz | Real full-day WHU `BRD400DLR` | Long repeated power cycling and restart transitions. |
+| `stress_50hz_1h` | KS | 1 h @ 50 Hz | Real full-day WHU `BRD400DLR` | Sustained high-rate streaming/resource stress across real broadcast navigation. |
+| `determinism_50hz_10m` | KS | 10 min @ 50 Hz, repeated twice | Committed real WHU RINEX 4 subset | Streamed SHA256 equality for receiver log and truth/manifest outputs. |
+| `memory_trend_50hz` | KS | 60 s vs 15 min @ 50 Hz | Committed real WHU RINEX 4 subset | Detect observation/solution history that grows with run duration. |
 
 Manual dispatch can select one case or `all`. The scheduled run intentionally selects `ks_8h` plus `memory_trend_50hz`; the other expensive cases remain independently dispatchable so a weekly schedule does not consume unnecessary CI minutes.
+
+## Frozen NAV provenance rule
+
+Broadcast ephemeris is input truth. Extended validation must not create navigation coverage by modifying an existing record.
+
+Forbidden operations include creating a new EPH record by changing any of the following from another record:
+
+- Toe or Toc;
+- transmit time or GPS week;
+- `M0`, `delta_n`, `Omega0`, `OmegaDot`, `i0`, `IDOT`, eccentricity, semi-major axis, harmonic corrections, or other orbit parameters;
+- clock polynomial values;
+- IODE/IODC/issue, health, accuracy, fit interval;
+- TGD/BGD/ISC or GLONASS timing/frequency-channel navigation values.
+
+The previous `shift_gps_ephemeris_reference()` / `materialize_long_gps_nav()` path was removed by #58. There is no synthetic fallback. If real NAV coverage is absent, the validation must fail or obtain the real RINEX file from an authoritative data center.
+
+Allowed preparation is limited to downloading, decompressing, copying, concatenating, filtering, or extracting a time window from real RINEX data while preserving the retained parsed navigation values unchanged.
+
+## Pinned real full-day RINEX source
+
+The current long-duration cases use the real full-day RINEX 4 broadcast navigation product already recorded by the repository's RINEX 4 acceptance-fixture metadata:
+
+- Data center: Wuhan University IGS Data Center (WHU/IGS).
+- Product: `BRD400DLR`.
+- Source file: `BRD400DLR_S_20250030000_01D_MN.rnx.gz`.
+- Primary source URL: `ftp://igs.gnsswhu.cn/pub/gps/data/daily/2025/brdc/BRD400DLR_S_20250030000_01D_MN.rnx.gz`.
+- HTTP fallback at the same WHU data center: `http://igs.gnsswhu.cn/pub/gps/data/daily/2025/brdc/BRD400DLR_S_20250030000_01D_MN.rnx.gz`.
+- Compressed SHA256: `fb84d4046b06e905e8e4ec0efb82f0e9ad044bc44d664cc0209cb9b4c92b9512`.
+- Uncompressed SHA256: `b11c638eea42978b8bd6aa8b65a5099fe6556dfe527bc037ed481d2b239afc42`.
+- Long-validation start: GPS week `2347`, SOW `436500`.
+- Eight-hour window: SOW `436500` through `465300`.
+
+The workflow downloads the compressed file before the long-duration validation job, verifies the compressed SHA256, decompresses it without changing RINEX contents, verifies the uncompressed SHA256, and then passes that file to the harness using `--real-nav`.
+
+The harness independently verifies the uncompressed SHA256 again before starting a long-duration case. A missing file or hash mismatch is a hard failure. The harness never extends the file by creating ephemeris records.
+
+For a future validation date, obtain the corresponding real daily RINEX NAV from WHU/IGS or another documented authoritative GNSS data center, pin its identity/hash, and change the test window to match that real source. Do not stretch an older fixture into a new time range.
+
+## Committed short RINEX 4 fixture
+
+`tests/data/minimal/brd400dlr_rinex4_acceptance_nav.rnx` is an unchanged-record subset of the same real WHU `BRD400DLR` source. Its provenance is recorded in:
+
+`tests/data/minimal/brd400dlr_rinex4_acceptance_nav.meta.json`
+
+The reduction tool selects complete real records and normalizes container line endings; it does not recalculate or rewrite ephemeris fields. This compact fixture remains suitable for short RINEX 4 / modern-navigation correctness, determinism, and memory-trend coverage. It is not used to fake long-duration coverage.
 
 ## Bounded stream capture
 
@@ -26,27 +71,9 @@ To avoid retaining multi-gigabyte output histories, the Linux harness creates na
 - `observation_truth.csv`;
 - `solution_truth.csv`.
 
-Reader threads consume those streams incrementally in fixed-size chunks. The harness records SHA256 and logical byte count but does not retain the large byte streams. `event_truth.csv` is small and is additionally retained in memory only long enough to count scenario transition rows. `scenario.json` and `run_manifest.json` remain regular small files and are hashed normally.
+Reader threads consume those streams incrementally in fixed-size chunks. The harness records SHA256 and logical byte count but does not retain the large byte streams. `event_truth.csv` is small and is retained only long enough to count scenario transition rows. `scenario.json` and `run_manifest.json` remain regular small files and are hashed normally.
 
-This means output serialization cost is still exercised while harness memory and artifact size stay bounded.
-
-## Long-duration NAV fixture
-
-The 8-hour cases and `stress_50hz_1h` use the committed deterministic full-sky GPS loopback fixture as their source. The harness materializes hourly broadcast ephemeris records across the required test window.
-
-The hourly records are not created by changing Toe/Toc alone. When the reference epoch is shifted by `dt`, the harness applies the corresponding broadcast-orbit/clock reference transformation used by RTKLIB:
-
-- `M0 += (sqrt(mu/A^3) + delta_n) * dt`;
-- `Omega0 += OmegaDot * dt`;
-- `i0 += IDOT * dt`;
-- the satellite clock polynomial is shifted to the new Toc;
-- Toe, GPS week and transmission time are moved consistently.
-
-This preserves a continuous deterministic orbit/clock across refresh boundaries and prevents a synthetic ephemeris switch from creating a non-physical satellite-state jump.
-
-The compact real WHU `BRD400DLR` RINEX 4 fixture from #40 remains the source for short RINEX 4 / modern navigation correctness coverage and is also used by the 10-minute determinism and 15-minute memory-trend cases. It is intentionally not stretched beyond its reduced ephemeris coverage window for the 1-hour stress case.
-
-No network access or live IGS download is used at extended-test runtime.
+This exercises normal output serialization while keeping harness memory and artifact size bounded.
 
 ## Exact correctness gates
 
@@ -56,22 +83,21 @@ For every run the harness requires:
 - `powered_epochs` to equal the exact powered portion of the scenario timeline;
 - RANGE, PSRPOS and PSRVEL message counts to equal `powered_epochs`;
 - REA `signal_on_epochs` / `signal_off_epochs` to match the exact RF-on/RF-off timeline;
-- TTFF power-off duration to be verified by `scheduled_epochs - powered_epochs`; TTFF `signal_off_epochs` remains zero because the simulator counts RF-off epochs only while the receiver is powered;
+- TTFF power-off duration to be verified by `scheduled_epochs - powered_epochs`;
 - scenario transition counts to match integer-time boundary calculations over the half-open `[0, duration)` interval;
 - at least one observation, valid position and valid velocity epoch;
 - simulator exit status to be zero;
 - `run_manifest.json` to exist and contain the run summary;
-- a non-zero peak RSS measurement to be available.
+- a non-zero peak RSS measurement;
+- for long-duration cases, the real full-day RINEX NAV SHA256 to match the pinned source exactly.
 
 ## Memory guardrail
 
-`memory_trend_50hz` compares a 60-second run with a 900-second run using the same RINEX 4 input, receiver configuration and seed. The long-run peak RSS must not exceed:
+`memory_trend_50hz` compares a 60-second run with a 900-second run using the same committed real RINEX 4 input, receiver configuration and seed. The long-run peak RSS must not exceed:
 
 `max(2 * short_peak_rss, short_peak_rss + 64 MiB)`
 
-The duration ratio is 15:1. The 64 MiB headroom is deliberately conservative relative to the measured implementation while still detecting retained per-epoch histories. The measured short/long peaks, growth and resolved limit are written to `summary.json`.
-
-This is intentionally a trend guardrail, not a fragile absolute performance benchmark.
+The duration ratio is 15:1. The 64 MiB headroom is deliberately conservative while still detecting retained per-epoch histories. The measured short/long peaks, growth and resolved limit are written to `summary.json`.
 
 ## Determinism
 
@@ -86,22 +112,11 @@ This is intentionally a trend guardrail, not a fragile absolute performance benc
 
 Comparison is streamed and bounded; no complete 10-minute observation history is loaded into memory.
 
-## Implementation evidence
+## Historical evidence
 
-During #41 implementation, real GitHub-hosted Ubuntu runners produced the following passing evidence before final workflow cleanup:
+The resource numbers recorded during #41 were produced before #58 and used the then-current synthetic long-NAV helper for the 8-hour/stress cases. They remain historical performance evidence only and are not navigation-provenance acceptance evidence after #58.
 
-| Case | Result | Peak RSS | Logical output |
-| --- | --- | ---: | ---: |
-| `ks_8h` | PASS | 5.9 MiB | 6.952 GiB |
-| `rea_8h` | PASS | 6.0 MiB | 6.705 GiB |
-| `ttff_8h` | PASS | 5.9 MiB | 6.269 GiB |
-| `stress_50hz_1h` | PASS | 6.0 MiB | 8.205 GiB |
-| `determinism_50hz_10m` | PASS | bounded streamed comparison | two identical output fingerprints |
-| `memory_trend_50hz` | PASS | 6.8 MiB -> 6.9 MiB | 0.360 GiB -> 5.565 GiB |
-
-The memory-trend run increased duration/output volume by 15x while peak RSS changed by only about 0.1 MiB, providing direct evidence that the simulator/harness path does not retain output history linearly with run duration.
-
-The final merge gate reruns the matrix through the unified harness rather than relying only on these intermediate implementation artifacts.
+After #58, a passing long-duration result is valid only when the job has downloaded and hash-verified the pinned real RINEX NAV described above.
 
 ## Diagnostics
 
@@ -110,10 +125,9 @@ Each case writes a small artifact directory containing:
 - resolved `config.json`;
 - `scenario.json` and `run_manifest.json` when produced;
 - simulator `stdout.txt` / `stderr.txt`;
-- `summary.json` with elapsed time, peak RSS, logical output sizes, SHA256 values and event counts;
-- `summary.md` for the GitHub Actions job summary;
-- generated long-duration GPS NAV when applicable.
+- `summary.json` with elapsed time, peak RSS, logical output sizes, SHA256 values, event counts, and NAV identity/provenance;
+- `summary.md` for the GitHub Actions job summary.
 
-`summary.json` also retains small stdout/stderr tails so missing-manifest or non-zero-exit failures are diagnosable without first downloading a multi-gigabyte output stream.
+The full-day RINEX NAV is a downloaded test input, not a generated diagnostic artifact. No generated NAV file should appear in the result directory.
 
 Artifacts are uploaded with `if: always()` so a failed case does not become a false PASS and still leaves useful evidence when the runner permits cleanup steps to execute.

--- a/tools/extended_validation/run_extended.py
+++ b/tools/extended_validation/run_extended.py
@@ -5,11 +5,9 @@ from __future__ import annotations
 
 import argparse
 import csv
-import datetime as dt
 import hashlib
 import io
 import json
-import math
 import os
 from pathlib import Path
 import shutil
@@ -17,9 +15,7 @@ import subprocess
 import threading
 import time
 
-GPS_EPOCH = dt.datetime(1980, 1, 6)
 NS = 1_000_000_000
-MU_GPS = 3.9860050e14
 MEMORY_HEADROOM_KIB = 64 * 1024
 FIFO_NAMES = ("simulated.log", "event_truth.csv", "observation_truth.csv", "solution_truth.csv")
 REGULAR_NAMES = ("scenario.json", "run_manifest.json")
@@ -31,6 +27,15 @@ ALL_CASES = (
     "determinism_50hz_10m",
     "memory_trend_50hz",
 )
+
+PINNED_REAL_NAV_FILENAME = "BRD400DLR_S_20250030000_01D_MN.rnx"
+PINNED_REAL_NAV_SHA256 = "b11c638eea42978b8bd6aa8b65a5099fe6556dfe527bc037ed481d2b239afc42"
+PINNED_REAL_NAV_SOURCE_URL = (
+    "ftp://igs.gnsswhu.cn/pub/gps/data/daily/2025/brdc/"
+    "BRD400DLR_S_20250030000_01D_MN.rnx.gz"
+)
+PINNED_REAL_NAV_WEEK = 2347
+PINNED_REAL_NAV_SOW = 436500
 
 
 def base_config(scenario: str, duration_sec: int, rate_hz: int) -> dict:
@@ -56,102 +61,18 @@ def base_config(scenario: str, duration_sec: int, rate_hz: int) -> dict:
 
 def case_definition(name: str):
     if name == "ks_8h":
-        return base_config("KS", 28800, 10), "long_gps", 2253, 172900
+        return base_config("KS", 28800, 10), "real_full_day", PINNED_REAL_NAV_WEEK, PINNED_REAL_NAV_SOW
     if name == "rea_8h":
-        return base_config("REA", 28800, 10), "long_gps", 2253, 172900
+        return base_config("REA", 28800, 10), "real_full_day", PINNED_REAL_NAV_WEEK, PINNED_REAL_NAV_SOW
     if name == "ttff_8h":
-        return base_config("TTFF", 28800, 10), "long_gps", 2253, 172900
+        return base_config("TTFF", 28800, 10), "real_full_day", PINNED_REAL_NAV_WEEK, PINNED_REAL_NAV_SOW
     if name == "stress_50hz_1h":
-        return base_config("KS", 3600, 50), "long_gps", 2253, 172900
+        return base_config("KS", 3600, 50), "real_full_day", PINNED_REAL_NAV_WEEK, PINNED_REAL_NAV_SOW
     if name == "determinism_50hz_10m":
-        return base_config("KS", 600, 50), "brd4", 2347, 436500
+        return base_config("KS", 600, 50), "brd4", PINNED_REAL_NAV_WEEK, PINNED_REAL_NAV_SOW
     if name == "memory_trend_50hz":
-        return base_config("KS", 900, 50), "brd4", 2347, 436500
+        return base_config("KS", 900, 50), "brd4", PINNED_REAL_NAV_WEEK, PINNED_REAL_NAV_SOW
     raise ValueError(f"unknown extended case: {name}")
-
-
-def split_gps_rinex(path: Path):
-    lines = path.read_text(encoding="ascii").splitlines(keepends=True)
-    for index, line in enumerate(lines):
-        if "END OF HEADER" in line:
-            header, body = lines[: index + 1], lines[index + 1 :]
-            break
-    else:
-        raise ValueError("GPS loopback RINEX has no END OF HEADER")
-    if not body or len(body) % 8:
-        raise ValueError("GPS loopback RINEX must contain complete 8-line GPS ephemerides")
-    records = [body[index : index + 8] for index in range(0, len(body), 8)]
-    if any(not record[0].startswith("G") for record in records):
-        raise ValueError("long NAV source must be GPS-only")
-    return header, records
-
-
-def field_value(line: str, first_column: int, field_index: int) -> float:
-    start = first_column + field_index * 19
-    end = start + 19
-    if len(line.rstrip("\n")) < end:
-        raise ValueError("short RINEX NAV field")
-    return float(line[start:end].replace("D", "E"))
-
-
-def replace_field(line: str, first_column: int, field_index: int, value: float) -> str:
-    start = first_column + field_index * 19
-    end = start + 19
-    if len(line.rstrip("\n")) < end:
-        raise ValueError("short RINEX NAV field")
-    return line[:start] + f"{value:19.12E}" + line[end:]
-
-
-def shift_gps_ephemeris_reference(base, toe: int, week: int):
-    """Move GPS LNAV Toe/Toc while preserving the same continuous orbit/clock."""
-    rec = list(base)
-    base_toe = field_value(base[3], 4, 0)
-    delta = float(toe) - base_toe
-
-    sqrt_a = field_value(base[2], 4, 3)
-    semi_major_axis = sqrt_a * sqrt_a
-    delta_n = field_value(base[1], 4, 2)
-    mean_motion = math.sqrt(MU_GPS / (semi_major_axis**3)) + delta_n
-
-    m0 = field_value(base[1], 4, 3)
-    omega0 = field_value(base[3], 4, 2)
-    i0 = field_value(base[4], 4, 0)
-    omega_dot = field_value(base[4], 4, 3)
-    i_dot = field_value(base[5], 4, 0)
-    f0 = field_value(base[0], 23, 0)
-    f1 = field_value(base[0], 23, 1)
-    f2 = field_value(base[0], 23, 2)
-
-    epoch = GPS_EPOCH + dt.timedelta(weeks=week, seconds=toe)
-    prefix = (
-        f"{rec[0][:3]} {epoch.year:04d} {epoch.month:02d} {epoch.day:02d} "
-        f"{epoch.hour:02d} {epoch.minute:02d} {epoch.second:02d}"
-    )
-    rec[0] = prefix + rec[0][23:]
-    rec[0] = replace_field(rec[0], 23, 0, f0 + f1 * delta + f2 * delta * delta)
-    rec[0] = replace_field(rec[0], 23, 1, f1 + 2.0 * f2 * delta)
-    rec[1] = replace_field(rec[1], 4, 3, m0 + mean_motion * delta)
-    rec[3] = replace_field(rec[3], 4, 0, float(toe))
-    rec[3] = replace_field(rec[3], 4, 2, omega0 + omega_dot * delta)
-    rec[4] = replace_field(rec[4], 4, 0, i0 + i_dot * delta)
-    rec[5] = replace_field(rec[5], 4, 2, float(week))
-    rec[7] = replace_field(rec[7], 4, 0, float(toe))
-    return rec
-
-
-def materialize_long_gps_nav(source: Path, destination: Path, week: int, start_sow: int, duration_sec: int) -> None:
-    header, records = split_gps_rinex(source)
-    interval = 3600
-    first_toe = (start_sow // interval) * interval
-    last_toe = start_sow + duration_sec + interval
-    output = list(header)
-    for toe in range(first_toe, last_toe + 1, interval):
-        if not 0 <= toe < 604800:
-            raise ValueError("long GPS NAV fixture currently stays within one GPS week")
-        for base in records:
-            output.extend(shift_gps_ephemeris_reference(base, toe, week))
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    destination.write_text("".join(output), encoding="ascii", newline="\n")
 
 
 class Capture:
@@ -200,6 +121,43 @@ def hash_file(path: Path) -> dict:
             digest.update(chunk)
             size += len(chunk)
     return {"sha256": digest.hexdigest(), "size_bytes": size}
+
+
+def resolve_nav(repo: Path, nav_kind: str, real_nav: Path | None) -> tuple[Path, dict]:
+    if nav_kind == "brd4":
+        nav = repo / "tests/data/minimal/brd400dlr_rinex4_acceptance_nav.rnx"
+        if not nav.is_file():
+            raise ValueError(f"real RINEX 4 fixture is missing: {nav}")
+        identity = hash_file(nav)
+        identity.update({"source": "committed real WHU RINEX subset", "pinned_full_day": False})
+        return nav, identity
+
+    if nav_kind != "real_full_day":
+        raise ValueError(f"unsupported NAV kind: {nav_kind}")
+    if real_nav is None:
+        raise ValueError(
+            "long-duration validation requires --real-nav pointing to the unmodified real RINEX NAV file; "
+            f"download {PINNED_REAL_NAV_SOURCE_URL} instead of synthesizing ephemeris"
+        )
+
+    nav = real_nav.resolve()
+    if not nav.is_file():
+        raise ValueError(f"real RINEX NAV file is missing: {nav}")
+    identity = hash_file(nav)
+    if identity["sha256"].lower() != PINNED_REAL_NAV_SHA256:
+        raise ValueError(
+            "real RINEX NAV SHA256 mismatch: expected "
+            f"{PINNED_REAL_NAV_SHA256}, got {identity['sha256']}; "
+            "do not alter or regenerate navigation records"
+        )
+    identity.update(
+        {
+            "source": PINNED_REAL_NAV_SOURCE_URL,
+            "source_filename": PINNED_REAL_NAV_FILENAME,
+            "pinned_full_day": True,
+        }
+    )
+    return nav, identity
 
 
 def tail_text(path: Path, limit: int = 4096) -> str:
@@ -291,8 +249,6 @@ def expected_epoch_counts(config: dict) -> dict:
             float(config["ttff"]["power_off_sec"]),
         )
         signal_on = powered
-        # Summary signal_off_epochs counts powered RF-off epochs only. Receiver
-        # power-off duration is verified separately by scheduled-powered.
         signal_off = 0
     else:
         raise ValueError(f"unsupported scenario: {scenario}")
@@ -417,7 +373,6 @@ def validate(run: dict, config: dict) -> list[str]:
         actual = int(run.get("event_counts", {}).get(key, 0))
         if actual != expected:
             failures.append(f"{key}: expected {expected}, got {actual}")
-
     if run.get("exit_code") != 0:
         message = f"simulator exit code {run.get('exit_code')}"
         if run.get("stderr_tail"):
@@ -462,21 +417,19 @@ def write_report(name: str, report: dict, out_dir: Path) -> None:
     (out_dir / "summary.md").write_text("\n".join(lines) + "\n")
 
 
-def run_case(simulator: Path, repo: Path, name: str, out_dir: Path) -> bool:
+def run_case(simulator: Path, repo: Path, name: str, out_dir: Path, real_nav: Path | None) -> bool:
     config, nav_kind, week, sow = case_definition(name)
-    if nav_kind == "brd4":
-        nav = repo / "tests/data/minimal/brd400dlr_rinex4_acceptance_nav.rnx"
-    else:
-        nav = out_dir / "long_gps_nav.rnx"
-        materialize_long_gps_nav(
-            repo / "tests/data/minimal/gps_loopback_nav.rnx",
-            nav,
-            week,
-            sow,
-            int(config["duration_sec"]),
-        )
+    nav, nav_identity = resolve_nav(repo, nav_kind, real_nav)
 
-    report = {"schema_version": 1, "case": name, "config": config, "nav_path": nav.name, "runs": [], "failures": []}
+    report = {
+        "schema_version": 1,
+        "case": name,
+        "config": config,
+        "nav_path": str(nav),
+        "nav_identity": nav_identity,
+        "runs": [],
+        "failures": [],
+    }
     failures = report["failures"]
 
     if name == "memory_trend_50hz":
@@ -550,31 +503,13 @@ def self_test() -> None:
     assert counts["range_messages"] == 60
     assert expected_events(ttff) == {"POWER_ON": 2, "POWER_OFF": 2, "SIGNAL_ON": 2, "SIGNAL_OFF": 2}
 
-    sample = [
-        "G01 2023 03 14 00 00 00 1.000000000000E-04 2.000000000000E-12 3.000000000000E-20\n",
-        "     1.000000000000E+00 0.000000000000E+00 4.000000000000E-09 5.000000000000E-01\n",
-        "     0.000000000000E+00 1.000000000000E-02 0.000000000000E+00 5.153795477500E+03\n",
-        "     1.728000000000E+05 0.000000000000E+00 1.000000000000E+00 0.000000000000E+00\n",
-        "     9.500000000000E-01 0.000000000000E+00 2.000000000000E+00-8.000000000000E-09\n",
-        "     1.000000000000E-10 0.000000000000E+00 2.253000000000E+03 0.000000000000E+00\n",
-        "     2.000000000000E+00 0.000000000000E+00 0.000000000000E+00 1.000000000000E+00\n",
-        "     1.728000000000E+05 4.000000000000E+00 0.000000000000E+00 0.000000000000E+00\n",
-    ]
-    shifted = shift_gps_ephemeris_reference(sample, 176400, 2253)
-    delta = 3600.0
-    semi_major_axis = field_value(sample[2], 4, 3) ** 2
-    mean_motion = math.sqrt(MU_GPS / (semi_major_axis**3)) + field_value(sample[1], 4, 2)
-    assert math.isclose(field_value(shifted[1], 4, 3), 0.5 + mean_motion * delta, rel_tol=0.0, abs_tol=1e-11)
-    assert math.isclose(field_value(shifted[3], 4, 2), 1.0 - 8.0e-9 * delta, rel_tol=0.0, abs_tol=1e-11)
-    assert math.isclose(field_value(shifted[4], 4, 0), 0.95 + 1.0e-10 * delta, rel_tol=0.0, abs_tol=1e-11)
-    assert math.isclose(
-        field_value(shifted[0], 23, 0),
-        1.0e-4 + 2.0e-12 * delta + 3.0e-20 * delta**2,
-        rel_tol=0.0,
-        abs_tol=1e-15,
+    assert case_definition("stress_50hz_1h")[1:] == (
+        "real_full_day",
+        PINNED_REAL_NAV_WEEK,
+        PINNED_REAL_NAV_SOW,
     )
-    assert case_definition("stress_50hz_1h")[1:] == ("long_gps", 2253, 172900)
     assert case_definition("determinism_50hz_10m")[1] == "brd4"
+    assert len(PINNED_REAL_NAV_SHA256) == 64
     assert MEMORY_HEADROOM_KIB == 64 * 1024
 
 
@@ -584,6 +519,11 @@ def main() -> int:
     parser.add_argument("--repo-root", type=Path, default=Path("."))
     parser.add_argument("--case", choices=ALL_CASES)
     parser.add_argument("--output-dir", type=Path)
+    parser.add_argument(
+        "--real-nav",
+        type=Path,
+        help="Unmodified full-day real RINEX NAV for long-duration cases; SHA256 is pinned and verified.",
+    )
     parser.add_argument("--self-test", action="store_true")
     args = parser.parse_args()
 
@@ -599,7 +539,17 @@ def main() -> int:
     simulator = args.simulator.resolve()
     if not simulator.is_file():
         raise SystemExit(f"simulator executable not found: {simulator}")
-    return 0 if run_case(simulator, args.repo_root.resolve(), args.case, args.output_dir.resolve()) else 1
+    try:
+        passed = run_case(
+            simulator,
+            args.repo_root.resolve(),
+            args.case,
+            args.output_dir.resolve(),
+            args.real_nav,
+        )
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    return 0 if passed else 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #58

## What changed

- Removed the synthetic long-duration ephemeris path from `tools/extended_validation/run_extended.py`, including the logic that shifted Toe/Toc and rewrote orbit/clock fields.
- Long-duration KS/REA/TTFF/stress cases now run at GPS week 2347 / SOW 436500 against the real full-day `BRD400DLR_S_20250030000_01D_MN.rnx` source.
- Added `--real-nav` for long-duration validation and hard-fail behavior when the real file is missing or its uncompressed SHA256 differs from the pinned WHU source.
- Updated `.github/workflows/extended.yml` to download the pinned WHU RINEX NAV before long-duration cases, verify both compressed and uncompressed SHA256 values, and pass the unmodified file to the harness.
- Added the harness `--self-test` to normal PR CI so Python syntax/basic deterministic-count regressions are caught without running the expensive long-duration matrix.
- Updated `docs/ENGINEERING_RULES.md` and `docs/EXTENDED_VALIDATION.md` to freeze the rule that navigation truth must come from real RINEX NAV and must never be synthesized.

## Why

The previous extended-validation harness manufactured hourly GPS ephemeris records from a compact fixture. Even though it attempted to preserve orbit continuity, those records did not exist in the source RINEX NAV. Broadcast navigation is an input truth source for this project, so missing time coverage must be solved by obtaining real RINEX data from WHU/IGS or another authoritative GNSS data center, not by generating ephemeris.

## Tests / validation

- `tools/extended_validation/run_extended.py --self-test` is now part of normal PR CI.
- Long-duration workflow verifies the repository-pinned WHU hashes before the simulator is launched:
  - compressed: `fb84d4046b06e905e8e4ec0efb82f0e9ad044bc44d664cc0209cb9b4c92b9512`
  - uncompressed: `b11c638eea42978b8bd6aa8b65a5099fe6556dfe527bc037ed481d2b239afc42`
- Branch diff is limited to the validation harness, CI workflows, and the two engineering/validation documents relevant to #58.

## Limitations / follow-up

- The expensive 8-hour extended matrix is still manual/scheduled by design and is not added to ordinary PR CI.
- Future validation dates must pin/download the corresponding real daily RINEX NAV rather than stretching this 2025-01-03 source.

## Implementation Notes

- There is intentionally no synthetic fallback. Missing NAV, download failure, compressed-hash mismatch, uncompressed-hash mismatch, or a modified `--real-nav` file causes a hard failure.
- The committed compact RINEX 4 fixture remains valid for short determinism/memory tests because it is an unchanged-record subset of a documented real WHU source; it is no longer stretched for long-duration coverage.
- Extended CI performs the network download as an explicit pre-validation tooling step. Production simulator runtime remains network-independent.