### PR TITLE
Add black-box TTFF/REA transient observation validation

### DIFF
--- a/.github/workflows/transient-validation-extended.yml
+++ b/.github/workflows/transient-validation-extended.yml
@@ -1,0 +1,293 @@
+name: TTFF and REA transient extended validation
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 19 1 * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: transient-validation-extended-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  real-whu-transients:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout with pinned dependencies
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Configure release build
+        run: cmake -S . -B build -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build simulator and validators
+        run: cmake --build build --config Release --parallel
+
+      - name: Download pinned real WHU RINEX NAV
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .cache/igs
+          compressed=".cache/igs/BRD400DLR_S_20250030000_01D_MN.rnx.gz"
+          nav=".cache/igs/BRD400DLR_S_20250030000_01D_MN.rnx"
+          expected_compressed="fb84d4046b06e905e8e4ec0efb82f0e9ad044bc44d664cc0209cb9b4c92b9512"
+          expected_uncompressed="b11c638eea42978b8bd6aa8b65a5099fe6556dfe527bc037ed481d2b239afc42"
+          sources=(
+            "ftp://igs.gnsswhu.cn/pub/gps/data/daily/2025/brdc/BRD400DLR_S_20250030000_01D_MN.rnx.gz"
+            "http://igs.gnsswhu.cn/pub/gps/data/daily/2025/brdc/BRD400DLR_S_20250030000_01D_MN.rnx.gz"
+          )
+          downloaded=0
+          for url in "${sources[@]}"; do
+            echo "Downloading ${url}"
+            rm -f "$compressed" "$nav"
+            if curl --fail --location --retry 3 --retry-delay 2 --connect-timeout 20 --max-time 300 \
+              "$url" --output "$compressed"; then
+              compressed_sha="$(sha256sum "$compressed" | awk '{print $1}')"
+              if [[ "$compressed_sha" != "$expected_compressed" ]]; then
+                echo "Compressed SHA256 mismatch: ${compressed_sha}" >&2
+                continue
+              fi
+              gzip -dc "$compressed" > "$nav"
+              uncompressed_sha="$(sha256sum "$nav" | awk '{print $1}')"
+              if [[ "$uncompressed_sha" != "$expected_uncompressed" ]]; then
+                echo "Uncompressed SHA256 mismatch: ${uncompressed_sha}" >&2
+                continue
+              fi
+              downloaded=1
+              break
+            fi
+          done
+          if [[ "$downloaded" -ne 1 ]]; then
+            echo "Unable to obtain pinned real WHU RINEX NAV." >&2
+            exit 1
+          fi
+
+      - name: Create deterministic scenario configs
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p extended-results/transients
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          root = Path("extended-results/transients")
+          cases = [
+              ("TTFF_HOT", "TTFF", "HOT", 35, 40, 2, 300, 10, 0.0, 74011),
+              ("TTFF_WARM", "TTFF", "WARM", 60, 65, 2, 300, 10, 0.0, 74012),
+              ("TTFF_COLD", "TTFF", "COLD", 120, 125, 2, 300, 10, 0.0, 74013),
+              ("REA_HARD", "REA", "HOT", 35, 300, 30, 8, 2, 0.0, 74014),
+              ("REA_FADE", "REA", "HOT", 35, 300, 30, 8, 2, 0.25, 74015),
+          ]
+          for label, scenario, startup, duration, power_on, power_off, signal_on, signal_off, fade, seed in cases:
+              directory = root / label
+              directory.mkdir(parents=True, exist_ok=True)
+              config = {
+                  "schema_version": 1,
+                  "scenario": scenario,
+                  "duration_sec": duration,
+                  "sampling_rate_hz": 10,
+                  "elevation_mask_deg": 3.0,
+                  "solution_elevation_mask_deg": 5.0,
+                  "output_eph": False,
+                  "output_ion": False,
+                  "multipath_enabled": False,
+                  "receiver_clock_bias_m": 0.0,
+                  "receiver_clock_drift_mps": 0.0,
+                  "atmosphere_mode": "broadcast",
+                  "receiver": {"latitude_deg": 20.0, "longitude_deg": 120.0, "height_m": 100.0},
+                  "ttff": {"startup_mode": startup, "power_on_sec": power_on, "power_off_sec": power_off},
+                  "rea": {"signal_on_sec": signal_on, "signal_off_sec": signal_off},
+                  "measurement_error": {"rea_fade": {"duration_sec": fade}},
+                  "seed": seed,
+              }
+              (directory / "config.json").write_text(json.dumps(config, indent=2) + "\n")
+          PY
+
+      - name: Generate and validate all transient cases
+        shell: bash
+        run: |
+          set -euo pipefail
+          nav=".cache/igs/BRD400DLR_S_20250030000_01D_MN.rnx"
+          for label in TTFF_HOT TTFF_WARM TTFF_COLD REA_HARD REA_FADE; do
+            case_dir="extended-results/transients/${label}"
+            fade="0"
+            if [[ "$label" == "REA_FADE" ]]; then fade="0.25"; fi
+            build/gnss-data-simulator \
+              --config "${case_dir}/config.json" \
+              --nav "$nav" \
+              --output "${case_dir}/simulated.log" \
+              --week 2347 \
+              --sow 436500
+            build/validate-transient-observations \
+              --log "${case_dir}/simulated.log" \
+              --truth "${case_dir}/observation_truth.csv" \
+              --events "${case_dir}/event_truth.csv" \
+              --nav "$nav" \
+              --scenario "$label" \
+              --fade-duration "$fade" \
+              --output "${case_dir}/transient_summary.json" \
+              --truth-lat 20 \
+              --truth-lon 120 \
+              --truth-height 100 \
+              --elevation-mask 5 \
+              --broadcast-atmosphere \
+              | tee "${case_dir}/validator.txt"
+          done
+
+      - name: Enforce extended statistical gates
+        shell: bash
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          root = Path("extended-results/transients")
+          labels = ["TTFF_HOT", "TTFF_WARM", "TTFF_COLD", "REA_HARD", "REA_FADE"]
+          summaries = {label: json.loads((root / label / "transient_summary.json").read_text()) for label in labels}
+          failures = []
+
+          def metric(data, window, name):
+              return data["windows"][window][name]
+
+          for label in labels:
+              data = summaries[label]
+              if data["matched_observations"] <= 0:
+                  failures.append(f"{label}: no matched observations")
+              if data["unmatched_observations"] != 0:
+                  failures.append(f"{label}: unmatched observations={data['unmatched_observations']}")
+              if data["positioning"]["valid_position_epochs"] <= 0:
+                  failures.append(f"{label}: no valid RTKLIB SPP epoch")
+              if not data["positioning"]["final_position_error_m"] < 5.0:
+                  failures.append(
+                      f"{label}: final SPP error {data['positioning']['final_position_error_m']} m is not < 5 m"
+                  )
+
+          for label in ["TTFF_HOT", "TTFF_WARM", "TTFF_COLD"]:
+              data = summaries[label]
+              early_psr = metric(data, "early_0_1s", "pseudorange_m")
+              recovery_psr = metric(data, "recovery_1_3s", "pseudorange_m")
+              settled_psr = metric(data, "settled_ge_3s", "pseudorange_m")
+              early_doppler = metric(data, "early_0_1s", "doppler_mps")
+              recovery_doppler = metric(data, "recovery_1_3s", "doppler_mps")
+              settled_doppler = metric(data, "settled_ge_3s", "doppler_mps")
+              early_cn0 = metric(data, "early_0_1s", "cn0_dbhz")
+              recovery_cn0 = metric(data, "recovery_1_3s", "cn0_dbhz")
+              settled_cn0 = metric(data, "settled_ge_3s", "cn0_dbhz")
+              settled_adr = metric(data, "settled_ge_3s", "adr_m")
+              if (
+                  early_psr["sample_count"] == 0
+                  or recovery_psr["sample_count"] == 0
+                  or settled_psr["sample_count"] == 0
+              ):
+                  failures.append(f"{label}: missing early, recovery, or settled PSR samples")
+              elif not early_psr["rms"] > recovery_psr["rms"] > settled_psr["rms"]:
+                  failures.append(f"{label}: PSR RMS did not decay through early > recovery > settled")
+              if (
+                  early_doppler["sample_count"] == 0
+                  or recovery_doppler["sample_count"] == 0
+                  or settled_doppler["sample_count"] == 0
+              ):
+                  failures.append(f"{label}: missing early, recovery, or settled Doppler samples")
+              elif not early_doppler["rms"] > recovery_doppler["rms"] > settled_doppler["rms"]:
+                  failures.append(f"{label}: Doppler RMS did not decay through early > recovery > settled")
+              if (
+                  early_cn0["sample_count"] == 0
+                  or recovery_cn0["sample_count"] == 0
+                  or settled_cn0["sample_count"] == 0
+              ):
+                  failures.append(f"{label}: missing early, recovery, or settled CN0 samples")
+              elif not early_cn0["rms"] > recovery_cn0["rms"] > settled_cn0["rms"]:
+                  failures.append(f"{label}: CN0 RMS did not decay through early > recovery > settled")
+              if not settled_psr["rms"] < 0.25:
+                  failures.append(f"{label}: settled PSR RMS {settled_psr['rms']} m is not < 0.25 m")
+              if not settled_doppler["rms"] < 0.10:
+                  failures.append(
+                      f"{label}: settled Doppler RMS {settled_doppler['rms']} m/s is not < 0.10 m/s"
+                  )
+              if settled_adr["sample_count"] == 0 or not settled_adr["rms"] < 0.005:
+                  failures.append(f"{label}: settled ADR RMS is missing or not < 0.005 m")
+
+          for label in ["REA_HARD", "REA_FADE"]:
+              data = summaries[label]
+              rea = data["rea"]
+              if rea["signal_off_range_epochs"] <= 0:
+                  failures.append(f"{label}: no serialized RANGEA signal-off epochs")
+              if rea["signal_off_nonzero_epochs"] != 0:
+                  failures.append(f"{label}: fabricated observations during signal-off")
+              if rea["reacquisition_cycles"] < 2:
+                  failures.append(f"{label}: expected at least two reacquisition cycles")
+              if rea["ambiguity_pairs_checked"] <= 0 or rea["ambiguity_pairs_changed"] != rea["ambiguity_pairs_checked"]:
+                  failures.append(f"{label}: ADR ambiguity did not reset for every comparable signal")
+              if not rea["max_first_psr_delay_sec"] < 4.0:
+                  failures.append(f"{label}: first PSR recovery delay >= 4 s")
+              if not rea["max_first_doppler_delay_sec"] < 4.0:
+                  failures.append(f"{label}: first Doppler recovery delay >= 4 s")
+              if not rea["max_first_adr_delay_sec"] < 4.5:
+                  failures.append(f"{label}: first ADR recovery delay >= 4.5 s")
+              early = metric(data, "rea_reacquisition_early_0_1s", "pseudorange_m")
+              settled = metric(data, "rea_reacquisition_settled_ge_3s", "pseudorange_m")
+              if early["sample_count"] == 0 or settled["sample_count"] == 0:
+                  failures.append(f"{label}: missing reacquisition early or settled PSR samples")
+              elif not early["rms"] > settled["rms"]:
+                  failures.append(f"{label}: reacquisition early PSR RMS did not exceed settled RMS")
+
+          hard_fade = metric(summaries["REA_HARD"], "rea_fade", "pseudorange_m")
+          if hard_fade["sample_count"] != 0:
+              failures.append("REA_HARD: fade window unexpectedly contains samples")
+          fade_cn0 = metric(summaries["REA_FADE"], "rea_fade", "cn0_dbhz")
+          if fade_cn0["sample_count"] == 0:
+              failures.append("REA_FADE: fade window contains no samples")
+          elif not fade_cn0["mean"] < -0.10:
+              failures.append(f"REA_FADE: mean CN0 delta {fade_cn0['mean']} dB does not show degradation")
+
+          aggregate = {
+              "cases": {
+                  label: {
+                      "matched_observations": summaries[label]["matched_observations"],
+                      "max_position_error_m": summaries[label]["positioning"]["max_position_error_m"],
+                      "final_position_error_m": summaries[label]["positioning"]["final_position_error_m"],
+                      "settled_psr_rms_m": metric(summaries[label], "settled_ge_3s", "pseudorange_m")["rms"],
+                      "settled_doppler_rms_mps": metric(summaries[label], "settled_ge_3s", "doppler_mps")["rms"],
+                  }
+                  for label in labels
+              },
+              "failures": failures,
+          }
+          (root / "extended_summary.json").write_text(json.dumps(aggregate, indent=2, sort_keys=True) + "\n")
+          if failures:
+              raise SystemExit("\n".join(failures))
+          PY
+
+      - name: Publish step summary
+        if: always()
+        shell: bash
+        run: |
+          echo "# Real-WHU TTFF/REA transient validation" >> "$GITHUB_STEP_SUMMARY"
+          echo >> "$GITHUB_STEP_SUMMARY"
+          if [[ -f extended-results/transients/extended_summary.json ]]; then
+            echo '```json' >> "$GITHUB_STEP_SUMMARY"
+            cat extended-results/transients/extended_summary.json >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No aggregate summary was produced." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: transient-real-whu-${{ github.run_id }}
+          path: |
+            extended-results/transients/*/config.json
+            extended-results/transients/*/run_manifest.json
+            extended-results/transients/*/transient_summary.json
+            extended-results/transients/*/validator.txt
+            extended-results/transients/extended_summary.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,23 @@ add_executable(validate-rangea-roundtrip
 target_link_libraries(validate-rangea-roundtrip PRIVATE rangea_roundtrip_core)
 gnss_sim_set_project_warnings(validate-rangea-roundtrip)
 
+add_library(transient_validator_core STATIC
+    tools/transient_validator/transient_validator.cpp
+)
+target_include_directories(transient_validator_core
+    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/tools/transient_validator"
+)
+target_link_libraries(transient_validator_core
+    PUBLIC rangea_roundtrip_core
+)
+gnss_sim_set_project_warnings(transient_validator_core)
+
+add_executable(validate-transient-observations
+    tools/transient_validator/main.cpp
+)
+target_link_libraries(validate-transient-observations PRIVATE transient_validator_core)
+gnss_sim_set_project_warnings(validate-transient-observations)
+
 if(BUILD_TESTING)
     include(FetchContent)
 
@@ -250,6 +267,7 @@ if(BUILD_TESTING)
         tests/integration/test_measurement_noise_integration.cpp
         tests/integration/test_rea_fade.cpp
         tests/integration/test_rangea_roundtrip.cpp
+        tests/integration/test_transient_validator.cpp
         tests/integration/test_residual_validator.cpp
         tests/integration/test_truth_outputs.cpp
         tests/integration/test_v1_acceptance.cpp
@@ -263,6 +281,7 @@ if(BUILD_TESTING)
         gnss_sim::rtklib
         residual_validator_core
         rangea_roundtrip_core
+        transient_validator_core
         GTest::gtest_main
     )
     gnss_sim_set_project_warnings(gnss_sim_integration_tests)

