### PR TITLE
Apply TTFF and REA observation transients

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,6 +247,7 @@ if(BUILD_TESTING)
     add_executable(gnss_sim_integration_tests
         tests/integration/test_scenarios.cpp
         tests/integration/test_all_signal_residuals.cpp
+        tests/integration/test_measurement_noise_integration.cpp
         tests/integration/test_rangea_roundtrip.cpp
         tests/integration/test_residual_validator.cpp
         tests/integration/test_truth_outputs.cpp

--- a/config/default_v1.json
+++ b/config/default_v1.json
@@ -6,7 +6,6 @@
   "elevation_mask_deg": 3.0,
   "output_eph": true,
   "output_ion": true,
-  "measurement_noise_enabled": false,
   "multipath_enabled": false,
   "receiver_clock_bias_m": 0.0,
   "receiver_clock_drift_mps": 0.0,

--- a/src/core/sim_config.cpp
+++ b/src/core/sim_config.cpp
@@ -402,10 +402,6 @@ bool validate_sim_config(const SimConfig& config, std::string* error_message) {
         set_error(error_message, "measurement_error configuration is invalid");
         return false;
     }
-    if (config.measurement_noise_enabled) {
-        set_error(error_message, "measurement noise is not supported in V1");
-        return false;
-    }
     if (config.multipath_enabled) {
         set_error(error_message, "multipath is not supported in V1");
         return false;
@@ -494,18 +490,24 @@ bool load_sim_config_json(const char* file_path, SimConfig* config, std::string*
     const char* scenario_name = scenario_type_name(parsed.scenario);
     const char* atmosphere_name = atmosphere_mode_name(parsed.atmosphere_mode);
     if (success) {
+        success = read_optional_int(root, "schema_version", &parsed.schema_version, error_message) &&
+                  read_optional_string(root, "scenario", &scenario_name, error_message) &&
+                  parse_scenario(scenario_name, &parsed.scenario, error_message) &&
+                  read_optional_number(root, "duration_sec", &duration_sec, error_message) &&
+                  seconds_to_ns(duration_sec, "duration_sec", &parsed.duration_ns, error_message) &&
+                  read_optional_int(root, "sampling_rate_hz", &parsed.sampling_rate_hz, error_message) &&
+                  read_optional_number(root, "elevation_mask_deg", &parsed.elevation_mask_deg, error_message) &&
+                  read_optional_number(root, "solution_elevation_mask_deg", &parsed.solution_elevation_mask_deg,
+                                       error_message) &&
+                  read_optional_bool(root, "output_eph", &parsed.output_eph, error_message) &&
+                  read_optional_bool(root, "output_ion", &parsed.output_ion, error_message);
+    }
+    if (success && cJSON_GetObjectItemCaseSensitive(root, "measurement_noise_enabled") == nullptr) {
+        parsed.measurement_noise_enabled =
+            parsed.scenario == ScenarioType::TTFF || parsed.scenario == ScenarioType::REA;
+    }
+    if (success) {
         success =
-            read_optional_int(root, "schema_version", &parsed.schema_version, error_message) &&
-            read_optional_string(root, "scenario", &scenario_name, error_message) &&
-            parse_scenario(scenario_name, &parsed.scenario, error_message) &&
-            read_optional_number(root, "duration_sec", &duration_sec, error_message) &&
-            seconds_to_ns(duration_sec, "duration_sec", &parsed.duration_ns, error_message) &&
-            read_optional_int(root, "sampling_rate_hz", &parsed.sampling_rate_hz, error_message) &&
-            read_optional_number(root, "elevation_mask_deg", &parsed.elevation_mask_deg, error_message) &&
-            read_optional_number(root, "solution_elevation_mask_deg", &parsed.solution_elevation_mask_deg,
-                                 error_message) &&
-            read_optional_bool(root, "output_eph", &parsed.output_eph, error_message) &&
-            read_optional_bool(root, "output_ion", &parsed.output_ion, error_message) &&
             read_optional_bool(root, "measurement_noise_enabled", &parsed.measurement_noise_enabled, error_message) &&
             read_optional_bool(root, "multipath_enabled", &parsed.multipath_enabled, error_message) &&
             read_optional_number(root, "receiver_clock_bias_m", &parsed.receiver_clock_bias_m, error_message) &&

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -11,6 +11,7 @@
 #include "gnss_sim/sim_time.h"
 #include "model/atmosphere_model.h"
 #include "model/cn0_model.h"
+#include "model/measurement_error_model.h"
 #include "model/measurement_model.h"
 #include "model/receiver_truth.h"
 #include "model/signal_tracking.h"
@@ -45,6 +46,7 @@ constexpr double kRadiansToDegrees = 180.0 / 3.141592653589793238462643383279502
 struct SignalRuntime {
     SignalTracker tracker;
     CarrierAmbiguityState ambiguity;
+    MeasurementErrorState measurement_error;
     bool ever_scheduled;
 };
 
@@ -433,6 +435,34 @@ AcquisitionContext startup_context(StartupMode mode) {
     return AcquisitionContext::kHot;
 }
 
+MeasurementErrorContext measurement_error_context(const SimConfig& config, const SignalTracker& tracker) {
+    MeasurementErrorContext context{};
+    context.phase = MeasurementErrorPhase::kStable;
+    context.rea_fade_progress = 0.0;
+    if (config.scenario == ScenarioType::REA && tracker.acquisition_context == AcquisitionContext::kReacquisition) {
+        context.phase = MeasurementErrorPhase::kReaReacquisition;
+        return context;
+    }
+    if (config.scenario != ScenarioType::TTFF) {
+        return context;
+    }
+    switch (tracker.acquisition_context) {
+        case AcquisitionContext::kHot:
+            context.phase = MeasurementErrorPhase::kTtffHot;
+            break;
+        case AcquisitionContext::kWarm:
+            context.phase = MeasurementErrorPhase::kTtffWarm;
+            break;
+        case AcquisitionContext::kCold:
+            context.phase = MeasurementErrorPhase::kTtffCold;
+            break;
+        case AcquisitionContext::kReacquisition:
+            context.phase = MeasurementErrorPhase::kStable;
+            break;
+    }
+    return context;
+}
+
 bool receiver_power_on(RuntimeState* runtime, const SimConfig& config, const SimTime& power_on_time,
                        std::ofstream* output, SimulatorRunSummary* summary, std::string* error_message) {
     runtime->startup_mode = scenario_startup_mode(config);
@@ -450,6 +480,7 @@ bool receiver_power_on(RuntimeState* runtime, const SimConfig& config, const Sim
         for (SignalRuntime& signal : satellite.signals) {
             reset_signal_tracker(&signal.tracker, signal.tracker.signal_id, power_on_time);
             reset_carrier_ambiguity_state(&signal.ambiguity);
+            reset_measurement_error_state(&signal.measurement_error);
             signal.ever_scheduled = false;
         }
         for (ColdFamilyRuntime& family : satellite.cold_families) {
@@ -472,6 +503,7 @@ void receiver_power_off(RuntimeState* runtime, const SimTime& time) {
         for (SignalRuntime& signal : satellite.signals) {
             reset_signal_tracker(&signal.tracker, signal.tracker.signal_id, time);
             reset_carrier_ambiguity_state(&signal.ambiguity);
+            reset_measurement_error_state(&signal.measurement_error);
         }
     }
 }
@@ -481,6 +513,7 @@ void receiver_signal_off(RuntimeState* runtime, const SimTime& time) {
         for (SignalRuntime& signal : satellite.signals) {
             static_cast<void>(update_signal_tracker(&signal.tracker, time, false, 0.0, runtime->cn0_model, nullptr));
             reset_carrier_ambiguity_state(&signal.ambiguity);
+            reset_measurement_error_state(&signal.measurement_error);
         }
     }
 }
@@ -799,6 +832,7 @@ bool update_tracking_and_measurements(RuntimeState* runtime, const SimConfig& co
             }
             if (signal.tracker.phase != SignalTrackingPhase::kTracking) {
                 reset_carrier_ambiguity_state(&signal.ambiguity);
+                reset_measurement_error_state(&signal.measurement_error);
                 continue;
             }
             satellite_tracking = true;
@@ -822,7 +856,14 @@ bool update_tracking_and_measurements(RuntimeState* runtime, const SimConfig& co
                                                                    signal.tracker, observation, error_message)) {
                 return false;
             }
-            measurements->push_back(observation);
+            MeasurementObservation reported_observation = observation;
+            if (config.measurement_noise_enabled &&
+                !apply_measurement_error(config.measurement_error, config.seed,
+                                         measurement_error_context(config, signal.tracker), signal.tracker, observation,
+                                         &signal.measurement_error, &reported_observation, error_message)) {
+                return false;
+            }
+            measurements->push_back(reported_observation);
         }
         if (satellite_tracking) {
             ++(*tracked_satellites);

--- a/src/output/truth_writer.cpp
+++ b/src/output/truth_writer.cpp
@@ -185,6 +185,36 @@ std::string config_json(const SimConfig& config, int indent) {
     output << inner << "  \"signal_on_ns\": " << config.rea.signal_on_ns << ",\n";
     output << inner << "  \"signal_off_ns\": " << config.rea.signal_off_ns << "\n";
     output << inner << "},\n";
+    output << inner << "\"measurement_error\": {\n";
+    output << inner << "  \"psr_sigma_m\": " << config.measurement_error.psr_sigma_m << ",\n";
+    output << inner << "  \"doppler_sigma_mps\": " << config.measurement_error.doppler_sigma_mps << ",\n";
+    output << inner << "  \"adr_sigma_m\": " << config.measurement_error.adr_sigma_m << ",\n";
+    output << inner << "  \"cn0_sigma_dbhz\": " << config.measurement_error.cn0_sigma_dbhz << ",\n";
+    output << inner << "  \"psr_correlation_tau_sec\": " << config.measurement_error.psr_correlation_tau_sec << ",\n";
+    output << inner << "  \"ttff_hot\": {\"psr_extra_sigma_m\": " << config.measurement_error.ttff_hot.psr_extra_sigma_m
+           << ", \"doppler_extra_sigma_mps\": " << config.measurement_error.ttff_hot.doppler_extra_sigma_mps
+           << ", \"cn0_extra_sigma_dbhz\": " << config.measurement_error.ttff_hot.cn0_extra_sigma_dbhz
+           << ", \"decay_tau_sec\": " << config.measurement_error.ttff_hot.decay_tau_sec << "},\n";
+    output << inner
+           << "  \"ttff_warm\": {\"psr_extra_sigma_m\": " << config.measurement_error.ttff_warm.psr_extra_sigma_m
+           << ", \"doppler_extra_sigma_mps\": " << config.measurement_error.ttff_warm.doppler_extra_sigma_mps
+           << ", \"cn0_extra_sigma_dbhz\": " << config.measurement_error.ttff_warm.cn0_extra_sigma_dbhz
+           << ", \"decay_tau_sec\": " << config.measurement_error.ttff_warm.decay_tau_sec << "},\n";
+    output << inner
+           << "  \"ttff_cold\": {\"psr_extra_sigma_m\": " << config.measurement_error.ttff_cold.psr_extra_sigma_m
+           << ", \"doppler_extra_sigma_mps\": " << config.measurement_error.ttff_cold.doppler_extra_sigma_mps
+           << ", \"cn0_extra_sigma_dbhz\": " << config.measurement_error.ttff_cold.cn0_extra_sigma_dbhz
+           << ", \"decay_tau_sec\": " << config.measurement_error.ttff_cold.decay_tau_sec << "},\n";
+    output << inner << "  \"rea_reacquisition\": {\"psr_extra_sigma_m\": "
+           << config.measurement_error.rea_reacquisition.psr_extra_sigma_m
+           << ", \"doppler_extra_sigma_mps\": " << config.measurement_error.rea_reacquisition.doppler_extra_sigma_mps
+           << ", \"cn0_extra_sigma_dbhz\": " << config.measurement_error.rea_reacquisition.cn0_extra_sigma_dbhz
+           << ", \"decay_tau_sec\": " << config.measurement_error.rea_reacquisition.decay_tau_sec << "},\n";
+    output << inner << "  \"rea_fade\": {\"duration_sec\": " << config.measurement_error.rea_fade.duration_sec
+           << ", \"psr_extra_sigma_m\": " << config.measurement_error.rea_fade.psr_extra_sigma_m
+           << ", \"doppler_extra_sigma_mps\": " << config.measurement_error.rea_fade.doppler_extra_sigma_mps
+           << ", \"cn0_drop_db\": " << config.measurement_error.rea_fade.cn0_drop_db << "}\n";
+    output << inner << "},\n";
     output << inner << "\"seed\": " << config.seed << "\n";
     output << pad << '}';
     return output.str();

--- a/tests/integration/test_measurement_noise_integration.cpp
+++ b/tests/integration/test_measurement_noise_integration.cpp
@@ -1,0 +1,217 @@
+#include "gnss_sim/sim_config.h"
+#include "gnss_sim/sim_time.h"
+#include "gnss_sim/simulator.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct RangeEpoch {
+    int observation_count;
+    std::vector<double> valid_pseudoranges_m;
+};
+
+std::string nav_path() {
+    return std::string(GNSS_SIM_TEST_DATA_DIR) + "/gps_loopback_nav.rnx";
+}
+
+gnss_sim::SimTime start_time() {
+    gnss_sim::SimTime time{};
+    EXPECT_TRUE(gnss_sim::sim_time_from_week_sow(2253, 172900.0, &time));
+    return time;
+}
+
+std::string read_file(const std::filesystem::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    return std::string((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
+}
+
+std::vector<std::string> split_csv(const std::string& text) {
+    std::vector<std::string> fields;
+    std::stringstream stream(text);
+    std::string field;
+    while (std::getline(stream, field, ',')) {
+        fields.push_back(field);
+    }
+    return fields;
+}
+
+std::vector<RangeEpoch> read_range_epochs(const std::filesystem::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    std::vector<RangeEpoch> epochs;
+    std::string line;
+    while (std::getline(input, line)) {
+        if (line.rfind("#RANGEA,", 0) != 0) {
+            continue;
+        }
+        const std::size_t semicolon = line.find(';');
+        const std::size_t star = line.rfind('*');
+        if (semicolon == std::string::npos || star == std::string::npos || star <= semicolon + 1U) {
+            continue;
+        }
+        const std::vector<std::string> fields = split_csv(line.substr(semicolon + 1U, star - semicolon - 1U));
+        if (fields.empty()) {
+            continue;
+        }
+        RangeEpoch epoch{};
+        epoch.observation_count = std::stoi(fields[0]);
+        if (fields.size() != 1U + static_cast<std::size_t>(epoch.observation_count) * 10U) {
+            continue;
+        }
+        for (int index = 0; index < epoch.observation_count; ++index) {
+            const std::size_t base = 1U + static_cast<std::size_t>(index) * 10U;
+            const unsigned long status = std::stoul(fields[base + 9U], nullptr, 16);
+            if ((status & (1UL << 12U)) != 0UL) {
+                epoch.valid_pseudoranges_m.push_back(std::stod(fields[base + 2U]));
+            }
+        }
+        epochs.push_back(epoch);
+    }
+    return epochs;
+}
+
+bool run_case(const std::filesystem::path& directory, const gnss_sim::SimConfig& config,
+              gnss_sim::SimulatorRunSummary* summary, std::string* error_message) {
+    std::error_code error;
+    std::filesystem::remove_all(directory, error);
+    error.clear();
+    if (!std::filesystem::create_directories(directory, error) || error) {
+        if (error_message != nullptr) {
+            *error_message = "cannot create measurement-noise integration directory";
+        }
+        return false;
+    }
+    const std::string input = nav_path();
+    const std::string output = (directory / "simulated.log").string();
+    const gnss_sim::SimulatorRunOptions options{input.c_str(), output.c_str(), start_time()};
+    return gnss_sim::run_simulator(config, options, summary, error_message);
+}
+
+void cleanup(const std::filesystem::path& path) {
+    std::error_code error;
+    std::filesystem::remove_all(path, error);
+}
+
+bool any_valid_psr_difference(const std::vector<RangeEpoch>& baseline, const std::vector<RangeEpoch>& noisy,
+                              std::size_t begin_epoch, std::size_t end_epoch, double minimum_difference_m) {
+    const std::size_t limit = std::min({baseline.size(), noisy.size(), end_epoch});
+    for (std::size_t epoch_index = begin_epoch; epoch_index < limit; ++epoch_index) {
+        const std::size_t observation_count =
+            std::min(baseline[epoch_index].valid_pseudoranges_m.size(), noisy[epoch_index].valid_pseudoranges_m.size());
+        for (std::size_t observation_index = 0; observation_index < observation_count; ++observation_index) {
+            if (std::fabs(baseline[epoch_index].valid_pseudoranges_m[observation_index] -
+                          noisy[epoch_index].valid_pseudoranges_m[observation_index]) >= minimum_difference_m) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+gnss_sim::SimConfig ttff_config(bool noise_enabled) {
+    gnss_sim::SimConfig config = gnss_sim::default_sim_config();
+    config.scenario = gnss_sim::ScenarioType::TTFF;
+    config.ttff.startup_mode = gnss_sim::StartupMode::HOT;
+    config.ttff.power_on_ns = 8LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    config.ttff.power_off_ns = 1LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    config.duration_ns = 5LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    config.sampling_rate_hz = 10;
+    config.elevation_mask_deg = 0.0;
+    config.atmosphere_mode = gnss_sim::AtmosphereMode::NONE;
+    config.measurement_noise_enabled = noise_enabled;
+    config.measurement_error.psr_sigma_m = 0.0;
+    config.measurement_error.doppler_sigma_mps = 0.0;
+    config.measurement_error.adr_sigma_m = 0.0;
+    config.measurement_error.cn0_sigma_dbhz = 0.0;
+    config.measurement_error.ttff_hot = {5.0, 0.0, 0.0, 10.0};
+    config.seed = 117U;
+    return config;
+}
+
+gnss_sim::SimConfig rea_config(bool noise_enabled) {
+    gnss_sim::SimConfig config = gnss_sim::default_sim_config();
+    config.scenario = gnss_sim::ScenarioType::REA;
+    config.rea.signal_on_ns = 4LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    config.rea.signal_off_ns = 1LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    config.duration_ns = 9LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    config.sampling_rate_hz = 10;
+    config.elevation_mask_deg = 0.0;
+    config.atmosphere_mode = gnss_sim::AtmosphereMode::NONE;
+    config.measurement_noise_enabled = noise_enabled;
+    config.measurement_error.psr_sigma_m = 0.0;
+    config.measurement_error.doppler_sigma_mps = 0.0;
+    config.measurement_error.adr_sigma_m = 0.0;
+    config.measurement_error.cn0_sigma_dbhz = 0.0;
+    config.measurement_error.rea_reacquisition = {5.0, 0.0, 0.0, 10.0};
+    config.seed = 117U;
+    return config;
+}
+
+TEST(MeasurementNoiseIntegration, TtffNoiseChangesReportedRangeButNotZeroNoiseTruthOrAcquisition) {
+    const std::filesystem::path baseline_directory = "gnss_sim_ttff_noise_off";
+    const std::filesystem::path noisy_directory = "gnss_sim_ttff_noise_on";
+    gnss_sim::SimulatorRunSummary baseline_summary{};
+    gnss_sim::SimulatorRunSummary noisy_summary{};
+    std::string error_message;
+    ASSERT_TRUE(run_case(baseline_directory, ttff_config(false), &baseline_summary, &error_message)) << error_message;
+    ASSERT_TRUE(run_case(noisy_directory, ttff_config(true), &noisy_summary, &error_message)) << error_message;
+
+    EXPECT_EQ(read_file(baseline_directory / "event_truth.csv"), read_file(noisy_directory / "event_truth.csv"));
+    EXPECT_EQ(read_file(baseline_directory / "observation_truth.csv"),
+              read_file(noisy_directory / "observation_truth.csv"));
+
+    const std::vector<RangeEpoch> baseline = read_range_epochs(baseline_directory / "simulated.log");
+    const std::vector<RangeEpoch> noisy = read_range_epochs(noisy_directory / "simulated.log");
+    ASSERT_EQ(baseline.size(), noisy.size());
+    ASSERT_FALSE(baseline.empty());
+    EXPECT_TRUE(any_valid_psr_difference(baseline, noisy, 0U, noisy.size(), 0.001));
+
+    const std::string manifest = read_file(noisy_directory / "run_manifest.json");
+    EXPECT_NE(manifest.find("\"measurement_noise_enabled\": true"), std::string::npos);
+    EXPECT_NE(manifest.find("\"measurement_error\": {"), std::string::npos);
+    EXPECT_NE(manifest.find("\"psr_sigma_m\": 0"), std::string::npos);
+    EXPECT_NE(manifest.find("\"psr_extra_sigma_m\": 5"), std::string::npos);
+
+    cleanup(baseline_directory);
+    cleanup(noisy_directory);
+}
+
+TEST(MeasurementNoiseIntegration, ReaReacquisitionNoiseStartsOnlyAfterSignalReturnsAndOffWindowIsEmpty) {
+    const std::filesystem::path baseline_directory = "gnss_sim_rea_noise_off";
+    const std::filesystem::path noisy_directory = "gnss_sim_rea_noise_on";
+    gnss_sim::SimulatorRunSummary baseline_summary{};
+    gnss_sim::SimulatorRunSummary noisy_summary{};
+    std::string error_message;
+    ASSERT_TRUE(run_case(baseline_directory, rea_config(false), &baseline_summary, &error_message)) << error_message;
+    ASSERT_TRUE(run_case(noisy_directory, rea_config(true), &noisy_summary, &error_message)) << error_message;
+
+    EXPECT_EQ(read_file(baseline_directory / "event_truth.csv"), read_file(noisy_directory / "event_truth.csv"));
+    EXPECT_EQ(read_file(baseline_directory / "observation_truth.csv"),
+              read_file(noisy_directory / "observation_truth.csv"));
+
+    const std::vector<RangeEpoch> baseline = read_range_epochs(baseline_directory / "simulated.log");
+    const std::vector<RangeEpoch> noisy = read_range_epochs(noisy_directory / "simulated.log");
+    ASSERT_EQ(baseline.size(), 90U);
+    ASSERT_EQ(noisy.size(), baseline.size());
+
+    for (std::size_t epoch = 40U; epoch < 50U; ++epoch) {
+        EXPECT_EQ(baseline[epoch].observation_count, 0) << epoch;
+        EXPECT_EQ(noisy[epoch].observation_count, 0) << epoch;
+    }
+
+    EXPECT_FALSE(any_valid_psr_difference(baseline, noisy, 0U, 40U, 0.001));
+    EXPECT_TRUE(any_valid_psr_difference(baseline, noisy, 50U, 90U, 0.001));
+
+    cleanup(baseline_directory);
+    cleanup(noisy_directory);
+}
+
+} // namespace

--- a/tests/unit/test_sim_config.cpp
+++ b/tests/unit/test_sim_config.cpp
@@ -175,13 +175,49 @@ TEST_F(SimConfigTest, RejectsInvalidMeasurementErrorConfiguration) {
     EXPECT_NE(error_message.find("measurement_error"), std::string::npos);
 }
 
-TEST_F(SimConfigTest, MeasurementNoiseMasterSwitchRemainsRejectedUntilIntegration) {
+TEST_F(SimConfigTest, MeasurementNoiseMasterSwitchIsAcceptedAfterIntegration) {
     write_test_config(R"json({"measurement_noise_enabled":true})json");
 
     gnss_sim::SimConfig config{};
     std::string error_message;
-    EXPECT_FALSE(gnss_sim::load_sim_config_json(TEST_CONFIG_PATH, &config, &error_message));
-    EXPECT_NE(error_message.find("measurement noise is not supported"), std::string::npos);
+    ASSERT_TRUE(gnss_sim::load_sim_config_json(TEST_CONFIG_PATH, &config, &error_message)) << error_message;
+    EXPECT_TRUE(config.measurement_noise_enabled);
+}
+
+TEST_F(SimConfigTest, TtffDefaultsMeasurementNoiseOnWhenFlagIsOmitted) {
+    write_test_config(R"json({"scenario":"TTFF"})json");
+
+    gnss_sim::SimConfig config{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::load_sim_config_json(TEST_CONFIG_PATH, &config, &error_message)) << error_message;
+    EXPECT_TRUE(config.measurement_noise_enabled);
+}
+
+TEST_F(SimConfigTest, ReaDefaultsMeasurementNoiseOnWhenFlagIsOmitted) {
+    write_test_config(R"json({"scenario":"REA"})json");
+
+    gnss_sim::SimConfig config{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::load_sim_config_json(TEST_CONFIG_PATH, &config, &error_message)) << error_message;
+    EXPECT_TRUE(config.measurement_noise_enabled);
+}
+
+TEST_F(SimConfigTest, KsKeepsMeasurementNoiseOffWhenFlagIsOmitted) {
+    write_test_config(R"json({"scenario":"KS"})json");
+
+    gnss_sim::SimConfig config{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::load_sim_config_json(TEST_CONFIG_PATH, &config, &error_message)) << error_message;
+    EXPECT_FALSE(config.measurement_noise_enabled);
+}
+
+TEST_F(SimConfigTest, ExplicitFalseOverridesTtffMeasurementNoiseDefault) {
+    write_test_config(R"json({"scenario":"TTFF","measurement_noise_enabled":false})json");
+
+    gnss_sim::SimConfig config{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::load_sim_config_json(TEST_CONFIG_PATH, &config, &error_message)) << error_message;
+    EXPECT_FALSE(config.measurement_noise_enabled);
 }
 
 } // namespace


### PR DESCRIPTION
Closes #72
Parent: #70
Depends on: #71 / PR #75

## What changed

- Wires `measurement_error_model` into the simulator after zero-noise truth generation.
- Keeps `observation_truth.csv` on the physical zero-noise observation.
- Copies the truth observation, applies deterministic receiver measurement error, then pushes that single reported object into the shared `measurements` vector consumed by both RTKLIB and RANGEA.
- Enables `measurement_noise_enabled=true` now that the data path is complete.
- JSON configs that select `TTFF` or `REA` and omit `measurement_noise_enabled` now default the receiver-grade error model ON; `KS` remains OFF by default, and an explicit boolean always overrides the scenario default.
- Selects TTFF HOT/WARM/COLD startup transient profiles from the existing acquisition context without changing acquisition timing.
- Applies the REA reacquisition transient only after an actual REA reacquisition lock; initial REA signal-on remains stable-noise context.
- TTFF in-run signal reacquisition is not mislabeled as REA and therefore falls back to stable noise in this issue.
- Reuses the existing `tracking_start_time` lock identity so correlated PSR state and ADR-related per-lock error state reset across signal loss/reacquisition.
- Adds the complete `measurement_error` configuration to `resolved_config` in truth manifests for deterministic replay.
- Adds integration coverage for TTFF and REA noise wiring plus parser coverage for implicit scenario defaults and explicit override.

## Data-path contract

```text
real RINEX NAV -> zero-noise MeasurementObservation
                       |-> observation_truth.csv
                       `-> copy -> measurement_error_model
                                   `-> shared reported observation
                                       |-> RTKLIB solution
                                       `-> RANGEA
```

RANGEA and RTKLIB therefore receive the same modified observation values; truth remains noise-free.

## Regression coverage

- noise on/off with the same seed preserves scenario/acquisition truth;
- TTFF startup produces modified reported pseudorange while truth remains unchanged;
- REA first signal-on is not mislabeled as reacquisition;
- REA signal-off epochs emit zero RANGE observations;
- REA post-loss reacquisition receives a new transient/error state;
- TTFF/REA omitted master switch defaults ON, KS omitted switch defaults OFF, and explicit false overrides TTFF default;
- resolved manifests contain the full error-model parameters.

## Non-goals

- No pre-loss REA fade; #73 owns that work.
- No multipath.
- No EPH/NAV scheduling changes.
- No synthetic ephemeris; all navigation truth remains real RINEX NAV.

## Implementation Notes

This is intentionally a stacked PR on PR #75 so #71 and #72 remain one-Issue/one-PR. After #75 is merged, this PR can be retargeted to `main` without changing its implementation scope.

Full format, tooling, Ubuntu and Windows CI must pass before merge.