### PR TITLE
Separate measurement and 5 degree RTKLIB solution masks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,4 +59,4 @@ jobs:
       - name: Report RANGEA round-trip positioning error
         if: runner.os == 'Linux'
         shell: bash
-        run: ./build/gnss_sim_integration_tests --gtest_filter=RangeaRoundtripIntegration.RealWhuRinex4SerializedRangeaPositionsWithinHalfMeter
+        run: ./build/gnss_sim_integration_tests --gtest_filter=RangeaRoundtripIntegration.LowElevationRangeIsRetainedWhileSppUsesFiveDegreeMask

--- a/.github/workflows/rangea-roundtrip-extended.yml
+++ b/.github/workflows/rangea-roundtrip-extended.yml
@@ -81,7 +81,8 @@ jobs:
             "scenario": "KS",
             "duration_sec": 600,
             "sampling_rate_hz": 1,
-            "elevation_mask_deg": 3.0,
+            "elevation_mask_deg": 0.0,
+            "solution_elevation_mask_deg": 5.0,
             "output_eph": true,
             "output_ion": true,
             "measurement_noise_enabled": false,
@@ -124,7 +125,7 @@ jobs:
             --truth-lat 20 \
             --truth-lon 120 \
             --truth-height 100 \
-            --elevation-mask 3 \
+            --elevation-mask 5 \
             --broadcast-atmosphere \
             | tee extended-results/rangea_roundtrip_10m/roundtrip.txt
 
@@ -144,6 +145,7 @@ jobs:
 
           manifest = json.loads((root / "run_manifest.json").read_text())
           summary = manifest["run_summary"]
+          config = manifest["config"]
           expected_range = int(summary["range_messages"])
           expected_valid = int(summary["valid_position_epochs"])
           range_epochs = int(values["range_epochs"])
@@ -152,6 +154,12 @@ jobs:
           max_error = float(values["max_position_error_m"])
 
           failures = []
+          if float(config["elevation_mask_deg"]) != 0.0:
+              failures.append(f"measurement elevation mask expected 0 deg, got {config['elevation_mask_deg']}")
+          if float(config["solution_elevation_mask_deg"]) != 5.0:
+              failures.append(
+                  f"solution elevation mask expected 5 deg, got {config['solution_elevation_mask_deg']}"
+              )
           if expected_range != 600:
               failures.append(f"simulator range_messages expected 600, got {expected_range}")
           if range_epochs != expected_range:
@@ -164,10 +172,12 @@ jobs:
               failures.append(
                   f"selected observation coverage too small: selected={selected}, valid_epochs={valid_epochs}"
               )