--- a/docs/TTFF_REA_TRANSIENT_VALIDATION.md
+++ b/docs/TTFF_REA_TRANSIENT_VALIDATION.md
@@ -1,0 +1,152 @@
+# TTFF / REA transient black-box validation
+
+## Purpose
+
+`validate-transient-observations` validates receiver-grade TTFF and REA observation transients from serialized receiver output. It intentionally does not use the simulator's in-memory `MeasurementObservation` objects as the acceptance path.
+
+The contract is:
+
+```text
+real RINEX NAV
+    -> simulator
+    -> zero-noise observation_truth.csv
+    -> serialized simulated.log / #RANGEA
+
+observation_truth.csv -------------------+
+                                         |
+serialized #RANGEA -> independent parser +-> GPST/satellite/signal matching
+                                             -> error statistics
+                                             -> TTFF/REA timing checks
+                                             -> REA loss/recovery checks
+
+serialized #RANGEA -> independent parser -> RTKLIB pntpos()
+                                             -> transient peak position error
+                                             -> final recovered position error
+```
+
+Navigation truth must come from real RINEX NAV. The validator does not generate, repair, interpolate, or fabricate ephemeris records.
+
+## Statistics
+
+For pseudorange, Doppler converted to range-rate, ADR converted to metres, and reported CN0, the JSON summary contains:
+
+- sample count;
+- mean error;
+- RMS;
+- population standard deviation;
+- P50 absolute error;
+- P95 absolute error;
+- maximum absolute error.
+
+The normal lock-time windows are:
+
+- `early_0_1s`: serialized observation lock time `< 1 s`;
+- `recovery_1_3s`: serialized observation lock time `1-3 s`;
+- `settled_ge_3s`: serialized observation lock time `>= 3 s`.
+
+The JSON also reports top-level `first_valid` delays for pseudorange, Doppler, ADR, and CN0. REA additionally reports pre-loss fade, reacquisition early/recovery/settled windows, zero-observation signal-off epochs, signal-on recovery timing, the last serialized observation before signal-off, the first serialized observation after signal-on, and ADR ambiguity identity changes across the loss.
+
+## Matching and validity
+
+Serialized RANGEA records are parsed independently, including NovAtel CRC32, GPST, constellation, PRN, OEM7 signal type, pseudorange-valid status, ADR validity, Doppler value, CN0, and lock time. They are matched to `observation_truth.csv` by normalized GPST, satellite number, and canonical signal id.
+
+Pseudorange first-valid timing is derived from the serialized pseudorange-valid bit. ADR first-valid timing is derived from serialized phase/ADR validity bits. CN0 first-valid timing requires a serialized observation. The current RANGEA writer does not serialize an independent Doppler-valid bit; therefore Doppler first-valid timing requires both a matched serialized observation and the zero-noise truth Doppler-valid state for that exact epoch/satellite/signal. This limitation is explicit and must not be mistaken for an independently encoded Doppler validity flag.
+
+`observation_truth.csv` remains the zero-noise reference for error magnitude and ADR ambiguity identity. Serialized RANGEA establishes whether the observation actually exists and carries the measured value. The integer ambiguity identity itself is not recoverable from RANGEA, so the pre-loss/post-reacquisition "fresh ambiguity" check compares truth ambiguity metadata for signals that are independently proven to exist in the black-box validation path.
+
+## Position recovery semantics
+
+The round-trip SPP path uses the complete real RINEX NAV store, the independently parsed serialized RANGEA code observations, RTKLIB `pntpos()`, and the normal 5 degree solution elevation mask.
+
+Two position metrics are retained:
+
+- `max_position_error_m`: the largest error over every valid SPP epoch, including intended TTFF/REA transient epochs;
+- `final_position_error_m`: the last valid SPP epoch, used to verify recovery.
+
+This distinction is intentional. Transient acquisition/reacquisition epochs can produce substantially larger SPP errors than the settled solution. Those peaks are retained as evidence rather than hidden by tuning the observations or loosening the statistic. Acceptance requires the final valid SPP epoch to recover below 5 m; it does not cap the transient maximum.
+
+## Compact CI
+
+`TransientValidatorIntegration` uses the provenance-traceable real `tests/data/minimal/brd400dlr_rinex4_acceptance_nav.rnx` fixture at GPST week 2347 / sow 436500.
+
+The compact tests cover TTFF HOT and REA fade/reacquisition. They require:
+
+- serialized/truth matching without unmatched observations;
+- TTFF pseudorange, Doppler, and CN0 RMS to decay through `early > recovery > settled`;
+- survey-grade settled noise bounds;
+- empty RANGEA observations while REA signal is off;
+- bounded serialized first-valid and signal-on recovery timing;
+- fresh ADR ambiguity after reacquisition;
+- recovered RTKLIB SPP;
+- identical acquisition/reacquisition timing for the same seed when `measurement_noise_enabled` is toggled on and off.
+
+The compact tests deliberately use statistical/envelope assertions instead of exact stochastic sample values.
+
+## Extended real-WHU survey
+
+`.github/workflows/transient-validation-extended.yml` is a manual/monthly survey using the pinned real WHU navigation file:
+
+```text
+BRD400DLR_S_20250030000_01D_MN.rnx.gz
+```
+
+Pinned hashes:
+
+```text
+gzip SHA256:         fb84d4046b06e905e8e4ec0efb82f0e9ad044bc44d664cc0209cb9b4c92b9512
+uncompressed SHA256: b11c638eea42978b8bd6aa8b65a5099fe6556dfe527bc037ed481d2b239afc42
+```
+
+The extended survey covers TTFF HOT, WARM, COLD, REA hard-cut, and REA fade using fixed seeds. Each case writes a JSON summary and the workflow uploads summaries, manifests, and validator diagnostics.
+
+The final TTFF gates require pseudorange, Doppler, and CN0 RMS to decrease through all three windows, not merely between the endpoints:
+
+```text
+early_0_1s > recovery_1_3s > settled_ge_3s
+```
+
+### Pre-merge real-WHU result
+
+A full five-scenario survey was executed in GitHub Actions run `33230616700` using the pinned WHU file and both SHA256 checks. The run completed successfully. The observed TTFF envelopes also satisfy the final three-stage gate with wide margin:
+
+| Scenario | PSR RMS early -> recovery -> settled (m) | Doppler RMS early -> recovery -> settled (m/s) | Settled ADR RMS (m) | Max transient SPP error (m) |
+| --- | --- | --- | --- | --- |
+| TTFF HOT | 0.367038 -> 0.204716 -> 0.081367 | 0.064916 -> 0.034994 -> 0.030016 | 0.000993 | 2.547964 |
+| TTFF WARM | 0.442217 -> 0.278356 -> 0.081871 | 0.091114 -> 0.046890 -> 0.030073 | 0.000998 | 3.993733 |
+| TTFF COLD | 0.629439 -> 0.442173 -> 0.084113 | 0.117659 -> 0.066533 -> 0.030133 | 0.000999 | 5.550588 |
+
+The COLD transient maximum exceeds 5 m, which is acceptable by design because the recovery gate applies to `final_position_error_m`, not `max_position_error_m`.
+
+REA results from the same run:
+
+- hard-cut and fade each produced 60 serialized RANGEA signal-off epochs with zero non-empty observation epochs;
+- each case exercised 3 reacquisition cycles;
+- first recovered pseudorange, Doppler, and ADR delays were at most 0.2 s, 0.3 s, and 0.6 s respectively;
+- all 721 comparable pre-loss/post-reacquisition ambiguity identities changed in each REA case;
+- maximum transient SPP error was 15.671076 m for hard-cut and 7.238175 m for fade;
+- both cases passed the final recovered SPP `< 5 m` gate;
+- the fade case contained the expected finite pre-loss degradation window, while hard-cut had no fade-window samples.
+
+The artifact from that run is named `transient-real-whu-33230616700` and contains the per-case JSON summaries and diagnostics.
+
+## CLI example
+
+```bash
+validate-transient-observations \
+  --log run/simulated.log \
+  --truth run/observation_truth.csv \
+  --events run/event_truth.csv \
+  --nav BRD400DLR_S_20250030000_01D_MN.rnx \
+  --scenario REA_FADE \
+  --fade-duration 0.25 \
+  --output run/transient_summary.json \
+  --truth-lat 20 \
+  --truth-lon 120 \
+  --truth-height 100 \
+  --elevation-mask 5 \
+  --broadcast-atmosphere
+```
+
+## Non-goals
+
+The validator does not tune observations to force RTKLIB truth, simulate multipath/obstruction geometry, fabricate navigation data, or emulate receiver ephemeris acquisition order inside the black-box round-trip solver. Receiver-NAV acquisition timing remains a separate concern from this observation-error validation.

--- a/tests/integration/test_transient_validator.cpp
+++ b/tests/integration/test_transient_validator.cpp
@@ -1,0 +1,222 @@
+#include "gnss_sim/sim_config.h"
+#include "gnss_sim/sim_time.h"
+#include "gnss_sim/simulator.h"
+#include "transient_validator.h"
+
+#include <filesystem>
+#include <gtest/gtest.h>
+#include <string>
+
+namespace {
+
+std::string brd4_nav_path() {
+    return std::string(GNSS_SIM_TEST_DATA_DIR) + "/brd400dlr_rinex4_acceptance_nav.rnx";
+}
+
+gnss_sim::SimTime start_time() {
+    gnss_sim::SimTime time{};
+    EXPECT_TRUE(gnss_sim::sim_time_from_week_sow(2347, 436500.0, &time));
+    return time;
+}
+
+bool run_case(const std::filesystem::path& directory, const gnss_sim::SimConfig& config,
+              gnss_sim::TransientValidationSummary* validation, std::string* error_message) {
+    std::error_code error;
+    std::filesystem::remove_all(directory, error);
+    error.clear();
+    if (!std::filesystem::create_directories(directory, error) || error) {
+        if (error_message != nullptr) {
+            *error_message = "cannot create transient-validator integration directory";
+        }
+        return false;
+    }
+
+    const std::string nav = brd4_nav_path();
+    const std::string log = (directory / "simulated.log").string();
+    const gnss_sim::SimulatorRunOptions run_options{nav.c_str(), log.c_str(), start_time()};
+    gnss_sim::SimulatorRunSummary run_summary{};
+    if (!gnss_sim::run_simulator(config, run_options, &run_summary, error_message)) {
+        return false;
+    }
+
+    const std::string truth = (directory / "observation_truth.csv").string();
+    const std::string events = (directory / "event_truth.csv").string();
+    const char* scenario_label = config.scenario == gnss_sim::ScenarioType::TTFF ? "TTFF_HOT" : "REA_FADE";
+    const gnss_sim::TransientValidationOptions options{
+        scenario_label,
+        config.measurement_error.rea_fade.duration_sec,
+        config.receiver.latitude_deg,
+        config.receiver.longitude_deg,
+        config.receiver.height_m,
+        config.solution_elevation_mask_deg,
+        config.atmosphere_mode == gnss_sim::AtmosphereMode::BROADCAST,
+    };
+    return gnss_sim::validate_transient_observations_files(log.c_str(), truth.c_str(), events.c_str(), nav.c_str(),
+                                                           options, validation, error_message);
+}
+
+void cleanup(const std::filesystem::path& directory) {
+    std::error_code error;
+    std::filesystem::remove_all(directory, error);
+}
+
+void expect_same_first_valid_timing(const gnss_sim::FirstValidTimingStatistics& lhs,
+                                    const gnss_sim::FirstValidTimingStatistics& rhs) {
+    EXPECT_DOUBLE_EQ(lhs.pseudorange_delay_sec, rhs.pseudorange_delay_sec);
+    EXPECT_DOUBLE_EQ(lhs.doppler_delay_sec, rhs.doppler_delay_sec);
+    EXPECT_DOUBLE_EQ(lhs.adr_delay_sec, rhs.adr_delay_sec);
+    EXPECT_DOUBLE_EQ(lhs.cn0_delay_sec, rhs.cn0_delay_sec);
+}
+
+gnss_sim::SimConfig ttff_hot_config() {
+    gnss_sim::SimConfig config = gnss_sim::default_sim_config();
+    config.scenario = gnss_sim::ScenarioType::TTFF;
+    config.ttff.startup_mode = gnss_sim::StartupMode::HOT;
+    config.ttff.power_on_ns = 20LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    config.ttff.power_off_ns = 2LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    config.duration_ns = 12LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    config.sampling_rate_hz = 10;
+    config.elevation_mask_deg = 3.0;
+    config.solution_elevation_mask_deg = 5.0;
+    config.atmosphere_mode = gnss_sim::AtmosphereMode::BROADCAST;
+    config.measurement_noise_enabled = true;
+    config.seed = 7401U;
+    return config;
+}
+
+gnss_sim::SimConfig rea_fade_config() {
+    gnss_sim::SimConfig config = gnss_sim::default_sim_config();
+    config.scenario = gnss_sim::ScenarioType::REA;
+    config.rea.signal_on_ns = 5LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    config.rea.signal_off_ns = 2LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    config.duration_ns = 18LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    config.sampling_rate_hz = 10;
+    config.elevation_mask_deg = 3.0;
+    config.solution_elevation_mask_deg = 5.0;
+    config.atmosphere_mode = gnss_sim::AtmosphereMode::BROADCAST;
+    config.measurement_noise_enabled = true;
+    config.measurement_error.rea_fade.duration_sec = 0.25;
+    config.seed = 7402U;
+    return config;
+}
+
+TEST(TransientValidatorIntegration, RealWhuTtffHotShowsTransientDecayAndPositionsSerializedRangea) {
+    const std::filesystem::path directory = "gnss_sim_transient_real_whu_ttff_hot";
+    gnss_sim::TransientValidationSummary summary{};
+    std::string error_message;
+    ASSERT_TRUE(run_case(directory, ttff_hot_config(), &summary, &error_message)) << error_message;
+
+    EXPECT_GT(summary.range_epochs, 0U);
+    EXPECT_GT(summary.matched_observations, 0U);
+    EXPECT_EQ(summary.unmatched_observations, 0U);
+    EXPECT_GE(summary.first_valid.pseudorange_delay_sec, 0.0);
+    EXPECT_GE(summary.first_valid.doppler_delay_sec, 0.0);
+    EXPECT_GE(summary.first_valid.adr_delay_sec, 0.0);
+    EXPECT_GE(summary.first_valid.cn0_delay_sec, 0.0);
+    EXPECT_LT(summary.first_valid.pseudorange_delay_sec, 8.0);
+    EXPECT_LT(summary.first_valid.doppler_delay_sec, 8.0);
+    EXPECT_LT(summary.first_valid.adr_delay_sec, 8.0);
+    ASSERT_GT(summary.early.pseudorange_m.sample_count, 20U);
+    ASSERT_GT(summary.recovery.pseudorange_m.sample_count, 20U);
+    ASSERT_GT(summary.settled.pseudorange_m.sample_count, 20U);
+    EXPECT_GT(summary.early.pseudorange_m.rms, summary.recovery.pseudorange_m.rms);
+    EXPECT_GT(summary.recovery.pseudorange_m.rms, summary.settled.pseudorange_m.rms);
+    ASSERT_GT(summary.early.doppler_mps.sample_count, 20U);
+    ASSERT_GT(summary.recovery.doppler_mps.sample_count, 20U);
+    ASSERT_GT(summary.settled.doppler_mps.sample_count, 20U);
+    EXPECT_GT(summary.early.doppler_mps.rms, summary.recovery.doppler_mps.rms);
+    EXPECT_GT(summary.recovery.doppler_mps.rms, summary.settled.doppler_mps.rms);
+    ASSERT_GT(summary.early.cn0_dbhz.sample_count, 20U);
+    ASSERT_GT(summary.recovery.cn0_dbhz.sample_count, 20U);
+    ASSERT_GT(summary.settled.cn0_dbhz.sample_count, 20U);
+    EXPECT_GT(summary.early.cn0_dbhz.rms, summary.recovery.cn0_dbhz.rms);
+    EXPECT_GT(summary.recovery.cn0_dbhz.rms, summary.settled.cn0_dbhz.rms);
+    EXPECT_LT(summary.settled.pseudorange_m.rms, 0.30);
+    EXPECT_LT(summary.settled.doppler_mps.rms, 0.15);
+    EXPECT_LT(summary.settled.adr_m.rms, 0.01);
+    EXPECT_GT(summary.positioning.valid_position_epochs, 0U);
+    EXPECT_LT(summary.positioning.final_position_error_m, 5.0);
+
+    cleanup(directory);
+}
+
+TEST(TransientValidatorIntegration, RealWhuReaFadeHasEmptyOffWindowsFreshAmbiguitiesAndRecovery) {
+    const std::filesystem::path directory = "gnss_sim_transient_real_whu_rea_fade";
+    gnss_sim::TransientValidationSummary summary{};
+    std::string error_message;
+    ASSERT_TRUE(run_case(directory, rea_fade_config(), &summary, &error_message)) << error_message;
+
+    EXPECT_GT(summary.matched_observations, 0U);
+    EXPECT_EQ(summary.unmatched_observations, 0U);
+    EXPECT_GT(summary.rea.signal_off_range_epochs, 0U);
+    EXPECT_EQ(summary.rea.signal_off_nonzero_epochs, 0U);
+    EXPECT_GE(summary.rea.reacquisition_cycles, 2U);
+    EXPECT_LT(summary.rea.max_first_psr_delay_sec, 3.5);
+    EXPECT_LT(summary.rea.max_first_doppler_delay_sec, 3.5);
+    EXPECT_LT(summary.rea.max_first_adr_delay_sec, 4.0);
+    EXPECT_GT(summary.rea.max_last_observation_to_signal_off_sec, 0.0);
+    EXPECT_LE(summary.rea.max_last_observation_to_signal_off_sec, 0.2);
+    EXPECT_GE(summary.rea.max_first_observation_after_signal_on_sec, 0.0);
+    EXPECT_LT(summary.rea.max_first_observation_after_signal_on_sec, 3.5);
+    ASSERT_GT(summary.rea.ambiguity_pairs_checked, 0U);
+    EXPECT_EQ(summary.rea.ambiguity_pairs_changed, summary.rea.ambiguity_pairs_checked);
+
+    ASSERT_GT(summary.fade.cn0_dbhz.sample_count, 0U);
+    EXPECT_LT(summary.fade.cn0_dbhz.mean, -0.10);
+    ASSERT_GT(summary.reacquisition_early.pseudorange_m.sample_count, 0U);
+    ASSERT_GT(summary.reacquisition_settled.pseudorange_m.sample_count, 0U);
+    EXPECT_GT(summary.reacquisition_early.pseudorange_m.rms, summary.reacquisition_settled.pseudorange_m.rms);
+    EXPECT_GT(summary.positioning.valid_position_epochs, 0U);
+    EXPECT_LT(summary.positioning.final_position_error_m, 5.0);
+
+    cleanup(directory);
+}
+
+TEST(TransientValidatorIntegration, MeasurementNoiseToggleDoesNotMoveAcquisitionOrReacquisitionTiming) {
+    const std::filesystem::path ttff_enabled_directory = "gnss_sim_transient_toggle_ttff_enabled";
+    const std::filesystem::path ttff_disabled_directory = "gnss_sim_transient_toggle_ttff_disabled";
+    gnss_sim::SimConfig ttff_enabled_config = ttff_hot_config();
+    gnss_sim::SimConfig ttff_disabled_config = ttff_enabled_config;
+    ttff_disabled_config.measurement_noise_enabled = false;
+    gnss_sim::TransientValidationSummary ttff_enabled{};
+    gnss_sim::TransientValidationSummary ttff_disabled{};
+    std::string error_message;
+    ASSERT_TRUE(run_case(ttff_enabled_directory, ttff_enabled_config, &ttff_enabled, &error_message)) << error_message;
+    error_message.clear();
+    ASSERT_TRUE(run_case(ttff_disabled_directory, ttff_disabled_config, &ttff_disabled, &error_message))
+        << error_message;
+
+    EXPECT_EQ(ttff_enabled.range_epochs, ttff_disabled.range_epochs);
+    expect_same_first_valid_timing(ttff_enabled.first_valid, ttff_disabled.first_valid);
+
+    const std::filesystem::path rea_enabled_directory = "gnss_sim_transient_toggle_rea_enabled";
+    const std::filesystem::path rea_disabled_directory = "gnss_sim_transient_toggle_rea_disabled";
+    gnss_sim::SimConfig rea_enabled_config = rea_fade_config();
+    gnss_sim::SimConfig rea_disabled_config = rea_enabled_config;
+    rea_disabled_config.measurement_noise_enabled = false;
+    gnss_sim::TransientValidationSummary rea_enabled{};
+    gnss_sim::TransientValidationSummary rea_disabled{};
+    error_message.clear();
+    ASSERT_TRUE(run_case(rea_enabled_directory, rea_enabled_config, &rea_enabled, &error_message)) << error_message;
+    error_message.clear();
+    ASSERT_TRUE(run_case(rea_disabled_directory, rea_disabled_config, &rea_disabled, &error_message)) << error_message;
+
+    EXPECT_EQ(rea_enabled.range_epochs, rea_disabled.range_epochs);
+    EXPECT_EQ(rea_enabled.rea.signal_off_range_epochs, rea_disabled.rea.signal_off_range_epochs);
+    EXPECT_EQ(rea_enabled.rea.reacquisition_cycles, rea_disabled.rea.reacquisition_cycles);
+    expect_same_first_valid_timing(rea_enabled.first_valid, rea_disabled.first_valid);
+    EXPECT_DOUBLE_EQ(rea_enabled.rea.max_first_psr_delay_sec, rea_disabled.rea.max_first_psr_delay_sec);
+    EXPECT_DOUBLE_EQ(rea_enabled.rea.max_first_doppler_delay_sec, rea_disabled.rea.max_first_doppler_delay_sec);
+    EXPECT_DOUBLE_EQ(rea_enabled.rea.max_first_adr_delay_sec, rea_disabled.rea.max_first_adr_delay_sec);
+    EXPECT_DOUBLE_EQ(rea_enabled.rea.max_last_observation_to_signal_off_sec,
+                     rea_disabled.rea.max_last_observation_to_signal_off_sec);
+    EXPECT_DOUBLE_EQ(rea_enabled.rea.max_first_observation_after_signal_on_sec,
+                     rea_disabled.rea.max_first_observation_after_signal_on_sec);
+
+    cleanup(ttff_enabled_directory);
+    cleanup(ttff_disabled_directory);
+    cleanup(rea_enabled_directory);
+    cleanup(rea_disabled_directory);
+}
+
+} // namespace