-          if not max_error < 0.5:
-              failures.append(f"max_position_error_m {max_error} is not < 0.5 m")
+          if not max_error < 0.01:
+              failures.append(f"max_position_error_m {max_error} is not < 0.01 m with the 5 deg SPP mask")
 
           result = {
+              "measurement_elevation_mask_deg": float(config["elevation_mask_deg"]),
+              "solution_elevation_mask_deg": float(config["solution_elevation_mask_deg"]),
               "range_epochs": range_epochs,
               "valid_position_epochs": valid_epochs,
               "simulator_valid_position_epochs": expected_valid,
@@ -184,7 +194,7 @@ jobs:
         if: always()
         shell: bash
         run: |
-          echo "# RANGEA real-WHU 10 minute round-trip (3 deg mask)" >> "$GITHUB_STEP_SUMMARY"
+          echo "# RANGEA real-WHU 10 minute round-trip (0 deg measurements / 5 deg SPP)" >> "$GITHUB_STEP_SUMMARY"
           echo >> "$GITHUB_STEP_SUMMARY"
           if [[ -f extended-results/rangea_roundtrip_10m/roundtrip.txt ]]; then
             echo '```text' >> "$GITHUB_STEP_SUMMARY"

--- a/docs/RANGEA_ROUNDTRIP_VALIDATION.md
+++ b/docs/RANGEA_ROUNDTRIP_VALIDATION.md
@@ -16,6 +16,19 @@ The black-box gate instead executes:
 
 The RTKLIB observations used by this gate come only from parsed RANGEA text. The evaluator does not read `observation_truth.csv` and does not receive the simulator's in-memory `MeasurementObservation` objects.
 
+## Elevation-mask semantics
+
+The simulator keeps measurement visibility and navigation-solution filtering independent:
+
+- `elevation_mask_deg` controls simulated tracking/measurement availability and therefore which low-elevation observations can appear in RANGEA;
+- `solution_elevation_mask_deg` controls the RTKLIB position/velocity solution elevation cutoff;
+- `solution_elevation_mask_deg` defaults to **5 deg** when omitted, including for existing schema-version-1 configs;
+- lowering `elevation_mask_deg` does not lower the RTKLIB SPP cutoff unless `solution_elevation_mask_deg` is changed explicitly.
+
+This matches a normal receiver architecture: RANGE can retain measurements that the navigation engine elects not to use. Issue #62 validation deliberately uses `elevation_mask_deg = 0 deg` and `solution_elevation_mask_deg = 5 deg` to prove that observations below 5 deg remain serialized while normal SPP rejects them.
+
+The separate low-elevation atmosphere/geometry consistency defect is tracked by Issue #63. The 5 deg solution policy is not considered a physical-model fix for that defect.
+
 ## Independence rules
 
 - RANGEA framing and CRC are decoded independently; the parser does not call the RANGEA writer or its framing helper.
@@ -48,20 +61,22 @@ This reuses the production SPP adapter for solution options, ephemeris staging, 
 
 ## Compact CI gate
 
-`RangeaRoundtripIntegration.RealWhuRinex4SerializedRangeaPositionsWithinHalfMeter` uses the provenance-traceable WHU-derived `BRD400DLR` RINEX 4 acceptance fixture:
+`RangeaRoundtripIntegration.LowElevationRangeIsRetainedWhileSppUsesFiveDegreeMask` uses the provenance-traceable WHU-derived `BRD400DLR` RINEX 4 acceptance fixture:
 
 - KS scenario;
 - fixed receiver truth: 20 deg N, 120 deg E, 100 m;
 - 1 Hz;
 - 60 s;
-- project-default `3 deg` elevation mask;
+- measurement/tracking elevation mask: `0 deg`;
+- RTKLIB solution elevation mask: `5 deg`;
 - zero measurement noise;
 - zero multipath;
 - broadcast ionosphere/troposphere enabled;
-- serialized RANGEA parsed back from the normal `simulated.log`;
+- at least one valid pseudorange below 5 deg must remain in the generated observation/RANGE path;
+- serialized RANGEA is parsed back from the normal `simulated.log`;
 - RANGEA epoch count must equal the simulator's emitted RANGE count;
 - reconstructed valid-position epoch count must equal the simulator's maintained in-memory SPP valid-position count;
-- maximum valid 3D position error must be `< 0.5 m`.
+- maximum valid 3D position error must be `< 0.01 m`.
 
 The exact maximum 3D error and its GPST are printed by Ubuntu CI on every successful compact run.
 
@@ -75,7 +90,9 @@ The scheduled/manual gate:
 
 - downloads the exact pinned WHU RINEX NAV and verifies both compressed and uncompressed SHA256 values;
 - runs a 10 minute KS simulation at 1 Hz starting at GPST week 2347 / SOW 436500;
-- uses the project-default `3 deg` elevation mask;
+- uses a `0 deg` measurement/tracking mask so low-elevation RANGE observations are retained;
+- uses a `5 deg` RTKLIB SPP mask independently;
+- records both masks explicitly in `run_manifest.json` and verifies them in the gate;
 - uses zero measurement noise and zero multipath;
 - enables broadcast ionosphere/troposphere;
 - parses only the generated `simulated.log` RANGEA records;
@@ -83,15 +100,13 @@ The scheduled/manual gate:
 - requires RANGEA epoch count to equal the simulator `range_messages` count;
 - requires round-trip valid-position epoch count to equal the simulator maintained-SPP count;
 - requires at least four selected serialized observations per valid position epoch in aggregate;
-- requires maximum 3D position error `< 0.5 m`.
+- requires maximum 3D position error `< 0.01 m` with the 5 deg SPP mask.
 
-A separate diagnostic run deliberately lowered the positioning mask to `0 deg`; that run measured `0.138821 m` maximum 3D error at GPST `2347/437021.000` and exposed the near-horizon geometry/atmosphere consistency problem described below. The `3 deg` A/B solve on the same generated data measured `0.000669 m` maximum 3D error.
+### Confirmed cause of the old 0-deg SPP error spike
 
-### Confirmed cause of the 0-deg error spike
+Before the masks were separated, a diagnostic also used `0 deg` as the **positioning** mask. That produced a `0.138821 m` maximum 3D error at GPST `2347/437021.000`. The peak was not caused by RANGEA serialization; the same epoch already showed the spike in the simulator's in-memory SPP path.
 
-The `0.138821 m` peak is not caused by RANGEA serialization. RANGEA writes pseudorange to `0.001 m`, while the same epoch also shows an error spike before serialization in the simulator's in-memory SPP path.
-
-The peak is caused by accepting a satellite essentially on the geometric horizon together with a geometry-consistency weakness in the generated atmosphere terms:
+The root cause is a near-horizon atmosphere/geometry consistency weakness:
 
 - BeiDou satellite 144 is at about `0.010385 deg` elevation at GPST `2347/437021`.
 - The generated Saastamoinen troposphere delay for that observation is about `13241.954 m` because the mapping function is extremely sensitive near zero elevation.
@@ -100,11 +115,9 @@ The peak is caused by accepting a satellite essentially on the geometric horizon
 - The already-computed ionosphere/troposphere terms are retained instead of being recomputed from the final family-specific line of sight.
 - At normal elevations the geometric difference is negligible. Near zero elevation the troposphere mapping derivative is so large that the tiny line-of-sight difference becomes a many-metre pseudorange-model inconsistency.
 
-Independent residual validation confirms that the outlier is concentrated in near-horizon observations. BeiDou satellite 144 reaches code residuals of about `18.601 m` on B1I at `0.006757 deg` and `34.473 m` on B3I at `0.004943 deg`; ordinary-elevation observations remain around sub-millimetre to tens-of-micrometre residuals.
+Independent residual validation found about `18.601 m` B1I and `34.473 m` B3I maximum code residuals on that near-horizon satellite. An A/B position solve using the same generated data showed:
 
-Elevation-mask A/B validation confirms causality:
-
-| Positioning mask | Maximum 3D round-trip error |
+| RTKLIB positioning mask | Maximum 3D round-trip error |
 | ---: | ---: |
 | 0.0 deg | 0.138821 m |
 | 0.5 deg | 0.000559 m |
@@ -113,15 +126,13 @@ Elevation-mask A/B validation confirms causality:
 | 5.0 deg | 0.000722 m |
 | 10.0 deg | 0.000867 m |
 
-Therefore the 13.9 cm value is a pathological near-horizon atmosphere/geometry-consistency artifact exposed by the diagnostic `0 deg` mask. At the project's normal `3 deg` mask, the same full-day WHU 10 minute RANGEA round-trip is sub-millimetre in the A/B solve (`0.000669 m`).
-
-The validation policy change to `3 deg` does not fix or hide the model inconsistency. The near-horizon geometry/atmosphere consistency defect remains a separate implementation issue to fix and should retain dedicated low-elevation regression coverage.
+The normal 5 deg solution mask therefore prevents this pathological near-horizon observation from entering routine SPP, while the 0 deg measurement mask can still preserve it in RANGE for downstream analysis. Issue #63 remains responsible for making the generated physical model itself self-consistent at low elevation.
 
 The full-day source is never modified and no synthetic ephemeris fallback exists.
 
 ## Reusable validator
 
-The `validate-rangea-roundtrip` executable exposes the same streaming evaluator for retained logs:
+The `validate-rangea-roundtrip` executable exposes the same streaming evaluator for retained logs. Its `--elevation-mask` argument is a **solution** mask for the RTKLIB round-trip solve; it does not alter observations already present in a retained RANGE log:
 
 ```text
 validate-rangea-roundtrip \
@@ -130,7 +141,7 @@ validate-rangea-roundtrip \
   --truth-lat 20 \
   --truth-lon 120 \
   --truth-height 100 \
-  --elevation-mask 3 \
+  --elevation-mask 5 \
   --broadcast-atmosphere
 ```
 

--- a/include/gnss_sim/sim_config.h
+++ b/include/gnss_sim/sim_config.h
@@ -43,6 +43,7 @@ struct SimConfig {
     std::int64_t duration_ns;
     int sampling_rate_hz;
     double elevation_mask_deg;
+    double solution_elevation_mask_deg;
     bool output_eph;
     bool output_ion;
     bool measurement_noise_enabled;

--- a/src/core/sim_config.cpp
+++ b/src/core/sim_config.cpp
@@ -266,6 +266,7 @@ SimConfig default_sim_config() {
     config.duration_ns = 28800LL * NANOSECONDS_PER_SECOND;
     config.sampling_rate_hz = 10;
     config.elevation_mask_deg = 3.0;
+    config.solution_elevation_mask_deg = 5.0;
     config.output_eph = true;
     config.output_ion = true;
     config.measurement_noise_enabled = false;
@@ -297,6 +298,11 @@ bool validate_sim_config(const SimConfig& config, std::string* error_message) {
     if (!std::isfinite(config.elevation_mask_deg) || config.elevation_mask_deg < 0.0 ||
         config.elevation_mask_deg > 90.0) {
         set_error(error_message, "elevation_mask_deg must be within [0, 90]");
+        return false;
+    }
+    if (!std::isfinite(config.solution_elevation_mask_deg) || config.solution_elevation_mask_deg < 0.0 ||
+        config.solution_elevation_mask_deg > 90.0) {
+        set_error(error_message, "solution_elevation_mask_deg must be within [0, 90]");
         return false;
     }
     if (config.measurement_noise_enabled) {
@@ -370,6 +376,7 @@ bool load_sim_config_json(const char* file_path, SimConfig* config, std::string*
                                         "duration_sec",
                                         "sampling_rate_hz",
                                         "elevation_mask_deg",
+                                        "solution_elevation_mask_deg",
                                         "output_eph",
                                         "output_ion",
                                         "measurement_noise_enabled",
@@ -383,7 +390,7 @@ bool load_sim_config_json(const char* file_path, SimConfig* config, std::string*
                                         "seed"};
 
     SimConfig parsed = default_sim_config();
-    bool success = validate_object_keys(root, "root", allowed_keys, 16U, error_message);
+    bool success = validate_object_keys(root, "root", allowed_keys, 17U, error_message);
 
     double duration_sec = static_cast<double>(parsed.duration_ns) / static_cast<double>(NANOSECONDS_PER_SECOND);
     const char* scenario_name = scenario_type_name(parsed.scenario);
@@ -397,6 +404,8 @@ bool load_sim_config_json(const char* file_path, SimConfig* config, std::string*
             seconds_to_ns(duration_sec, "duration_sec", &parsed.duration_ns, error_message) &&
             read_optional_int(root, "sampling_rate_hz", &parsed.sampling_rate_hz, error_message) &&
             read_optional_number(root, "elevation_mask_deg", &parsed.elevation_mask_deg, error_message) &&
+            read_optional_number(root, "solution_elevation_mask_deg", &parsed.solution_elevation_mask_deg,
+                                 error_message) &&
             read_optional_bool(root, "output_eph", &parsed.output_eph, error_message) &&
             read_optional_bool(root, "output_ion", &parsed.output_ion, error_message) &&
             read_optional_bool(root, "measurement_noise_enabled", &parsed.measurement_noise_enabled, error_message) &&

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -1022,7 +1022,7 @@ bool run_simulator(const SimConfig& config, const SimulatorRunOptions& options, 
         SolutionEpoch solution{};
         const MeasurementObservation* data = measurements.empty() ? nullptr : measurements.data();
         if (!solve_receiver_epoch(receiver_navigation_store(runtime.navigation), current_time, data,
-                                  static_cast<int>(measurements.size()), config.elevation_mask_deg,
+                                  static_cast<int>(measurements.size()), config.solution_elevation_mask_deg,
                                   config.atmosphere_mode, &runtime.solution_state, &solution, error_message) ||
             !truth_writer_write_solution(truth_writer, solution, tracked_satellites, error_message) ||
             !emit_epoch_logs(config, scenario, measurements, tracked_satellites, solution, runtime.receiver, &output,

--- a/src/output/truth_writer.cpp
+++ b/src/output/truth_writer.cpp
@@ -163,6 +163,7 @@ std::string config_json(const SimConfig& config, int indent) {
     output << inner << "\"duration_ns\": " << config.duration_ns << ",\n";
     output << inner << "\"sampling_rate_hz\": " << config.sampling_rate_hz << ",\n";
     output << inner << "\"elevation_mask_deg\": " << config.elevation_mask_deg << ",\n";
+    output << inner << "\"solution_elevation_mask_deg\": " << config.solution_elevation_mask_deg << ",\n";
     output << inner << "\"output_eph\": " << bool_json(config.output_eph) << ",\n";
     output << inner << "\"output_ion\": " << bool_json(config.output_ion) << ",\n";
     output << inner << "\"measurement_noise_enabled\": " << bool_json(config.measurement_noise_enabled) << ",\n";

--- a/tests/integration/test_rangea_roundtrip.cpp
+++ b/tests/integration/test_rangea_roundtrip.cpp
@@ -10,6 +10,7 @@
 #include <iterator>
 #include <sstream>
 #include <string>
+#include <vector>
 
 namespace {
 
@@ -29,7 +30,8 @@ gnss_sim::SimConfig config() {
     value.atmosphere_mode = gnss_sim::AtmosphereMode::BROADCAST;
     value.sampling_rate_hz = 1;
     value.duration_ns = 60LL * gnss_sim::NANOSECONDS_PER_SECOND;
-    value.elevation_mask_deg = 3.0;
+    value.elevation_mask_deg = 0.0;
+    value.solution_elevation_mask_deg = 5.0;
     value.receiver = {20.0, 120.0, 100.0};
     value.measurement_noise_enabled = false;
     value.multipath_enabled = false;
@@ -62,23 +64,72 @@ std::string read_file(const std::filesystem::path& path) {
     return std::string((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
 }
 
+std::vector<std::string> split_csv(const std::string& line) {
+    std::vector<std::string> fields;
+    std::istringstream input(line);
+    std::string field;
+    while (std::getline(input, field, ',')) {
+        fields.push_back(field);
+    }
+    return fields;
+}
+
+bool has_valid_pseudorange_below_mask(const std::filesystem::path& path, double mask_deg) {
+    std::ifstream input(path);
+    std::string line;
+    if (!std::getline(input, line)) {
+        return false;
+    }
+    const std::vector<std::string> header = split_csv(line);
+    std::size_t elevation_index = header.size();
+    std::size_t validity_index = header.size();
+    for (std::size_t index = 0; index < header.size(); ++index) {
+        if (header[index] == "elevation_deg") {
+            elevation_index = index;
+        } else if (header[index] == "pseudorange_valid") {
+            validity_index = index;
+        }
+    }
+    if (elevation_index >= header.size() || validity_index >= header.size()) {
+        return false;
+    }
+
+    while (std::getline(input, line)) {
+        const std::vector<std::string> fields = split_csv(line);
+        if (fields.size() <= elevation_index || fields.size() <= validity_index || fields[validity_index] != "1") {
+            continue;
+        }
+        try {
+            const double elevation_deg = std::stod(fields[elevation_index]);
+            if (elevation_deg >= 0.0 && elevation_deg < mask_deg) {
+                return true;
+            }
+        } catch (...) {
+            return false;
+        }
+    }
+    return false;
+}
+
 void cleanup(const std::filesystem::path& path) {
     std::error_code error;
     std::filesystem::remove_all(path, error);
 }
 
-TEST(RangeaRoundtripIntegration, RealWhuRinex4SerializedRangeaPositionsWithinHalfMeter) {
+TEST(RangeaRoundtripIntegration, LowElevationRangeIsRetainedWhileSppUsesFiveDegreeMask) {
     const std::filesystem::path directory = "gnss_sim_rangea_roundtrip_real_whu";
     gnss_sim::SimulatorRunSummary simulator_summary{};
     std::string error_message;
     ASSERT_TRUE(run_simulator(directory, &simulator_summary, &error_message)) << error_message;
     ASSERT_GT(simulator_summary.range_messages, 0U);
     ASSERT_GT(simulator_summary.valid_position_epochs, 0U);
+    ASSERT_TRUE(has_valid_pseudorange_below_mask(directory / "observation_truth.csv", 5.0))
+        << "measurement mask 0 deg should preserve at least one valid observation below the 5 deg SPP mask";
 
     gnss_sim::RangeaRoundtripSummary roundtrip{};
     const std::string log_path = (directory / "simulated.log").string();
     const std::string nav_path = brd4_nav_path();
-    ASSERT_TRUE(gnss_sim::validate_rangea_roundtrip_file(log_path.c_str(), nav_path.c_str(), 20.0, 120.0, 100.0, 3.0,
+    ASSERT_TRUE(gnss_sim::validate_rangea_roundtrip_file(log_path.c_str(), nav_path.c_str(), 20.0, 120.0, 100.0, 5.0,
                                                          true, &roundtrip, &error_message))
         << error_message;
     EXPECT_EQ(roundtrip.range_epochs, simulator_summary.range_messages);
@@ -90,8 +141,8 @@ TEST(RangeaRoundtripIntegration, RealWhuRinex4SerializedRangeaPositionsWithinHal
     std::cout << "rangea_roundtrip_max_error_gpst=" << roundtrip.max_error_gps_week << '/'
               << roundtrip.max_error_sow_sec << '\n';
     std::cout << "rangea_roundtrip_valid_position_epochs=" << roundtrip.valid_position_epochs << '\n';
-    EXPECT_LT(roundtrip.max_position_error_m, 0.5)
-        << "serialized RANGEA must retain enough precision and mapping fidelity for RTKLIB SPP";
+    EXPECT_LT(roundtrip.max_position_error_m, 0.01)
+        << "5 deg RTKLIB SPP mask should exclude the known near-horizon pathology from normal positioning";
 
     cleanup(directory);
 }
@@ -102,7 +153,7 @@ TEST(RangeaRoundtripIntegration, MalformedSerializedRangeaFailsExplicitly) {
     gnss_sim::RangeaRoundtripSummary summary{};
     std::string error_message;
     const std::string nav_path = brd4_nav_path();
-    EXPECT_FALSE(gnss_sim::validate_rangea_roundtrip_stream(&malformed, nav_path.c_str(), 20.0, 120.0, 100.0, 3.0, true,
+    EXPECT_FALSE(gnss_sim::validate_rangea_roundtrip_stream(&malformed, nav_path.c_str(), 20.0, 120.0, 100.0, 5.0, true,
                                                             &summary, &error_message));
     EXPECT_FALSE(error_message.empty());
 }
@@ -122,10 +173,10 @@ TEST(RangeaRoundtripIntegration, SameInputProducesIdenticalRoundtripResult) {
     const std::string second_log = (second_directory / "simulated.log").string();
     gnss_sim::RangeaRoundtripSummary first_roundtrip{};
     gnss_sim::RangeaRoundtripSummary second_roundtrip{};
-    ASSERT_TRUE(gnss_sim::validate_rangea_roundtrip_file(first_log.c_str(), nav_path.c_str(), 20.0, 120.0, 100.0, 3.0,
+    ASSERT_TRUE(gnss_sim::validate_rangea_roundtrip_file(first_log.c_str(), nav_path.c_str(), 20.0, 120.0, 100.0, 5.0,
                                                          true, &first_roundtrip, &error_message))
         << error_message;
-    ASSERT_TRUE(gnss_sim::validate_rangea_roundtrip_file(second_log.c_str(), nav_path.c_str(), 20.0, 120.0, 100.0, 3.0,
+    ASSERT_TRUE(gnss_sim::validate_rangea_roundtrip_file(second_log.c_str(), nav_path.c_str(), 20.0, 120.0, 100.0, 5.0,
                                                          true, &second_roundtrip, &error_message))
         << error_message;
 

--- a/tests/integration/test_v1_acceptance.cpp
+++ b/tests/integration/test_v1_acceptance.cpp
@@ -278,6 +278,9 @@ TEST(V1Acceptance, FrozenRatesRunThroughFullStreamingPipeline) {
 
 TEST(V1Acceptance, RealMixedNavProducesAllFiveV1ConstellationsAndValidSolution) {
     gnss_sim::SimConfig config = acceptance_config();
+    // This compact fixture validates five-system plumbing, not the production SPP cutoff.
+    // Real BRD400 and RANGEA acceptance exercise the 5 degree solution default.
+    config.solution_elevation_mask_deg = 0.0;
     config.sampling_rate_hz = 1;
     config.duration_ns = 60LL * gnss_sim::NANOSECONDS_PER_SECOND;
     config.receiver = {10.0, 80.0, 100.0};

--- a/tests/unit/test_sim_config.cpp
+++ b/tests/unit/test_sim_config.cpp
@@ -27,6 +27,7 @@ TEST_F(SimConfigTest, FrozenDefaultsAreCentralized) {
     EXPECT_EQ(config.duration_ns, 28800LL * gnss_sim::NANOSECONDS_PER_SECOND);
     EXPECT_EQ(config.sampling_rate_hz, 10);
     EXPECT_DOUBLE_EQ(config.elevation_mask_deg, 3.0);
+    EXPECT_DOUBLE_EQ(config.solution_elevation_mask_deg, 5.0);
     EXPECT_TRUE(config.output_eph);
     EXPECT_TRUE(config.output_ion);
     EXPECT_FALSE(config.measurement_noise_enabled);
@@ -42,7 +43,8 @@ TEST_F(SimConfigTest, LoadsValidOverridesWithoutLeakingJsonTypes) {
         "scenario": "TTFF",
         "duration_sec": 60,
         "sampling_rate_hz": 50,
-        "elevation_mask_deg": 3,
+        "elevation_mask_deg": 2,
+        "solution_elevation_mask_deg": 7,
         "atmosphere_mode": "broadcast",
         "receiver": {"latitude_deg": 21, "longitude_deg": 121, "height_m": 50},
         "ttff": {"startup_mode": "COLD", "power_on_sec": 20, "power_off_sec": 5},
@@ -55,6 +57,8 @@ TEST_F(SimConfigTest, LoadsValidOverridesWithoutLeakingJsonTypes) {
     EXPECT_EQ(config.scenario, gnss_sim::ScenarioType::TTFF);
     EXPECT_EQ(config.duration_ns, 60LL * gnss_sim::NANOSECONDS_PER_SECOND);
     EXPECT_EQ(config.sampling_rate_hz, 50);
+    EXPECT_DOUBLE_EQ(config.elevation_mask_deg, 2.0);
+    EXPECT_DOUBLE_EQ(config.solution_elevation_mask_deg, 7.0);
     EXPECT_EQ(config.atmosphere_mode, gnss_sim::AtmosphereMode::BROADCAST);
     EXPECT_EQ(config.ttff.startup_mode, gnss_sim::StartupMode::COLD);
     EXPECT_EQ(config.seed, 42U);
@@ -86,6 +90,25 @@ TEST_F(SimConfigTest, RejectsUnknownKey) {
     std::string error_message;
     EXPECT_FALSE(gnss_sim::load_sim_config_json(TEST_CONFIG_PATH, &config, &error_message));
     EXPECT_NE(error_message.find("unsupported key"), std::string::npos);
+}
+
+TEST_F(SimConfigTest, OmittedSolutionMaskKeepsFiveDegreeDefault) {
+    write_test_config(R"json({"elevation_mask_deg": 0})json");
+
+    gnss_sim::SimConfig config{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::load_sim_config_json(TEST_CONFIG_PATH, &config, &error_message)) << error_message;
+    EXPECT_DOUBLE_EQ(config.elevation_mask_deg, 0.0);
+    EXPECT_DOUBLE_EQ(config.solution_elevation_mask_deg, 5.0);
+}
+
+TEST_F(SimConfigTest, RejectsInvalidSolutionElevationMask) {
+    write_test_config(R"json({"solution_elevation_mask_deg": 91})json");
+
+    gnss_sim::SimConfig config{};
+    std::string error_message;
+    EXPECT_FALSE(gnss_sim::load_sim_config_json(TEST_CONFIG_PATH, &config, &error_message));
+    EXPECT_NE(error_message.find("solution_elevation_mask_deg"), std::string::npos);
 }
 
 TEST_F(SimConfigTest, RejectsUnsupportedRateAndV1Noise) {


### PR DESCRIPTION
Closes #62

## What changed

- Added `solution_elevation_mask_deg` to `SimConfig` while retaining `elevation_mask_deg` for measurement/tracking visibility.
- Defaulted RTKLIB solution elevation filtering to **5.0 deg** for existing and new schema-version-1 configs when the new field is omitted.
- Passed `solution_elevation_mask_deg` to the maintained RTKLIB position and velocity solution path.
- Kept RANGE generation and signal tracking controlled only by `elevation_mask_deg`.
- Added both elevation masks to the run-manifest config snapshot.
- Strengthened the real-RINEX RANGEA integration case to generate measurements down to `0 deg` while both simulator SPP and serialized RANGEA round-trip SPP use `5 deg`.
- Added an explicit assertion that at least one valid pseudorange below 5 deg remains in the generated measurement/RANGE path.
- Updated the real-WHU 10-minute extended gate to use `0 deg` measurement visibility + `5 deg` SPP and tightened the normal-position max-error gate to `< 0.01 m`.
- Updated RANGEA validation documentation and CI's explicit test filter.

## Why

Measurement availability and navigation-solution filtering are different receiver concepts. A receiver can output low-elevation RANGE observations while its SPP engine rejects them. Reusing one elevation mask for both made a diagnostic `0 deg` measurement setting also lower RTKLIB `pntpos()` to `0 deg`, which admitted a near-horizon observation and exposed a 13.9 cm position spike.

The confirmed low-elevation atmosphere/geometry consistency defect is tracked separately in Issue #63. This PR establishes the normal **5 deg RTKLIB SPP policy** without suppressing low-elevation RANGE observations or treating the policy as a physical-model fix.

## Tests / acceptance

- `SimConfigTest.FrozenDefaultsAreCentralized` checks measurement `3 deg` and solution `5 deg` defaults.
- Config override test verifies the two values parse independently.
- Omitted `solution_elevation_mask_deg` retains the deterministic `5 deg` default.
- Invalid solution masks outside `[0, 90]` fail validation.
- `RangeaRoundtripIntegration.LowElevationRangeIsRetainedWhileSppUsesFiveDegreeMask`:
  - uses real WHU-derived RINEX 4 NAV;
  - measurement mask `0 deg`;
  - solution mask `5 deg`;
  - requires a valid pseudorange below 5 deg to remain in generated observations;
  - requires simulator and serialized RANGEA round-trip position availability to agree;
  - requires maximum 3D position error `< 0.01 m`.
- Scheduled/manual full-day WHU 10-minute gate records and verifies both masks and uses the same `0 deg` measurement / `5 deg` SPP split.
- The legacy compact `RealMixedNavProducesAllFiveV1ConstellationsAndValidSolution` fixture explicitly keeps a `0 deg` solution mask because its purpose is five-system plumbing and its tiny historical NAV fixture does not have enough satellites above 5 deg. The real BRD400 and RANGEA acceptance cases exercise the new 5 deg policy.

## Current compact result

On the real-WHU-derived 60 s RANGEA gate with `0 deg` measurement visibility and `5 deg` SPP:

- valid position epochs: **59**
- maximum 3D position error: **0.000817122 m** (~0.82 mm)
- maximum-error epoch: **GPST 2347/436501**

## Limitations / follow-ups

- This PR does not fix the near-horizon atmosphere/geometry inconsistency; Issue #63 owns that change and its dedicated low-elevation regression.
- The RANGEA black-box baseline merged in PR #61 intentionally uses all eligible real EPH from the supplied RINEX; receiver-realistic ephemeris acquisition/update timing remains deferred.
- The solution mask is configurable; 5 deg is the default policy, not a hard-coded physical limitation.

## Implementation Notes

- No ephemeris is synthesized or rewritten. Issue #58 real-RINEX-only provenance remains binding.
- `elevation_mask_deg` retains its previous measurement/tracking meaning and default `3.0 deg`.
- `solution_elevation_mask_deg` is additive and optional in schema version 1, preserving compatibility with existing config files.
- Both position and velocity RTKLIB calls receive the solution mask through the existing maintained solution engine.
- The 5 deg SPP policy filters observations only inside the solution path; it does not remove them from RANGE output.
- After PR #61 was squash-merged, this branch was rebuilt directly on the resulting `main` commit so PR #64 contains only the Issue #62 delta.