--- a/tools/rangea_roundtrip/main.cpp
+++ b/tools/rangea_roundtrip/main.cpp
@@ -108,6 +108,9 @@ int main(int argc, char** argv) {
               << "selected_position_observations=" << summary.selected_position_observations << '\n'
               << "valid_position_epochs=" << summary.valid_position_epochs << '\n'
               << std::fixed << std::setprecision(6) << "max_position_error_m=" << summary.max_position_error_m << '\n'
-              << "max_error_gpst=" << summary.max_error_gps_week << '/' << summary.max_error_sow_sec << '\n';
+              << "max_error_gpst=" << summary.max_error_gps_week << '/' << summary.max_error_sow_sec << '\n'
+              << "final_position_error_m=" << summary.final_position_error_m << '\n'
+              << "final_position_gpst=" << summary.final_position_gps_week << '/' << summary.final_position_sow_sec
+              << '\n';
     return 0;
 }

--- a/tools/rangea_roundtrip/rangea_roundtrip.cpp
+++ b/tools/rangea_roundtrip/rangea_roundtrip.cpp
@@ -19,27 +19,11 @@ namespace gnss_sim {
 namespace {
 
 constexpr unsigned int kPseudorangeValidBit = 1U << 12U;
+constexpr unsigned int kAdrValidMask = (1U << 10U) | (1U << 11U);
 constexpr unsigned int kConstellationShift = 16U;
 constexpr unsigned int kConstellationMask = 0x7U;
 constexpr unsigned int kSignalTypeShift = 21U;
 constexpr unsigned int kSignalTypeMask = 0x1FU;
-
-struct ParsedRangeObservation {
-    int satellite_number;
-    const SignalDefinition* definition;
-    double pseudorange_m;
-    double doppler_hz;
-    double cn0_dbhz;
-    double lock_time_sec;
-    unsigned int tracking_status;
-    bool pseudorange_valid;
-};
-
-struct ParsedRangeEpoch {
-    int gps_week;
-    double sow_sec;
-    std::vector<ParsedRangeObservation> observations;
-};
 
 struct SelectedObservation {
     int satellite_number;
@@ -202,7 +186,7 @@ RtklibBroadcastMessageFamily rtklib_message_family(NavMessageFamily family) {
     return RtklibBroadcastMessageFamily::kUnknown;
 }
 
-bool parse_rangea_line(const std::string& raw_line, ParsedRangeEpoch* epoch, std::string* error_message) {
+bool parse_rangea_line_impl(const std::string& raw_line, ParsedRangeEpoch* epoch, std::string* error_message) {
     if (epoch == nullptr) {
         set_error(error_message, "RANGEA parser output is null");
         return false;
@@ -283,7 +267,6 @@ bool parse_rangea_line(const std::string& raw_line, ParsedRangeEpoch* epoch, std
                       "RANGEA observation contains malformed numeric fields at index " + std::to_string(index));
             return false;
         }
-        static_cast<void>(adr_cycles);
 
         GnssConstellation constellation{};
         char satellite_prefix = '\0';
@@ -328,13 +311,15 @@ bool parse_rangea_line(const std::string& raw_line, ParsedRangeEpoch* epoch, std
 
         ParsedRangeObservation observation{};
         observation.satellite_number = satellite_number;
-        observation.definition = definition;
+        observation.signal_id = static_cast<int>(definition->signal_id);
         observation.pseudorange_m = pseudorange_m;
+        observation.adr_cycles = adr_cycles;
         observation.doppler_hz = doppler_hz;
         observation.cn0_dbhz = cn0_dbhz;
         observation.lock_time_sec = lock_time_sec;
         observation.tracking_status = status;
         observation.pseudorange_valid = pseudorange_valid;
+        observation.adr_valid = (status & kAdrValidMask) == kAdrValidMask;
         result.observations.push_back(observation);
     }
 
@@ -364,19 +349,24 @@ bool select_position_observations(const ParsedRangeEpoch& epoch, std::vector<Rtk
         if (!source.pseudorange_valid) {
             continue;
         }
-        const int priority = signal_single_point_priority(source.definition->signal_id);
+        const SignalId signal_id = static_cast<SignalId>(source.signal_id);
+        const SignalDefinition* definition = find_signal_definition(signal_id);
+        if (definition == nullptr) {
+            set_error(error_message, "RANGEA selected observation has no signal definition");
+            return false;
+        }
+        const int priority = signal_single_point_priority(signal_id);
         if (priority < 0) {
             continue;
         }
         int observation_code = 0;
         int frequency_index = 0;
-        if (!signal_rtklib_observation_code(*source.definition, &observation_code, &frequency_index)) {
-            set_error(error_message,
-                      std::string("cannot map RANGEA signal to RTKLIB code: ") + source.definition->name);
+        if (!signal_rtklib_observation_code(*definition, &observation_code, &frequency_index)) {
+            set_error(error_message, std::string("cannot map RANGEA signal to RTKLIB code: ") + definition->name);
             return false;
         }
         static_cast<void>(frequency_index);
-        const RtklibBroadcastMessageFamily family = rtklib_message_family(source.definition->nav_message_family);
+        const RtklibBroadcastMessageFamily family = rtklib_message_family(definition->nav_message_family);
         if (family == RtklibBroadcastMessageFamily::kUnknown) {
             continue;
         }
@@ -416,6 +406,10 @@ bool select_position_observations(const ParsedRangeEpoch& epoch, std::vector<Rtk
 }
 
 } // namespace
+
+bool parse_rangea_line_independent(const std::string& raw_line, ParsedRangeEpoch* epoch, std::string* error_message) {
+    return parse_rangea_line_impl(raw_line, epoch, error_message);
+}
 
 bool validate_rangea_roundtrip_stream(std::istream* input, const char* rinex_nav_path, double truth_latitude_deg,
                                       double truth_longitude_deg, double truth_height_m, double elevation_mask_deg,
@@ -457,7 +451,7 @@ bool validate_rangea_roundtrip_stream(std::istream* input, const char* rinex_nav
 
         ParsedRangeEpoch epoch{};
         std::string parse_error;
-        if (!parse_rangea_line(line, &epoch, &parse_error)) {
+        if (!parse_rangea_line_independent(line, &epoch, &parse_error)) {
             destroy_rtklib_nav_store(nav);
             set_error(error_message, "RANGEA line " + std::to_string(line_number) + ": " + parse_error);
             return false;
@@ -500,6 +494,9 @@ bool validate_rangea_roundtrip_stream(std::istream* input, const char* rinex_nav
             return false;
         }
         ++result.valid_position_epochs;
+        result.final_position_error_m = error_m;
+        result.final_position_gps_week = epoch.gps_week;
+        result.final_position_sow_sec = epoch.sow_sec;
         if (error_m > result.max_position_error_m) {
             result.max_position_error_m = error_m;
             result.max_error_gps_week = epoch.gps_week;

--- a/tools/rangea_roundtrip/rangea_roundtrip.h
+++ b/tools/rangea_roundtrip/rangea_roundtrip.h
@@ -4,8 +4,30 @@
 #include <cstdint>
 #include <istream>
 #include <string>
+#include <vector>
 
 namespace gnss_sim {
+
+struct ParsedRangeObservation {
+    int satellite_number;
+    int signal_id;
+    double pseudorange_m;
+    double adr_cycles;
+    double doppler_hz;
+    double cn0_dbhz;
+    double lock_time_sec;
+    unsigned int tracking_status;
+    bool pseudorange_valid;
+    bool adr_valid;
+};
+
+struct ParsedRangeEpoch {
+    int gps_week;
+    double sow_sec;
+    std::vector<ParsedRangeObservation> observations;
+};
+
+bool parse_rangea_line_independent(const std::string& raw_line, ParsedRangeEpoch* epoch, std::string* error_message);
 
 struct RangeaRoundtripSummary {
     std::uint64_t range_epochs;
@@ -15,6 +37,9 @@ struct RangeaRoundtripSummary {
     double max_position_error_m;
     int max_error_gps_week;
     double max_error_sow_sec;
+    double final_position_error_m;
+    int final_position_gps_week;
+    double final_position_sow_sec;
 };
 
 bool validate_rangea_roundtrip_stream(std::istream* input, const char* rinex_nav_path, double truth_latitude_deg,

--- a/tools/transient_validator/main.cpp
+++ b/tools/transient_validator/main.cpp
@@ -1,0 +1,165 @@
+#include "transient_validator.h"
+
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <locale>
+#include <string>
+
+namespace {
+
+struct Options {
+    std::string log_path;
+    std::string truth_path;
+    std::string events_path;
+    std::string nav_path;
+    std::string scenario;
+    std::string output_path;
+    double fade_duration_sec = 0.0;
+    double latitude_deg = 0.0;
+    double longitude_deg = 0.0;
+    double height_m = 0.0;
+    double elevation_mask_deg = 5.0;
+    bool have_latitude = false;
+    bool have_longitude = false;
+    bool have_height = false;
+    bool broadcast_atmosphere = false;
+};
+
+bool parse_double(const char* text, double* value) {
+    if (text == nullptr || value == nullptr) {
+        return false;
+    }
+    char* end = nullptr;
+    const double parsed = std::strtod(text, &end);
+    if (end == text || end == nullptr || *end != '\0') {
+        return false;
+    }
+    *value = parsed;
+    return true;
+}
+
+bool parse_args(int argc, char** argv, Options* options) {
+    if (options == nullptr) {
+        return false;
+    }
+    for (int index = 1; index < argc; ++index) {
+        const std::string argument = argv[index];
+        if (argument == "--broadcast-atmosphere") {
+            options->broadcast_atmosphere = true;
+            continue;
+        }
+        if (index + 1 >= argc) {
+            return false;
+        }
+        const char* value = argv[++index];
+        if (argument == "--log") {
+            options->log_path = value;
+        } else if (argument == "--truth") {
+            options->truth_path = value;
+        } else if (argument == "--events") {
+            options->events_path = value;
+        } else if (argument == "--nav") {
+            options->nav_path = value;
+        } else if (argument == "--scenario") {
+            options->scenario = value;
+        } else if (argument == "--output") {
+            options->output_path = value;
+        } else if (argument == "--fade-duration") {
+            if (!parse_double(value, &options->fade_duration_sec)) {
+                return false;
+            }
+        } else if (argument == "--truth-lat") {
+            options->have_latitude = parse_double(value, &options->latitude_deg);
+            if (!options->have_latitude) {
+                return false;
+            }
+        } else if (argument == "--truth-lon") {
+            options->have_longitude = parse_double(value, &options->longitude_deg);
+            if (!options->have_longitude) {
+                return false;
+            }
+        } else if (argument == "--truth-height") {
+            options->have_height = parse_double(value, &options->height_m);
+            if (!options->have_height) {
+                return false;
+            }
+        } else if (argument == "--elevation-mask") {
+            if (!parse_double(value, &options->elevation_mask_deg)) {
+                return false;
+            }
+        } else {
+            return false;
+        }
+    }
+    return !options->log_path.empty() && !options->truth_path.empty() && !options->events_path.empty() &&
+           !options->nav_path.empty() && !options->scenario.empty() && !options->output_path.empty() &&
+           options->have_latitude && options->have_longitude && options->have_height;
+}
+
+void usage() {
+    std::cerr << "usage: validate-transient-observations --log FILE --truth observation_truth.csv --events "
+                 "event_truth.csv --nav FILE --scenario LABEL --output summary.json --truth-lat DEG --truth-lon DEG "
+                 "--truth-height M [--fade-duration SEC] [--elevation-mask DEG] [--broadcast-atmosphere]\n";
+}
+
+void print_window(const char* name, const gnss_sim::ObservationWindowStatistics& statistics) {
+    std::cout << name << ".psr_samples=" << statistics.pseudorange_m.sample_count << '\n'
+              << name << ".psr_rms_m=" << statistics.pseudorange_m.rms << '\n'
+              << name << ".doppler_samples=" << statistics.doppler_mps.sample_count << '\n'
+              << name << ".doppler_rms_mps=" << statistics.doppler_mps.rms << '\n'
+              << name << ".adr_samples=" << statistics.adr_m.sample_count << '\n'
+              << name << ".adr_rms_m=" << statistics.adr_m.rms << '\n'
+              << name << ".cn0_samples=" << statistics.cn0_dbhz.sample_count << '\n'
+              << name << ".cn0_rms_dbhz=" << statistics.cn0_dbhz.rms << '\n';
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    Options options{};
+    if (!parse_args(argc, argv, &options)) {
+        usage();
+        return 2;
+    }
+
+    const gnss_sim::TransientValidationOptions validator_options{
+        options.scenario.c_str(), options.fade_duration_sec,  options.latitude_deg,         options.longitude_deg,
+        options.height_m,         options.elevation_mask_deg, options.broadcast_atmosphere,
+    };
+    gnss_sim::TransientValidationSummary summary{};
+    std::string error_message;
+    if (!gnss_sim::validate_transient_observations_files(options.log_path.c_str(), options.truth_path.c_str(),
+                                                         options.events_path.c_str(), options.nav_path.c_str(),
+                                                         validator_options, &summary, &error_message)) {
+        std::cerr << error_message << '\n';
+        return 1;
+    }
+    if (!gnss_sim::write_transient_validation_json(options.output_path.c_str(), validator_options, summary,
+                                                   &error_message)) {
+        std::cerr << error_message << '\n';
+        return 1;
+    }
+
+    std::cout.imbue(std::locale::classic());
+    std::cout << std::fixed << std::setprecision(6) << "range_epochs=" << summary.range_epochs << '\n'
+              << "parsed_observations=" << summary.parsed_observations << '\n'
+              << "matched_observations=" << summary.matched_observations << '\n'
+              << "unmatched_observations=" << summary.unmatched_observations << '\n';
+    print_window("early", summary.early);
+    print_window("recovery", summary.recovery);
+    print_window("settled", summary.settled);
+    print_window("fade", summary.fade);
+    print_window("reacquisition_early", summary.reacquisition_early);
+    std::cout << "rea.signal_off_range_epochs=" << summary.rea.signal_off_range_epochs << '\n'
+              << "rea.signal_off_nonzero_epochs=" << summary.rea.signal_off_nonzero_epochs << '\n'
+              << "rea.reacquisition_cycles=" << summary.rea.reacquisition_cycles << '\n'
+              << "rea.max_first_psr_delay_sec=" << summary.rea.max_first_psr_delay_sec << '\n'
+              << "rea.max_first_doppler_delay_sec=" << summary.rea.max_first_doppler_delay_sec << '\n'
+              << "rea.max_first_adr_delay_sec=" << summary.rea.max_first_adr_delay_sec << '\n'
+              << "rea.ambiguity_pairs_checked=" << summary.rea.ambiguity_pairs_checked << '\n'
+              << "rea.ambiguity_pairs_changed=" << summary.rea.ambiguity_pairs_changed << '\n'
+              << "positioning.valid_position_epochs=" << summary.positioning.valid_position_epochs << '\n'
+              << "positioning.max_position_error_m=" << summary.positioning.max_position_error_m << '\n';
+    return 0;
+}

--- a/tools/transient_validator/transient_validator.cpp
+++ b/tools/transient_validator/transient_validator.cpp
@@ -1,0 +1,861 @@
+#include "transient_validator.h"
+
+#include "gnss_sim/sim_time.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <fstream>
+#include <iomanip>
+#include <limits>
+#include <locale>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace gnss_sim {
+namespace {
+
+struct ObservationKey {
+    int gps_week;
+    std::int64_t tow_ns;
+    int satellite_number;
+    int signal_id;
+
+    bool operator==(const ObservationKey& other) const {
+        return gps_week == other.gps_week && tow_ns == other.tow_ns && satellite_number == other.satellite_number &&
+               signal_id == other.signal_id;
+    }
+};
+
+struct ObservationKeyHash {
+    std::size_t operator()(const ObservationKey& key) const {
+        std::size_t value = static_cast<std::size_t>(key.gps_week);
+        value ^= static_cast<std::size_t>(key.tow_ns) + 0x9e3779b9U + (value << 6U) + (value >> 2U);
+        value ^= static_cast<std::size_t>(key.satellite_number) + 0x9e3779b9U + (value << 6U) + (value >> 2U);
+        value ^= static_cast<std::size_t>(key.signal_id) + 0x9e3779b9U + (value << 6U) + (value >> 2U);
+        return value;
+    }
+};
+
+struct SignalKey {
+    int satellite_number;
+    int signal_id;
+
+    bool operator==(const SignalKey& other) const {
+        return satellite_number == other.satellite_number && signal_id == other.signal_id;
+    }
+};
+
+struct SignalKeyHash {
+    std::size_t operator()(const SignalKey& key) const {
+        return (static_cast<std::size_t>(key.satellite_number) << 8U) ^ static_cast<std::size_t>(key.signal_id);
+    }
+};
+
+struct TruthObservation {
+    ObservationKey key;
+    double wavelength_m;
+    double pseudorange_m;
+    double doppler_hz;
+    double adr_cycles;
+    double cn0_dbhz;
+    bool pseudorange_valid;
+    bool doppler_valid;
+    bool adr_valid;
+    std::int64_t ambiguity_cycles;
+    std::int64_t ambiguity_epoch_tow_ns;
+};
+
+struct EventRecord {
+    std::int64_t absolute_ns;
+    std::string type;
+};
+
+struct ReaCycle {
+    std::int64_t off_ns;
+    std::int64_t on_ns;
+    std::int64_t end_ns;
+};
+
+struct ReaSerializedTiming {
+    std::int64_t first_psr_ns;
+    std::int64_t first_doppler_ns;
+    std::int64_t first_adr_ns;
+    std::int64_t last_observation_before_off_ns;
+    std::int64_t first_observation_after_on_ns;
+};
+
+struct MetricAccumulator {
+    std::vector<double> values;
+};
+
+struct WindowAccumulator {
+    MetricAccumulator pseudorange_m;
+    MetricAccumulator doppler_mps;
+    MetricAccumulator adr_m;
+    MetricAccumulator cn0_dbhz;
+};
+
+void set_error(std::string* error_message, const std::string& message) {
+    if (error_message != nullptr) {
+        *error_message = message;
+    }
+}
+
+bool parse_csv_line(const std::string& line, std::vector<std::string>* fields) {
+    if (fields == nullptr) {
+        return false;
+    }
+    fields->clear();
+    std::string field;
+    bool quoted = false;
+    for (std::size_t index = 0; index < line.size(); ++index) {
+        const char character = line[index];
+        if (quoted) {
+            if (character == '"') {
+                if (index + 1U < line.size() && line[index + 1U] == '"') {
+                    field.push_back('"');
+                    ++index;
+                } else {
+                    quoted = false;
+                }
+            } else {
+                field.push_back(character);
+            }
+            continue;
+        }
+        if (character == '"' && field.empty()) {
+            quoted = true;
+        } else if (character == ',') {
+            fields->push_back(field);
+            field.clear();
+        } else if (character != '\r') {
+            field.push_back(character);
+        }
+    }
+    if (quoted) {
+        return false;
+    }
+    fields->push_back(field);
+    return true;
+}
+
+std::size_t column_index(const std::vector<std::string>& header, const char* name) {
+    const auto iterator = std::find(header.begin(), header.end(), name);
+    return iterator == header.end() ? header.size() : static_cast<std::size_t>(iterator - header.begin());
+}
+
+bool parse_int(const std::string& text, int* value) {
+    if (value == nullptr || text.empty()) {
+        return false;
+    }
+    std::istringstream stream(text);
+    stream.imbue(std::locale::classic());
+    int result = 0;
+    stream >> result;
+    if (!stream || stream.peek() != std::char_traits<char>::eof()) {
+        return false;
+    }
+    *value = result;
+    return true;
+}
+
+bool parse_int64(const std::string& text, std::int64_t* value) {
+    if (value == nullptr || text.empty()) {
+        return false;
+    }
+    std::istringstream stream(text);
+    stream.imbue(std::locale::classic());
+    std::int64_t result = 0;
+    stream >> result;
+    if (!stream || stream.peek() != std::char_traits<char>::eof()) {
+        return false;
+    }
+    *value = result;
+    return true;
+}
+
+bool parse_double(const std::string& text, double* value) {
+    if (value == nullptr || text.empty()) {
+        return false;
+    }
+    std::istringstream stream(text);
+    stream.imbue(std::locale::classic());
+    double result = 0.0;
+    stream >> result;
+    if (!stream || stream.peek() != std::char_traits<char>::eof() || !std::isfinite(result)) {
+        return false;
+    }
+    *value = result;
+    return true;
+}
+
+bool parse_bool01(const std::string& text, bool* value) {
+    if (value == nullptr || (text != "0" && text != "1")) {
+        return false;
+    }
+    *value = text == "1";
+    return true;
+}
+
+bool absolute_time_ns(int gps_week, std::int64_t tow_ns, std::int64_t* absolute_ns) {
+    if (absolute_ns == nullptr || gps_week < 0 || tow_ns < 0 || tow_ns >= GPS_WEEK_NANOSECONDS) {
+        return false;
+    }
+    const long double value = static_cast<long double>(gps_week) * static_cast<long double>(GPS_WEEK_NANOSECONDS) +
+                              static_cast<long double>(tow_ns);
+    if (value > static_cast<long double>(std::numeric_limits<std::int64_t>::max())) {
+        return false;
+    }
+    *absolute_ns = static_cast<std::int64_t>(value);
+    return true;
+}
+
+bool load_truth_observations(const char* path, std::vector<TruthObservation>* records,
+                             std::unordered_map<ObservationKey, std::size_t, ObservationKeyHash>* index,
+                             std::string* error_message) {
+    std::ifstream input(path, std::ios::binary);
+    if (!input) {
+        set_error(error_message, std::string("cannot open observation truth: ") + path);
+        return false;
+    }
+    std::string line;
+    if (!std::getline(input, line)) {
+        set_error(error_message, "observation truth is empty");
+        return false;
+    }
+    std::vector<std::string> header;
+    if (!parse_csv_line(line, &header)) {
+        set_error(error_message, "observation truth header is malformed");
+        return false;
+    }
+    const std::size_t gps_week_column = column_index(header, "gps_week");
+    const std::size_t tow_column = column_index(header, "tow_ns");
+    const std::size_t satellite_column = column_index(header, "satellite_number");
+    const std::size_t signal_column = column_index(header, "signal_id");
+    const std::size_t wavelength_column = column_index(header, "wavelength_m");
+    const std::size_t psr_valid_column = column_index(header, "pseudorange_valid");
+    const std::size_t doppler_valid_column = column_index(header, "doppler_valid");
+    const std::size_t adr_valid_column = column_index(header, "adr_valid");
+    const std::size_t ambiguity_column = column_index(header, "ambiguity_cycles");
+    const std::size_t ambiguity_epoch_column = column_index(header, "ambiguity_epoch_tow_ns");
+    const std::size_t psr_column = column_index(header, "pseudorange_m");
+    const std::size_t doppler_column = column_index(header, "doppler_hz");
+    const std::size_t adr_column = column_index(header, "adr_cycles");
+    const std::size_t cn0_column = column_index(header, "cn0_dbhz");
+    const std::size_t required[] = {
+        gps_week_column,  tow_column,           satellite_column, signal_column,    wavelength_column,
+        psr_valid_column, doppler_valid_column, adr_valid_column, ambiguity_column, ambiguity_epoch_column,
+        psr_column,       doppler_column,       adr_column,       cn0_column};
+    for (std::size_t value : required) {
+        if (value == header.size()) {
+            set_error(error_message, "observation truth is missing a required column");
+            return false;
+        }
+    }
+
+    records->clear();
+    index->clear();
+    std::uint64_t line_number = 1;
+    while (std::getline(input, line)) {
+        ++line_number;
+        std::vector<std::string> fields;
+        if (!parse_csv_line(line, &fields) || fields.size() != header.size()) {
+            set_error(error_message, "observation truth row is malformed at line " + std::to_string(line_number));
+            return false;
+        }
+        TruthObservation record{};
+        if (!parse_int(fields[gps_week_column], &record.key.gps_week) ||
+            !parse_int64(fields[tow_column], &record.key.tow_ns) ||
+            !parse_int(fields[satellite_column], &record.key.satellite_number) ||
+            !parse_int(fields[signal_column], &record.key.signal_id) ||
+            !parse_double(fields[wavelength_column], &record.wavelength_m) ||
+            !parse_bool01(fields[psr_valid_column], &record.pseudorange_valid) ||
+            !parse_bool01(fields[doppler_valid_column], &record.doppler_valid) ||
+            !parse_bool01(fields[adr_valid_column], &record.adr_valid) ||
+            !parse_int64(fields[ambiguity_column], &record.ambiguity_cycles) ||
+            !parse_int64(fields[ambiguity_epoch_column], &record.ambiguity_epoch_tow_ns) ||
+            !parse_double(fields[psr_column], &record.pseudorange_m) ||
+            !parse_double(fields[doppler_column], &record.doppler_hz) ||
+            !parse_double(fields[adr_column], &record.adr_cycles) ||
+            !parse_double(fields[cn0_column], &record.cn0_dbhz) || record.wavelength_m <= 0.0) {
+            set_error(error_message,
+                      "observation truth numeric field is malformed at line " + std::to_string(line_number));
+            return false;
+        }
+        const auto inserted = index->emplace(record.key, records->size());
+        if (!inserted.second) {
+            set_error(error_message, "observation truth contains a duplicate epoch/satellite/signal key");
+            return false;
+        }
+        records->push_back(record);
+    }
+    if (records->empty()) {
+        set_error(error_message, "observation truth contains no observations");
+        return false;
+    }
+    return true;
+}
+
+bool load_events(const char* path, std::vector<EventRecord>* events, std::string* error_message) {
+    std::ifstream input(path, std::ios::binary);
+    if (!input) {
+        set_error(error_message, std::string("cannot open event truth: ") + path);
+        return false;
+    }
+    std::string line;
+    if (!std::getline(input, line)) {
+        set_error(error_message, "event truth is empty");
+        return false;
+    }
+    std::vector<std::string> header;
+    if (!parse_csv_line(line, &header)) {
+        set_error(error_message, "event truth header is malformed");
+        return false;
+    }
+    const std::size_t gps_week_column = column_index(header, "gps_week");
+    const std::size_t tow_column = column_index(header, "tow_ns");
+    const std::size_t type_column = column_index(header, "event_type");
+    if (gps_week_column == header.size() || tow_column == header.size() || type_column == header.size()) {
+        set_error(error_message, "event truth is missing required columns");
+        return false;
+    }
+
+    events->clear();
+    while (std::getline(input, line)) {
+        std::vector<std::string> fields;
+        int gps_week = 0;
+        std::int64_t tow_ns = 0;
+        std::int64_t absolute_ns = 0;
+        if (!parse_csv_line(line, &fields) || fields.size() != header.size() ||
+            !parse_int(fields[gps_week_column], &gps_week) || !parse_int64(fields[tow_column], &tow_ns) ||
+            !absolute_time_ns(gps_week, tow_ns, &absolute_ns)) {
+            set_error(error_message, "event truth row is malformed");
+            return false;
+        }
+        events->push_back({absolute_ns, fields[type_column]});
+    }
+    std::sort(events->begin(), events->end(),
+              [](const EventRecord& lhs, const EventRecord& rhs) { return lhs.absolute_ns < rhs.absolute_ns; });
+    return true;
+}
+
+std::vector<ReaCycle> build_rea_cycles(const std::vector<EventRecord>& events) {
+    std::vector<ReaCycle> cycles;
+    bool waiting_for_on = false;
+    std::int64_t off_ns = 0;
+    for (const EventRecord& event : events) {
+        if (event.type == "SIGNAL_OFF") {
+            if (!cycles.empty() && cycles.back().end_ns == std::numeric_limits<std::int64_t>::max()) {
+                cycles.back().end_ns = event.absolute_ns;
+            }
+            waiting_for_on = true;
+            off_ns = event.absolute_ns;
+        } else if (event.type == "SIGNAL_ON" && waiting_for_on) {
+            cycles.push_back({off_ns, event.absolute_ns, std::numeric_limits<std::int64_t>::max()});
+            waiting_for_on = false;
+        }
+    }
+    return cycles;
+}
+
+bool in_signal_off_interval(std::int64_t time_ns, const std::vector<ReaCycle>& cycles) {
+    for (const ReaCycle& cycle : cycles) {
+        if (time_ns >= cycle.off_ns && time_ns < cycle.on_ns) {
+            return true;
+        }
+    }
+    return false;
+}
+
+const ReaCycle* active_reacquisition_cycle(std::int64_t time_ns, const std::vector<ReaCycle>& cycles) {
+    for (const ReaCycle& cycle : cycles) {
+        if (time_ns >= cycle.on_ns && time_ns < cycle.end_ns) {
+            return &cycle;
+        }
+    }
+    return nullptr;
+}
+
+bool in_fade_window(std::int64_t time_ns, const std::vector<EventRecord>& events, double fade_duration_sec) {
+    if (!(fade_duration_sec > 0.0) || !std::isfinite(fade_duration_sec)) {
+        return false;
+    }
+    const long double fade_ns =
+        static_cast<long double>(fade_duration_sec) * static_cast<long double>(NANOSECONDS_PER_SECOND);
+    for (const EventRecord& event : events) {
+        if (event.type != "SIGNAL_OFF" || event.absolute_ns < time_ns) {
+            continue;
+        }
+        return static_cast<long double>(event.absolute_ns - time_ns) <= fade_ns;
+    }
+    return false;
+}
+
+void add_metric(MetricAccumulator* accumulator, double value) {
+    if (std::isfinite(value)) {
+        accumulator->values.push_back(value);
+    }
+}
+
+void add_observation(WindowAccumulator* accumulator, const ParsedRangeObservation& parsed,
+                     const TruthObservation& truth) {
+    if (truth.pseudorange_valid && parsed.pseudorange_valid) {
+        add_metric(&accumulator->pseudorange_m, parsed.pseudorange_m - truth.pseudorange_m);
+    }
+    if (truth.doppler_valid) {
+        add_metric(&accumulator->doppler_mps, (parsed.doppler_hz - truth.doppler_hz) * truth.wavelength_m);
+    }
+    if (truth.adr_valid && parsed.adr_valid) {
+        add_metric(&accumulator->adr_m, (parsed.adr_cycles - truth.adr_cycles) * truth.wavelength_m);
+    }
+    add_metric(&accumulator->cn0_dbhz, parsed.cn0_dbhz - truth.cn0_dbhz);
+}
+
+double quantile_sorted(const std::vector<double>& sorted, double probability) {
+    if (sorted.empty()) {
+        return 0.0;
+    }
+    const double position = probability * static_cast<double>(sorted.size() - 1U);
+    const std::size_t lower = static_cast<std::size_t>(std::floor(position));
+    const std::size_t upper = static_cast<std::size_t>(std::ceil(position));
+    const double fraction = position - static_cast<double>(lower);
+    return sorted[lower] + (sorted[upper] - sorted[lower]) * fraction;
+}
+
+ErrorMetricStatistics finalize_metric(const MetricAccumulator& accumulator) {
+    ErrorMetricStatistics result{};
+    result.sample_count = static_cast<std::uint64_t>(accumulator.values.size());
+    if (accumulator.values.empty()) {
+        return result;
+    }
+    long double sum = 0.0L;
+    long double square_sum = 0.0L;
+    std::vector<double> absolute;
+    absolute.reserve(accumulator.values.size());
+    for (double value : accumulator.values) {
+        sum += value;
+        square_sum += static_cast<long double>(value) * static_cast<long double>(value);
+        absolute.push_back(std::fabs(value));
+    }
+    const long double count = static_cast<long double>(accumulator.values.size());
+    result.mean = static_cast<double>(sum / count);
+    result.rms = static_cast<double>(std::sqrt(square_sum / count));
+    long double variance_sum = 0.0L;
+    for (double value : accumulator.values) {
+        const long double difference = static_cast<long double>(value) - static_cast<long double>(result.mean);
+        variance_sum += difference * difference;
+    }
+    result.standard_deviation = static_cast<double>(std::sqrt(variance_sum / count));
+    std::sort(absolute.begin(), absolute.end());
+    result.p50_absolute = quantile_sorted(absolute, 0.50);
+    result.p95_absolute = quantile_sorted(absolute, 0.95);
+    result.max_absolute = absolute.back();
+    return result;
+}
+
+ObservationWindowStatistics finalize_window(const WindowAccumulator& accumulator) {
+    ObservationWindowStatistics result{};
+    result.pseudorange_m = finalize_metric(accumulator.pseudorange_m);
+    result.doppler_mps = finalize_metric(accumulator.doppler_mps);
+    result.adr_m = finalize_metric(accumulator.adr_m);
+    result.cn0_dbhz = finalize_metric(accumulator.cn0_dbhz);
+    return result;
+}
+
+void update_rea_timing(const std::vector<TruthObservation>& truth, const std::vector<ReaCycle>& cycles,
+                       const std::vector<ReaSerializedTiming>& serialized_timing, ReaTransientStatistics* statistics) {
+    statistics->reacquisition_cycles = static_cast<std::uint64_t>(cycles.size());
+    for (std::size_t cycle_index = 0; cycle_index < cycles.size(); ++cycle_index) {
+        const ReaCycle& cycle = cycles[cycle_index];
+        const ReaSerializedTiming& timing = serialized_timing[cycle_index];
+        const auto update_delay = [cycle](std::int64_t first_ns, double* maximum) {
+            if (first_ns == std::numeric_limits<std::int64_t>::max()) {
+                return;
+            }
+            const double delay =
+                static_cast<double>(first_ns - cycle.on_ns) / static_cast<double>(NANOSECONDS_PER_SECOND);
+            *maximum = std::max(*maximum, delay);
+        };
+        update_delay(timing.first_psr_ns, &statistics->max_first_psr_delay_sec);
+        update_delay(timing.first_doppler_ns, &statistics->max_first_doppler_delay_sec);
+        update_delay(timing.first_adr_ns, &statistics->max_first_adr_delay_sec);
+        if (timing.last_observation_before_off_ns != std::numeric_limits<std::int64_t>::min()) {
+            const double gap = static_cast<double>(cycle.off_ns - timing.last_observation_before_off_ns) /
+                               static_cast<double>(NANOSECONDS_PER_SECOND);
+            statistics->max_last_observation_to_signal_off_sec =
+                std::max(statistics->max_last_observation_to_signal_off_sec, gap);
+        }
+        if (timing.first_observation_after_on_ns != std::numeric_limits<std::int64_t>::max()) {
+            const double delay = static_cast<double>(timing.first_observation_after_on_ns - cycle.on_ns) /
+                                 static_cast<double>(NANOSECONDS_PER_SECOND);
+            statistics->max_first_observation_after_signal_on_sec =
+                std::max(statistics->max_first_observation_after_signal_on_sec, delay);
+        }
+
+        std::unordered_map<SignalKey, const TruthObservation*, SignalKeyHash> before;
+        std::unordered_map<SignalKey, const TruthObservation*, SignalKeyHash> after;
+        for (const TruthObservation& record : truth) {
+            if (!record.adr_valid) {
+                continue;
+            }
+            std::int64_t time_ns = 0;
+            if (!absolute_time_ns(record.key.gps_week, record.key.tow_ns, &time_ns)) {
+                continue;
+            }
+            const SignalKey key{record.key.satellite_number, record.key.signal_id};
+            if (time_ns < cycle.off_ns) {
+                const auto iterator = before.find(key);
+                if (iterator == before.end() || iterator->second->key.gps_week < record.key.gps_week ||
+                    (iterator->second->key.gps_week == record.key.gps_week &&
+                     iterator->second->key.tow_ns < record.key.tow_ns)) {
+                    before[key] = &record;
+                }
+            } else if (time_ns >= cycle.on_ns && time_ns < cycle.end_ns && after.find(key) == after.end()) {
+                after[key] = &record;
+            }
+        }
+        for (const auto& entry : before) {
+            const auto iterator = after.find(entry.first);
+            if (iterator == after.end()) {
+                continue;
+            }
+            ++statistics->ambiguity_pairs_checked;
+            const TruthObservation* lhs = entry.second;
+            const TruthObservation* rhs = iterator->second;
+            if (lhs->ambiguity_epoch_tow_ns != rhs->ambiguity_epoch_tow_ns &&
+                lhs->ambiguity_cycles != rhs->ambiguity_cycles) {
+                ++statistics->ambiguity_pairs_changed;
+            }
+        }
+    }
+}
+
+bool is_rea_label(const char* label) {
+    return label != nullptr && std::string(label).rfind("REA", 0) == 0;
+}
+
+std::string json_escape(const char* text) {
+    std::ostringstream output;
+    for (const unsigned char character : std::string(text != nullptr ? text : "")) {
+        switch (character) {
+            case '\\':
+                output << "\\\\";
+                break;
+            case '"':
+                output << "\\\"";
+                break;
+            case '\n':
+                output << "\\n";
+                break;
+            case '\r':
+                output << "\\r";
+                break;
+            case '\t':
+                output << "\\t";
+                break;
+            default:
+                output << static_cast<char>(character);
+                break;
+        }
+    }
+    return output.str();
+}
+
+void write_metric_json(std::ostream& output, const ErrorMetricStatistics& metric, int indent) {
+    const std::string pad(static_cast<std::size_t>(indent), ' ');
+    output << "{\n"
+           << pad << "  \"sample_count\": " << metric.sample_count << ",\n"
+           << pad << "  \"mean\": " << metric.mean << ",\n"
+           << pad << "  \"rms\": " << metric.rms << ",\n"
+           << pad << "  \"standard_deviation\": " << metric.standard_deviation << ",\n"
+           << pad << "  \"p50_absolute\": " << metric.p50_absolute << ",\n"
+           << pad << "  \"p95_absolute\": " << metric.p95_absolute << ",\n"
+           << pad << "  \"max_absolute\": " << metric.max_absolute << '\n'
+           << pad << '}';
+}
+
+void write_window_json(std::ostream& output, const ObservationWindowStatistics& window, int indent) {
+    const std::string pad(static_cast<std::size_t>(indent), ' ');
+    output << "{\n" << pad << "  \"pseudorange_m\": ";
+    write_metric_json(output, window.pseudorange_m, indent + 2);
+    output << ",\n" << pad << "  \"doppler_mps\": ";
+    write_metric_json(output, window.doppler_mps, indent + 2);
+    output << ",\n" << pad << "  \"adr_m\": ";
+    write_metric_json(output, window.adr_m, indent + 2);
+    output << ",\n" << pad << "  \"cn0_dbhz\": ";
+    write_metric_json(output, window.cn0_dbhz, indent + 2);
+    output << '\n' << pad << '}';
+}
+
+} // namespace
+
+bool validate_transient_observations_files(const char* log_path, const char* observation_truth_path,
+                                           const char* event_truth_path, const char* rinex_nav_path,
+                                           const TransientValidationOptions& options,
+                                           TransientValidationSummary* summary, std::string* error_message) {
+    if (log_path == nullptr || observation_truth_path == nullptr || event_truth_path == nullptr ||
+        rinex_nav_path == nullptr || options.scenario_label == nullptr || summary == nullptr ||
+        !std::isfinite(options.fade_duration_sec) || options.fade_duration_sec < 0.0 ||
+        !std::isfinite(options.solution_elevation_mask_deg) || options.solution_elevation_mask_deg < 0.0 ||
+        options.solution_elevation_mask_deg > 90.0) {
+        set_error(error_message, "transient validator request has invalid arguments");
+        return false;
+    }
+
+    std::vector<TruthObservation> truth;
+    std::unordered_map<ObservationKey, std::size_t, ObservationKeyHash> truth_index;
+    std::vector<EventRecord> events;
+    if (!load_truth_observations(observation_truth_path, &truth, &truth_index, error_message) ||
+        !load_events(event_truth_path, &events, error_message)) {
+        return false;
+    }
+    const std::vector<ReaCycle> rea_cycles = build_rea_cycles(events);
+    const bool rea = is_rea_label(options.scenario_label);
+    std::vector<ReaSerializedTiming> rea_serialized_timing(
+        rea_cycles.size(), {std::numeric_limits<std::int64_t>::max(), std::numeric_limits<std::int64_t>::max(),
+                            std::numeric_limits<std::int64_t>::max(), std::numeric_limits<std::int64_t>::min(),
+                            std::numeric_limits<std::int64_t>::max()});
+
+    std::ifstream input(log_path, std::ios::binary);
+    if (!input) {
+        set_error(error_message, std::string("cannot open serialized receiver log: ") + log_path);
+        return false;
+    }
+
+    WindowAccumulator early;
+    WindowAccumulator recovery;
+    WindowAccumulator settled;
+    WindowAccumulator fade;
+    WindowAccumulator reacquisition_early;
+    WindowAccumulator reacquisition_recovery;
+    WindowAccumulator reacquisition_settled;
+    TransientValidationSummary result{};
+    result.first_valid = {-1.0, -1.0, -1.0, -1.0};
+    std::int64_t first_rangea_ns = std::numeric_limits<std::int64_t>::max();
+    std::int64_t first_psr_ns = std::numeric_limits<std::int64_t>::max();
+    std::int64_t first_doppler_ns = std::numeric_limits<std::int64_t>::max();
+    std::int64_t first_adr_ns = std::numeric_limits<std::int64_t>::max();
+    std::int64_t first_cn0_ns = std::numeric_limits<std::int64_t>::max();
+    std::string line;
+    std::uint64_t line_number = 0;
+    while (std::getline(input, line)) {
+        ++line_number;
+        if (line.rfind("#RANGEA,", 0) != 0) {
+            continue;
+        }
+        ParsedRangeEpoch epoch{};
+        std::string parse_error;
+        if (!parse_rangea_line_independent(line, &epoch, &parse_error)) {
+            set_error(error_message, "RANGEA line " + std::to_string(line_number) + ": " + parse_error);
+            return false;
+        }
+        ++result.range_epochs;
+        result.parsed_observations += static_cast<std::uint64_t>(epoch.observations.size());
+
+        SimTime time{};
+        std::int64_t absolute_ns = 0;
+        if (!sim_time_from_week_sow(epoch.gps_week, epoch.sow_sec, &time) ||
+            !absolute_time_ns(time.gps_week, time.tow_ns, &absolute_ns)) {
+            set_error(error_message, "serialized RANGEA epoch time cannot be normalized");
+            return false;
+        }
+        first_rangea_ns = std::min(first_rangea_ns, absolute_ns);
+        if (rea && !epoch.observations.empty()) {
+            for (std::size_t cycle_index = 0; cycle_index < rea_cycles.size(); ++cycle_index) {
+                const ReaCycle& cycle = rea_cycles[cycle_index];
+                ReaSerializedTiming& timing = rea_serialized_timing[cycle_index];
+                if (absolute_ns < cycle.off_ns) {
+                    timing.last_observation_before_off_ns =
+                        std::max(timing.last_observation_before_off_ns, absolute_ns);
+                } else if (absolute_ns >= cycle.on_ns && absolute_ns < cycle.end_ns) {
+                    timing.first_observation_after_on_ns = std::min(timing.first_observation_after_on_ns, absolute_ns);
+                }
+            }
+        }
+        if (rea && in_signal_off_interval(absolute_ns, rea_cycles)) {
+            ++result.rea.signal_off_range_epochs;
+            if (!epoch.observations.empty()) {
+                ++result.rea.signal_off_nonzero_epochs;
+            }
+        }
+        const ReaCycle* reacquisition_cycle = rea ? active_reacquisition_cycle(absolute_ns, rea_cycles) : nullptr;
+        const bool fade_active = rea && in_fade_window(absolute_ns, events, options.fade_duration_sec);
+
+        for (const ParsedRangeObservation& parsed : epoch.observations) {
+            const ObservationKey key{time.gps_week, time.tow_ns, parsed.satellite_number,
+                                     static_cast<int>(parsed.signal_id)};
+            const auto iterator = truth_index.find(key);
+            if (iterator == truth_index.end()) {
+                ++result.unmatched_observations;
+                continue;
+            }
+            ++result.matched_observations;
+            const TruthObservation& source = truth[iterator->second];
+            if (parsed.pseudorange_valid) {
+                first_psr_ns = std::min(first_psr_ns, absolute_ns);
+            }
+            // RANGEA has no independent Doppler-valid bit; require a matched serialized record and
+            // the zero-noise truth validity for that exact field.
+            if (source.doppler_valid) {
+                first_doppler_ns = std::min(first_doppler_ns, absolute_ns);
+            }
+            if (parsed.adr_valid) {
+                first_adr_ns = std::min(first_adr_ns, absolute_ns);
+            }
+            first_cn0_ns = std::min(first_cn0_ns, absolute_ns);
+            if (reacquisition_cycle != nullptr) {
+                const std::size_t cycle_index = static_cast<std::size_t>(reacquisition_cycle - rea_cycles.data());
+                ReaSerializedTiming& timing = rea_serialized_timing[cycle_index];
+                if (parsed.pseudorange_valid) {
+                    timing.first_psr_ns = std::min(timing.first_psr_ns, absolute_ns);
+                }
+                // RANGEA currently carries no independent Doppler-valid bit. A matched serialized
+                // record is therefore gated by the zero-noise truth validity for that exact field.
+                if (source.doppler_valid) {
+                    timing.first_doppler_ns = std::min(timing.first_doppler_ns, absolute_ns);
+                }
+                if (parsed.adr_valid) {
+                    timing.first_adr_ns = std::min(timing.first_adr_ns, absolute_ns);
+                }
+            }
+            WindowAccumulator* lock_window = &settled;
+            if (parsed.lock_time_sec < 1.0) {
+                lock_window = &early;
+            } else if (parsed.lock_time_sec < 3.0) {
+                lock_window = &recovery;
+            }
+            add_observation(lock_window, parsed, source);
+            if (fade_active) {
+                add_observation(&fade, parsed, source);
+            }
+            if (reacquisition_cycle != nullptr) {
+                WindowAccumulator* reacquisition_window = &reacquisition_settled;
+                const double elapsed_sec = static_cast<double>(absolute_ns - reacquisition_cycle->on_ns) /
+                                           static_cast<double>(NANOSECONDS_PER_SECOND);
+                if (elapsed_sec < 1.0) {
+                    reacquisition_window = &reacquisition_early;
+                } else if (elapsed_sec < 3.0) {
+                    reacquisition_window = &reacquisition_recovery;
+                }
+                add_observation(reacquisition_window, parsed, source);
+            }
+        }
+    }
+    if (result.range_epochs == 0U || result.matched_observations == 0U) {
+        set_error(error_message, "transient validator found no matched serialized RANGEA observations");
+        return false;
+    }
+
+    const auto delay_from_first_rangea = [first_rangea_ns](std::int64_t sample_ns) {
+        if (first_rangea_ns == std::numeric_limits<std::int64_t>::max() ||
+            sample_ns == std::numeric_limits<std::int64_t>::max()) {
+            return -1.0;
+        }
+        return static_cast<double>(sample_ns - first_rangea_ns) / static_cast<double>(NANOSECONDS_PER_SECOND);
+    };
+    result.first_valid.pseudorange_delay_sec = delay_from_first_rangea(first_psr_ns);
+    result.first_valid.doppler_delay_sec = delay_from_first_rangea(first_doppler_ns);
+    result.first_valid.adr_delay_sec = delay_from_first_rangea(first_adr_ns);
+    result.first_valid.cn0_delay_sec = delay_from_first_rangea(first_cn0_ns);
+
+    result.early = finalize_window(early);
+    result.recovery = finalize_window(recovery);
+    result.settled = finalize_window(settled);
+    result.fade = finalize_window(fade);
+    result.reacquisition_early = finalize_window(reacquisition_early);
+    result.reacquisition_recovery = finalize_window(reacquisition_recovery);
+    result.reacquisition_settled = finalize_window(reacquisition_settled);
+    if (rea) {
+        update_rea_timing(truth, rea_cycles, rea_serialized_timing, &result.rea);
+    }
+
+    if (!validate_rangea_roundtrip_file(
+            log_path, rinex_nav_path, options.truth_latitude_deg, options.truth_longitude_deg, options.truth_height_m,
+            options.solution_elevation_mask_deg, options.broadcast_atmosphere, &result.positioning, error_message)) {
+        return false;
+    }
+    *summary = result;
+    return true;
+}
+
+bool write_transient_validation_json(const char* output_path, const TransientValidationOptions& options,
+                                     const TransientValidationSummary& summary, std::string* error_message) {
+    if (output_path == nullptr || output_path[0] == '\0' || options.scenario_label == nullptr) {
+        set_error(error_message, "transient validation JSON request has invalid arguments");
+        return false;
+    }
+    std::ofstream output(output_path, std::ios::binary | std::ios::trunc);
+    if (!output) {
+        set_error(error_message, std::string("cannot open transient validation JSON: ") + output_path);
+        return false;
+    }
+    output.imbue(std::locale::classic());
+    output << std::setprecision(17);
+    output << "{\n"
+           << "  \"schema_version\": 1,\n"
+           << "  \"scenario\": \"" << json_escape(options.scenario_label) << "\",\n"
+           << "  \"fade_duration_sec\": " << options.fade_duration_sec << ",\n"
+           << "  \"range_epochs\": " << summary.range_epochs << ",\n"
+           << "  \"parsed_observations\": " << summary.parsed_observations << ",\n"
+           << "  \"matched_observations\": " << summary.matched_observations << ",\n"
+           << "  \"unmatched_observations\": " << summary.unmatched_observations << ",\n"
+           << "  \"first_valid\": {\n"
+           << "    \"pseudorange_delay_sec\": " << summary.first_valid.pseudorange_delay_sec << ",\n"
+           << "    \"doppler_delay_sec\": " << summary.first_valid.doppler_delay_sec << ",\n"
+           << "    \"adr_delay_sec\": " << summary.first_valid.adr_delay_sec << ",\n"
+           << "    \"cn0_delay_sec\": " << summary.first_valid.cn0_delay_sec << "\n"
+           << "  },\n"
+           << "  \"windows\": {\n"
+           << "    \"early_0_1s\": ";
+    write_window_json(output, summary.early, 4);
+    output << ",\n    \"recovery_1_3s\": ";
+    write_window_json(output, summary.recovery, 4);
+    output << ",\n    \"settled_ge_3s\": ";
+    write_window_json(output, summary.settled, 4);
+    output << ",\n    \"rea_fade\": ";
+    write_window_json(output, summary.fade, 4);
+    output << ",\n    \"rea_reacquisition_early_0_1s\": ";
+    write_window_json(output, summary.reacquisition_early, 4);
+    output << ",\n    \"rea_reacquisition_recovery_1_3s\": ";
+    write_window_json(output, summary.reacquisition_recovery, 4);
+    output << ",\n    \"rea_reacquisition_settled_ge_3s\": ";
+    write_window_json(output, summary.reacquisition_settled, 4);
+    output << "\n  },\n"
+           << "  \"rea\": {\n"
+           << "    \"signal_off_range_epochs\": " << summary.rea.signal_off_range_epochs << ",\n"
+           << "    \"signal_off_nonzero_epochs\": " << summary.rea.signal_off_nonzero_epochs << ",\n"
+           << "    \"reacquisition_cycles\": " << summary.rea.reacquisition_cycles << ",\n"
+           << "    \"max_first_psr_delay_sec\": " << summary.rea.max_first_psr_delay_sec << ",\n"
+           << "    \"max_first_doppler_delay_sec\": " << summary.rea.max_first_doppler_delay_sec << ",\n"
+           << "    \"max_first_adr_delay_sec\": " << summary.rea.max_first_adr_delay_sec << ",\n"
+           << "    \"max_last_observation_to_signal_off_sec\": " << summary.rea.max_last_observation_to_signal_off_sec
+           << ",\n"
+           << "    \"max_first_observation_after_signal_on_sec\": "
+           << summary.rea.max_first_observation_after_signal_on_sec << ",\n"
+           << "    \"ambiguity_pairs_checked\": " << summary.rea.ambiguity_pairs_checked << ",\n"
+           << "    \"ambiguity_pairs_changed\": " << summary.rea.ambiguity_pairs_changed << "\n"
+           << "  },\n"
+           << "  \"positioning\": {\n"
+           << "    \"solution_elevation_mask_deg\": " << options.solution_elevation_mask_deg << ",\n"
+           << "    \"valid_position_epochs\": " << summary.positioning.valid_position_epochs << ",\n"
+           << "    \"selected_position_observations\": " << summary.positioning.selected_position_observations << ",\n"
+           << "    \"max_position_error_m\": " << summary.positioning.max_position_error_m << ",\n"
+           << "    \"max_error_gps_week\": " << summary.positioning.max_error_gps_week << ",\n"
+           << "    \"max_error_sow_sec\": " << summary.positioning.max_error_sow_sec << ",\n"
+           << "    \"final_position_error_m\": " << summary.positioning.final_position_error_m << ",\n"
+           << "    \"final_position_gps_week\": " << summary.positioning.final_position_gps_week << ",\n"
+           << "    \"final_position_sow_sec\": " << summary.positioning.final_position_sow_sec << "\n"
+           << "  }\n"
+           << "}\n";
+    if (!output) {
+        set_error(error_message, "failed to write transient validation JSON");
+        return false;
+    }
+    return true;
+}
+
+} // namespace gnss_sim

--- a/tools/transient_validator/transient_validator.h
+++ b/tools/transient_validator/transient_validator.h
@@ -1,0 +1,85 @@
+#ifndef GNSS_SIM_TOOLS_TRANSIENT_VALIDATOR_TRANSIENT_VALIDATOR_H_
+#define GNSS_SIM_TOOLS_TRANSIENT_VALIDATOR_TRANSIENT_VALIDATOR_H_
+
+#include "rangea_roundtrip.h"
+
+#include <cstdint>
+#include <string>
+
+namespace gnss_sim {
+
+struct ErrorMetricStatistics {
+    std::uint64_t sample_count;
+    double mean;
+    double rms;
+    double standard_deviation;
+    double p50_absolute;
+    double p95_absolute;
+    double max_absolute;
+};
+
+struct ObservationWindowStatistics {
+    ErrorMetricStatistics pseudorange_m;
+    ErrorMetricStatistics doppler_mps;
+    ErrorMetricStatistics adr_m;
+    ErrorMetricStatistics cn0_dbhz;
+};
+
+struct FirstValidTimingStatistics {
+    double pseudorange_delay_sec;
+    double doppler_delay_sec;
+    double adr_delay_sec;
+    double cn0_delay_sec;
+};
+
+struct ReaTransientStatistics {
+    std::uint64_t signal_off_range_epochs;
+    std::uint64_t signal_off_nonzero_epochs;
+    std::uint64_t reacquisition_cycles;
+    double max_first_psr_delay_sec;
+    double max_first_doppler_delay_sec;
+    double max_first_adr_delay_sec;
+    double max_last_observation_to_signal_off_sec;
+    double max_first_observation_after_signal_on_sec;
+    std::uint64_t ambiguity_pairs_checked;
+    std::uint64_t ambiguity_pairs_changed;
+};
+
+struct TransientValidationOptions {
+    const char* scenario_label;
+    double fade_duration_sec;
+    double truth_latitude_deg;
+    double truth_longitude_deg;
+    double truth_height_m;
+    double solution_elevation_mask_deg;
+    bool broadcast_atmosphere;
+};
+
+struct TransientValidationSummary {
+    std::uint64_t range_epochs;
+    std::uint64_t parsed_observations;
+    std::uint64_t matched_observations;
+    std::uint64_t unmatched_observations;
+    FirstValidTimingStatistics first_valid;
+    ObservationWindowStatistics early;
+    ObservationWindowStatistics recovery;
+    ObservationWindowStatistics settled;
+    ObservationWindowStatistics fade;
+    ObservationWindowStatistics reacquisition_early;
+    ObservationWindowStatistics reacquisition_recovery;
+    ObservationWindowStatistics reacquisition_settled;
+    ReaTransientStatistics rea;
+    RangeaRoundtripSummary positioning;
+};
+
+bool validate_transient_observations_files(const char* log_path, const char* observation_truth_path,
+                                           const char* event_truth_path, const char* rinex_nav_path,
+                                           const TransientValidationOptions& options,
+                                           TransientValidationSummary* summary, std::string* error_message);
+
+bool write_transient_validation_json(const char* output_path, const TransientValidationOptions& options,
+                                     const TransientValidationSummary& summary, std::string* error_message);
+
+} // namespace gnss_sim
+
+#endif // GNSS_SIM_TOOLS_TRANSIENT_VALIDATOR_TRANSIENT_VALIDATOR_H_


### PR DESCRIPTION
Closes #74
Parent: #70
Integrated dependencies: #71 / PR #75, #72 / PR #76, and #73 / PR #77 are merged into `main`.

## What changed

- Reuses the existing independent NovAtel `RANGEA` parser as the authoritative black-box parser instead of adding a second implementation.
- Exposes parsed ADR, validity, lock time, tracking status, and canonical signal id needed by transient validation.
- Adds `validate-transient-observations`, which matches serialized `#RANGEA` to zero-noise `observation_truth.csv` by normalized GPST + satellite + signal.
- Computes PSR, Doppler/range-rate, ADR, and reported-CN0 count/mean/RMS/population-stddev/P50/P95/max statistics for early (`<1 s`), recovery (`1-3 s`), settled (`>=3 s`), REA fade, and REA reacquisition windows.
- Adds machine-readable first-valid timing and REA boundary/recovery statistics.
- Verifies REA signal-off epochs contain zero serialized observations and checks post-loss ADR ambiguity identity changes.
- Runs the same serialized `RANGEA` through the independent parser -> RTKLIB `pntpos()` path with the normal 5 degree solution mask and reports both transient maximum and final recovered position error.
- Adds compact same-seed noise-on/noise-off timing-invariance validation.
- Adds a manual/monthly real-WHU five-scenario extended workflow covering TTFF HOT/WARM/COLD and REA hard-cut/fade.
- Documents the evidence contract, current Doppler-valid limitation, ambiguity-identity limitation, statistical gates, and real-WHU validation results.

## Black-box contract

```text
real RINEX NAV
    -> simulator
    -> serialized simulated.log / #RANGEA

observation_truth.csv -------------------+
                                         |
serialized #RANGEA -> independent parser +-> GPST/satellite/signal matching
                                             -> transient error statistics
                                             -> first-valid / REA timing checks
                                             -> signal-off / reacquisition checks

serialized #RANGEA -> independent parser -> RTKLIB pntpos()
                                             -> max transient SPP error
                                             -> final recovered SPP error
```

The validator does not consume the simulator's in-memory `MeasurementObservation` as its acceptance source and never modifies observations to force RTKLIB truth.

## Final main-based compact validation

GitHub Actions run `33231899896` on head `8f61a32d9f732b0397e6b19e1e8ffbeca39e5048`:

- format: PASS
- tooling self-test: PASS
- Ubuntu build/test: PASS, **186/186 tests**
- Windows build/test: PASS
- TTFF HOT black-box gate: PSR/Doppler/CN0 all require `early > recovery > settled`
- REA fade gate: zero observations during off windows, bounded serialized recovery timing, fresh ambiguity identity, and final SPP recovery
- same-seed `measurement_noise_enabled=true/false`: serialized acquisition/reacquisition timing remains identical
- serialized RANGEA positioning report remains `0.000817122 m` max 3D error at GPST `2347/436501`, 59 valid epochs

The retargeted head uses exactly the same Git tree (`5389754c1e326b89836702aec58ab34b6a7b5b0f`) as the previously reviewed/extended-validated stacked head. Only commit ancestry changed to make `main` the parent after #75-#77 were squash-merged.

## Extended real-WHU validation

Real-WHU Actions run `33230616700` completed successfully using the pinned source:

`BRD400DLR_S_20250030000_01D_MN.rnx.gz`

- gzip SHA256: `fb84d4046b06e905e8e4ec0efb82f0e9ad044bc44d664cc0209cb9b4c92b9512`
- uncompressed SHA256: `b11c638eea42978b8bd6aa8b65a5099fe6556dfe527bc037ed481d2b239afc42`

TTFF RMS progression:

| Scenario | PSR RMS early -> recovery -> settled (m) | Doppler RMS early -> recovery -> settled (m/s) | Settled ADR RMS (m) | Max transient SPP error (m) |
| --- | --- | --- | --- | --- |
| HOT | 0.367038 -> 0.204716 -> 0.081367 | 0.064916 -> 0.034994 -> 0.030016 | 0.000993 | 2.547964 |
| WARM | 0.442217 -> 0.278356 -> 0.081871 | 0.091114 -> 0.046890 -> 0.030073 | 0.000998 | 3.993733 |
| COLD | 0.629439 -> 0.442173 -> 0.084113 | 0.117659 -> 0.066533 -> 0.030133 | 0.000999 | 5.550588 |

REA hard-cut and fade results:

- each case: 60 serialized signal-off RANGEA epochs, **0** non-empty off epochs
- each case: 3 reacquisition cycles
- max first recovered PSR / Doppler / ADR delay: 0.2 s / 0.3 s / 0.6 s
- each case: **721/721** comparable pre-loss/post-reacquisition ambiguity identities changed
- max transient SPP error: 15.671076 m hard-cut, 7.238175 m fade
- both pass the final recovered SPP `<5 m` gate
- hard-cut has no artificial fade window; fade has finite pre-loss degradation

The final workflow is manual + monthly. TTFF HOT/WARM/COLD gates require PSR, Doppler, and CN0 RMS to decay through all three windows: `early > recovery > settled`.

## Evidence limitations

- Current RANGEA wire output does not encode an independent Doppler-valid bit. Doppler first-valid timing therefore requires a matched serialized record plus the zero-noise truth Doppler-valid state for that exact epoch/satellite/signal.
- Integer ADR ambiguity identity is not recoverable from RANGEA itself. RANGEA proves the observation exists; fresh-ambiguity identity comparison uses zero-noise truth metadata for matched signals.
- The black-box SPP path intentionally uses the complete real RINEX NAV store, not receiver ephemeris acquisition/update order. Receiver-NAV replay is a separate concern.

## Non-goals

- No synthetic navigation or ephemeris.
- No observation tuning to RTKLIB truth.
- No multipath/obstruction model.
- No change to #71-#73 measurement generation semantics.

## Implementation Notes

PR #75, #76, and #77 are now integrated into `main`. This PR was retargeted by preserving the exact previously validated final tree and rebuilding only its parent onto the post-#77 `main` commit. The resulting diff is one commit, `ahead=1 / behind=0`, exactly 10 Issue #74 business files, with no temporary patch helpers/workflows.

The existing RANGEA parser remains authoritative; this PR only exposes the parsed fields needed by the transient validator. The extended five-scenario survey is recorded in `docs/TTFF_REA_TRANSIENT_VALIDATION.md`, and the extended workflow remains manual/monthly.