### PR TITLE
Position from serialized RANGEA and NAV logs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,25 @@ add_executable(validate-rangea-roundtrip
 target_link_libraries(validate-rangea-roundtrip PRIVATE rangea_roundtrip_core)
 gnss_sim_set_project_warnings(validate-rangea-roundtrip)
 
+add_library(serialized_nav_roundtrip_core STATIC
+    tools/serialized_nav_roundtrip/serialized_nav_roundtrip.cpp
+)
+target_include_directories(serialized_nav_roundtrip_core
+    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/tools/serialized_nav_roundtrip"
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src"
+)
+target_link_libraries(serialized_nav_roundtrip_core
+    PUBLIC rangea_roundtrip_core
+    PRIVATE gnss_sim::rtklib
+)
+gnss_sim_set_project_warnings(serialized_nav_roundtrip_core)
+
+add_executable(validate-serialized-nav-roundtrip
+    tools/serialized_nav_roundtrip/main.cpp
+)
+target_link_libraries(validate-serialized-nav-roundtrip PRIVATE serialized_nav_roundtrip_core)
+gnss_sim_set_project_warnings(validate-serialized-nav-roundtrip)
+
 add_library(transient_validator_core STATIC
     tools/transient_validator/transient_validator.cpp
 )
@@ -269,6 +288,7 @@ if(BUILD_TESTING)
         tests/integration/test_measurement_noise_integration.cpp
         tests/integration/test_rea_fade.cpp
         tests/integration/test_rangea_roundtrip.cpp
+        tests/integration/test_serialized_nav_roundtrip.cpp
         tests/integration/test_transient_validator.cpp
         tests/integration/test_residual_validator.cpp
         tests/integration/test_truth_outputs.cpp
@@ -283,6 +303,7 @@ if(BUILD_TESTING)
         gnss_sim::rtklib
         residual_validator_core
         rangea_roundtrip_core
+        serialized_nav_roundtrip_core
         transient_validator_core
         GTest::gtest_main
     )

--- a/src/gnss/rtklib_adapter.cpp
+++ b/src/gnss/rtklib_adapter.cpp
@@ -1,5 +1,7 @@
 #include "gnss/rtklib_adapter.h"
 
+#include "gnss/nav_output_record.h"
+
 extern "C" {
 #include <rtklib.h>
 #include <rtklib_obs_ext.h>
@@ -439,6 +441,198 @@ bool rtklib_copy_nav_record(const RtklibNavStore* source, int record_index, Rtkl
         return false;
     }
     return true;
+}
+
+int output_system_to_rtklib(NavOutputSystem system) {
+    switch (system) {
+        case NavOutputSystem::kGps:
+            return SYS_GPS;
+        case NavOutputSystem::kGlonass:
+            return SYS_GLO;
+        case NavOutputSystem::kGalileo:
+            return SYS_GAL;
+        case NavOutputSystem::kBeidou:
+            return SYS_CMP;
+        case NavOutputSystem::kQzss:
+            return SYS_QZS;
+        case NavOutputSystem::kNavic:
+            return SYS_IRN;
+        case NavOutputSystem::kUnknown:
+            return SYS_NONE;
+    }
+    return SYS_NONE;
+}
+
+int output_family_to_message_type(int system, RtklibBroadcastMessageFamily family) {
+    switch (family) {
+        case RtklibBroadcastMessageFamily::kLegacy:
+            if (system == SYS_GPS || system == SYS_QZS) {
+                return NAV_LNAV;
+            }
+            if (system == SYS_CMP) {
+                return NAV_D1D2;
+            }
+            return 0;
+        case RtklibBroadcastMessageFamily::kCnav:
+            return NAV_CNAV;
+        case RtklibBroadcastMessageFamily::kCnav2:
+            return NAV_CNV2;
+        case RtklibBroadcastMessageFamily::kGalileoInav:
+            return NAV_INAV;
+        case RtklibBroadcastMessageFamily::kGalileoFnav:
+            return NAV_FNAV;
+        case RtklibBroadcastMessageFamily::kBeidouBcnav1:
+            return NAV_CNV1;
+        case RtklibBroadcastMessageFamily::kBeidouBcnav2:
+            return NAV_CNV2;
+        case RtklibBroadcastMessageFamily::kBeidouBcnav3:
+            return NAV_CNV3;
+        case RtklibBroadcastMessageFamily::kGlonassFdma:
+            return NAV_FDMA;
+        case RtklibBroadcastMessageFamily::kGlonassL3Oc:
+            return NAV_L3OC;
+        case RtklibBroadcastMessageFamily::kUnknown:
+            return 0;
+    }
+    return 0;
+}
+
+bool rtklib_append_nav_output_record(RtklibNavStore* destination, const NavOutputRecord& record,
+                                     std::string* error_message) {
+    if (destination == nullptr) {
+        set_error(error_message, "serialized NAV append request has null destination");
+        return false;
+    }
+
+    if (record.kind == RtklibNavRecordKind::kEphemeris) {
+        const KeplerianNavOutputData& source = record.ephemeris;
+        const int system = output_system_to_rtklib(source.system);
+        const int message_type = output_family_to_message_type(system, source.message_family);
+        if (system == SYS_NONE || message_type == 0 || source.prn <= 0 || source.toe_week < 0 || source.toc_week < 0 ||
+            source.transmit_week < 0 || !valid_gps_time(source.toe_week, source.toe_sow_sec) ||
+            !valid_gps_time(source.toc_week, source.toc_sow_sec) ||
+            !valid_gps_time(source.transmit_week, source.transmit_sow_sec) ||
+            !std::isfinite(source.semi_major_axis_m) || source.semi_major_axis_m <= 0.0) {
+            set_error(error_message, "serialized Keplerian NAV record has invalid required fields");
+            return false;
+        }
+        const int satellite = satno(system, source.prn);
+        if (satellite <= 0) {
+            set_error(error_message, "serialized Keplerian NAV record has unsupported satellite");
+            return false;
+        }
+
+        eph_t eph{};
+        eph.sat = satellite;
+        eph.iode = source.iode;
+        eph.iodc = source.iodc;
+        eph.sva = source.sva;
+        eph.svh = source.svh;
+        eph.week = source.toe_week;
+        eph.code = source.code;
+        eph.flag = source.flag;
+        eph.toe = gpst2time(source.toe_week, source.toe_sow_sec);
+        eph.toc = gpst2time(source.toc_week, source.toc_sow_sec);
+        eph.ttr = gpst2time(source.transmit_week, source.transmit_sow_sec);
+        eph.A = source.semi_major_axis_m;
+        eph.e = source.eccentricity;
+        eph.i0 = source.inclination_rad;
+        eph.OMG0 = source.omega0_rad;
+        eph.omg = source.argument_of_perigee_rad;
+        eph.M0 = source.mean_anomaly_rad;
+        eph.deln = source.delta_mean_motion_radps;
+        eph.OMGd = source.omega_dot_radps;
+        eph.idot = source.inclination_dot_radps;
+        eph.crc = source.crc_m;
+        eph.crs = source.crs_m;
+        eph.cuc = source.cuc_rad;
+        eph.cus = source.cus_rad;
+        eph.cic = source.cic_rad;
+        eph.cis = source.cis_rad;
+        eph.toes = source.toe_sow_sec;
+        eph.fit = source.fit_hours;
+        eph.f0 = source.clock_bias_sec;
+        eph.f1 = source.clock_drift_sec_per_sec;
+        eph.f2 = source.clock_drift_rate_sec_per_sec2;
+        std::memcpy(eph.tgd, source.tgd_sec, sizeof(eph.tgd));
+        std::memcpy(eph.isc, source.isc_sec, sizeof(eph.isc));
+        eph.hdr.data_type = NAV_EPH;
+        eph.hdr.sys = system;
+        eph.hdr.prn = source.prn;
+        eph.hdr.msg_type = message_type;
+        if (!append_eph(eph, &destination->nav)) {
+            set_error(error_message, "cannot allocate serialized Keplerian NAV record");
+            return false;
+        }
+        uniqnav(&destination->nav);
+        return true;
+    }
+
+    if (record.kind == RtklibNavRecordKind::kGlonassEphemeris) {
+        const GlonassNavOutputData& source = record.glonass;
+        if (source.message_family != RtklibBroadcastMessageFamily::kGlonassFdma || source.prn <= 0 ||
+            source.toe_week < 0 || source.frame_week < 0 || !valid_gps_time(source.toe_week, source.toe_sow_sec) ||
+            !valid_gps_time(source.frame_week, source.frame_sow_sec)) {
+            set_error(error_message, "serialized GLONASS NAV record has invalid required fields");
+            return false;
+        }
+        const int satellite = satno(SYS_GLO, source.prn);
+        if (satellite <= 0) {
+            set_error(error_message, "serialized GLONASS NAV record has unsupported satellite");
+            return false;
+        }
+        geph_t geph{};
+        geph.sat = satellite;
+        geph.iode = source.iode;
+        geph.frq = source.frequency_channel;
+        geph.svh = source.svh;
+        geph.sva = source.sva;
+        geph.age = source.age_days;
+        geph.flag = source.flags;
+        geph.toe = gpst2time(source.toe_week, source.toe_sow_sec);
+        geph.tof = gpst2time(source.frame_week, source.frame_sow_sec);
+        std::memcpy(geph.pos, source.position_ecef_m, sizeof(geph.pos));
+        std::memcpy(geph.vel, source.velocity_ecef_mps, sizeof(geph.vel));
+        std::memcpy(geph.acc, source.acceleration_ecef_mps2, sizeof(geph.acc));
+        geph.taun = source.clock_bias_sec;
+        geph.gamn = source.relative_frequency_bias;
+        geph.dtaun = source.differential_delay_sec;
+        geph.hdr.data_type = NAV_EPH;
+        geph.hdr.sys = SYS_GLO;
+        geph.hdr.prn = source.prn;
+        geph.hdr.msg_type = NAV_FDMA;
+        if (!append_geph(geph, &destination->nav)) {
+            set_error(error_message, "cannot allocate serialized GLONASS NAV record");
+            return false;
+        }
+        uniqnav(&destination->nav);
+        return true;
+    }
+
+    if (record.kind == RtklibNavRecordKind::kIonosphere) {
+        const IonosphereNavOutputData& source = record.ionosphere;
+        if (!source.legacy_metadata || source.coefficient_count < 8) {
+            set_error(error_message, "serialized ionosphere record is outside supported legacy ASCII scope");
+            return false;
+        }
+        if (source.system == NavOutputSystem::kGps) {
+            std::memcpy(destination->nav.ion_gps, source.coefficients, sizeof(destination->nav.ion_gps));
+            std::memcpy(destination->nav.utc_gps, source.utc, sizeof(destination->nav.utc_gps));
+            destination->nav.leaps = source.leap_seconds;
+            return true;
+        }
+        if (source.system == NavOutputSystem::kBeidou) {
+            std::memcpy(destination->nav.ion_cmp, source.coefficients, sizeof(destination->nav.ion_cmp));
+            std::memcpy(destination->nav.utc_cmp, source.utc, sizeof(destination->nav.utc_cmp));
+            destination->nav.leaps = source.leap_seconds;
+            return true;
+        }
+        set_error(error_message, "serialized ionosphere record has unsupported system");
+        return false;
+    }
+
+    set_error(error_message, "serialized NAV record has unsupported kind");
+    return false;
 }
 
 bool rtklib_nav_store_has_satellite_ephemeris(const RtklibNavStore* store, int satellite_number) {

--- a/src/gnss/rtklib_adapter.h
+++ b/src/gnss/rtklib_adapter.h
@@ -6,6 +6,7 @@
 namespace gnss_sim {
 
 struct RtklibNavStore;
+struct NavOutputRecord;
 
 enum class RtklibNavRecordKind {
     kEphemeris,
@@ -148,6 +149,8 @@ bool rtklib_copy_nav_snapshot(const RtklibNavStore* source, int gps_week, double
                               std::string* error_message);
 bool rtklib_copy_nav_record(const RtklibNavStore* source, int record_index, RtklibNavStore* destination,
                             std::string* error_message);
+bool rtklib_append_nav_output_record(RtklibNavStore* destination, const NavOutputRecord& record,
+                                     std::string* error_message);
 bool rtklib_nav_store_has_satellite_ephemeris(const RtklibNavStore* store, int satellite_number);
 
 bool rtklib_satellite_state_available(const RtklibNavStore* store, int gps_week, double sow_sec, int satellite_number);
@@ -177,6 +180,10 @@ bool rtklib_solve_raw_single_position(const RtklibNavStore* receiver_nav, int gp
                                       const RtklibRawCodeObservation* observations, int observation_count,
                                       double elevation_mask_deg, bool broadcast_atmosphere,
                                       RtklibPositionSolution* solution, std::string* error_message);
+bool rtklib_solve_raw_single_position_available_nav(const RtklibNavStore* receiver_nav, int gps_week, double sow_sec,
+                                                    const RtklibRawCodeObservation* observations, int observation_count,
+                                                    double elevation_mask_deg, bool broadcast_atmosphere,
+                                                    RtklibPositionSolution* solution, std::string* error_message);
 bool rtklib_solve_single_velocity(const RtklibNavStore* receiver_nav, int gps_week, double sow_sec,
                                   const RtklibSolutionObservation* observations, int observation_count,
                                   const double position_hint_ecef_m[3], double elevation_mask_deg,

--- a/src/gnss/rtklib_raw_position_adapter.cpp
+++ b/src/gnss/rtklib_raw_position_adapter.cpp
@@ -101,10 +101,10 @@ bool validate_raw_observation(const RtklibRawCodeObservation& source, int index,
 
 } // namespace
 
-bool rtklib_solve_raw_single_position(const RtklibNavStore* receiver_nav, int gps_week, double sow_sec,
-                                      const RtklibRawCodeObservation* observations, int observation_count,
-                                      double elevation_mask_deg, bool broadcast_atmosphere,
-                                      RtklibPositionSolution* solution, std::string* error_message) {
+bool solve_raw_single_position_impl(const RtklibNavStore* receiver_nav, int gps_week, double sow_sec,
+                                    const RtklibRawCodeObservation* observations, int observation_count,
+                                    double elevation_mask_deg, bool broadcast_atmosphere, bool skip_missing_navigation,
+                                    RtklibPositionSolution* solution, std::string* error_message) {
     if (receiver_nav == nullptr || observations == nullptr || observation_count < 0 || observation_count > MAXOBS ||
         solution == nullptr || !valid_time(gps_week, sow_sec) || !std::isfinite(elevation_mask_deg) ||
         elevation_mask_deg < -90.0 || elevation_mask_deg > 90.0) {
@@ -112,10 +112,6 @@ bool rtklib_solve_raw_single_position(const RtklibNavStore* receiver_nav, int gp
         return false;
     }
 
-    // The current black-box accuracy gate intentionally uses every ephemeris
-    // available in the real RINEX NAV input. Receiver acquisition/update order
-    // is out of scope until the serialized RANGEA positioning error is first
-    // characterized with unrestricted real broadcast navigation.
     const gtime_t epoch_time = gpst2time(gps_week, sow_sec);
     RtklibSolutionObservation converted[MAXOBS]{};
     bool seen_satellite[MAXSAT]{};
@@ -140,6 +136,9 @@ bool rtklib_solve_raw_single_position(const RtklibNavStore* receiver_nav, int gp
         double rtklib_code_bias_m = 0.0;
         const int bias_status = signal_bias_status(receiver_nav, epoch_time, source, message_mask, &rtklib_code_bias_m);
         if (bias_status != 1 || !std::isfinite(rtklib_code_bias_m)) {
+            if (skip_missing_navigation && bias_status == 0) {
+                continue;
+            }
             if (error_message != nullptr) {
                 char message[224]{};
                 std::snprintf(message, sizeof(message),
@@ -168,6 +167,27 @@ bool rtklib_solve_raw_single_position(const RtklibNavStore* receiver_nav, int gp
 
     return rtklib_solve_single_position(receiver_nav, gps_week, sow_sec, converted, prepared_count, elevation_mask_deg,
                                         broadcast_atmosphere, solution, error_message);
+}
+
+bool rtklib_solve_raw_single_position(const RtklibNavStore* receiver_nav, int gps_week, double sow_sec,
+                                      const RtklibRawCodeObservation* observations, int observation_count,
+                                      double elevation_mask_deg, bool broadcast_atmosphere,
+                                      RtklibPositionSolution* solution, std::string* error_message) {
+    // The historical RANGEA black-box reference path intentionally assumes a
+    // complete real-RINEX NAV store. Keep missing family EPH as a hard failure.
+    return solve_raw_single_position_impl(receiver_nav, gps_week, sow_sec, observations, observation_count,
+                                          elevation_mask_deg, broadcast_atmosphere, false, solution, error_message);
+}
+
+bool rtklib_solve_raw_single_position_available_nav(const RtklibNavStore* receiver_nav, int gps_week, double sow_sec,
+                                                    const RtklibRawCodeObservation* observations, int observation_count,
+                                                    double elevation_mask_deg, bool broadcast_atmosphere,
+                                                    RtklibPositionSolution* solution, std::string* error_message) {
+    // A receiver can track a signal before it owns the corresponding broadcast
+    // family. Serialized-log replay must therefore ignore only observations
+    // whose valid family EPH has not appeared yet, matching solve_receiver_epoch().
+    return solve_raw_single_position_impl(receiver_nav, gps_week, sow_sec, observations, observation_count,
+                                          elevation_mask_deg, broadcast_atmosphere, true, solution, error_message);
 }
 
 } // namespace gnss_sim

--- a/tests/integration/test_serialized_nav_roundtrip.cpp
+++ b/tests/integration/test_serialized_nav_roundtrip.cpp
@@ -1,6 +1,7 @@
 #include "gnss_sim/sim_config.h"
 #include "gnss_sim/sim_time.h"
 #include "gnss_sim/simulator.h"
+#include "rangea_roundtrip.h"
 #include "serialized_nav_roundtrip.h"
 
 #include <filesystem>

--- a/tests/integration/test_serialized_nav_roundtrip.cpp
+++ b/tests/integration/test_serialized_nav_roundtrip.cpp
@@ -1,0 +1,173 @@
+#include "gnss_sim/sim_config.h"
+#include "gnss_sim/sim_time.h"
+#include "gnss_sim/simulator.h"
+#include "serialized_nav_roundtrip.h"
+
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <iterator>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::string nav_path() {
+    return std::string(GNSS_SIM_TEST_DATA_DIR) + "/brd400dlr_rinex4_acceptance_nav.rnx";
+}
+
+gnss_sim::SimTime start_time() {
+    gnss_sim::SimTime time{};
+    EXPECT_TRUE(gnss_sim::sim_time_from_week_sow(2347, 436500.0, &time));
+    return time;
+}
+
+gnss_sim::SimConfig config() {
+    gnss_sim::SimConfig value = gnss_sim::default_sim_config();
+    value.scenario = gnss_sim::ScenarioType::KS;
+    value.atmosphere_mode = gnss_sim::AtmosphereMode::BROADCAST;
+    value.sampling_rate_hz = 1;
+    value.duration_ns = 60LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    value.elevation_mask_deg = 0.0;
+    value.solution_elevation_mask_deg = 5.0;
+    value.receiver = {20.0, 120.0, 100.0};
+    value.measurement_noise_enabled = false;
+    value.multipath_enabled = false;
+    value.output_eph = true;
+    value.output_ion = true;
+    value.seed = 0x81U;
+    return value;
+}
+
+bool run_case(const std::filesystem::path& directory, std::string* error_message) {
+    std::error_code error;
+    std::filesystem::remove_all(directory, error);
+    error.clear();
+    if (!std::filesystem::create_directories(directory, error) || error) {
+        if (error_message != nullptr) {
+            *error_message = error.message();
+        }
+        return false;
+    }
+    const std::string log = (directory / "simulated.log").string();
+    const std::string nav = nav_path();
+    const gnss_sim::SimulatorRunOptions options{nav.c_str(), log.c_str(), start_time()};
+    gnss_sim::SimulatorRunSummary summary{};
+    return gnss_sim::run_simulator(config(), options, &summary, error_message);
+}
+
+std::vector<std::string> read_lines(const std::filesystem::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    std::vector<std::string> lines;
+    std::string line;
+    while (std::getline(input, line)) {
+        lines.push_back(line);
+    }
+    return lines;
+}
+
+void cleanup(const std::filesystem::path& path) {
+    std::error_code error;
+    std::filesystem::remove_all(path, error);
+}
+
+TEST(SerializedNavRoundtripIntegration, GeneratedNovatelLogPositionsWithoutOriginalRinexNav) {
+    const std::filesystem::path directory = "gnss_sim_serialized_nav_roundtrip";
+    std::string error_message;
+    ASSERT_TRUE(run_case(directory, &error_message)) << error_message;
+
+    gnss_sim::SerializedNavRoundtripSummary summary{};
+    const std::string log = (directory / "simulated.log").string();
+    ASSERT_TRUE(gnss_sim::validate_serialized_nav_roundtrip_file(log.c_str(), 20.0, 120.0, 100.0, 5.0, true, &summary,
+                                                                 &error_message))
+        << error_message;
+    EXPECT_GT(summary.gps_ephemeris_records, 0U);
+    EXPECT_GT(summary.glonass_ephemeris_records, 0U);
+    EXPECT_GT(summary.galileo_ephemeris_records, 0U);
+    EXPECT_GT(summary.beidou_ephemeris_records, 0U);
+    EXPECT_GT(summary.qzss_ephemeris_records, 0U);
+    EXPECT_GT(summary.ionosphere_records, 0U);
+    EXPECT_EQ(summary.range_epochs, 60U);
+    EXPECT_GT(summary.valid_position_epochs, 0U);
+    EXPECT_LT(summary.max_position_error_m, 0.05)
+        << "15-digit serialized orbital/clock fields should preserve centimeter-class black-box SPP agreement";
+    cleanup(directory);
+}
+
+TEST(SerializedNavRoundtripIntegration, FutureNavRecordsCannotBeUsedBeforeTheyAppear) {
+    const std::filesystem::path directory = "gnss_sim_serialized_nav_ordering";
+    std::string error_message;
+    ASSERT_TRUE(run_case(directory, &error_message)) << error_message;
+    const std::vector<std::string> lines = read_lines(directory / "simulated.log");
+
+    std::string moved_range;
+    gnss_sim::ParsedRangeEpoch moved_epoch{};
+    for (const std::string& line : lines) {
+        if (line.rfind("#RANGEA,", 0) != 0) {
+            continue;
+        }
+        gnss_sim::ParsedRangeEpoch candidate{};
+        ASSERT_TRUE(gnss_sim::parse_rangea_line_independent(line, &candidate, &error_message)) << error_message;
+        int valid_psr = 0;
+        for (const gnss_sim::ParsedRangeObservation& observation : candidate.observations) {
+            if (observation.pseudorange_valid) {
+                ++valid_psr;
+            }
+        }
+        if (valid_psr >= 4) {
+            moved_range = line;
+            moved_epoch = candidate;
+            break;
+        }
+    }
+    ASSERT_FALSE(moved_range.empty());
+
+    std::ostringstream reordered;
+    reordered << moved_range << '\n';
+    bool removed_original = false;
+    for (const std::string& line : lines) {
+        if (!removed_original && line == moved_range) {
+            removed_original = true;
+            continue;
+        }
+        reordered << line << '\n';
+    }
+    std::istringstream input(reordered.str());
+    gnss_sim::SerializedNavRoundtripSummary summary{};
+    ASSERT_TRUE(gnss_sim::validate_serialized_nav_roundtrip_stream(&input, 20.0, 120.0, 100.0, 5.0, true, &summary,
+                                                                   &error_message))
+        << error_message;
+    EXPECT_GT(summary.valid_position_epochs, 0U);
+    EXPECT_TRUE(summary.first_valid_position_gps_week > moved_epoch.gps_week ||
+                (summary.first_valid_position_gps_week == moved_epoch.gps_week &&
+                 summary.first_valid_position_sow_sec > moved_epoch.sow_sec));
+    cleanup(directory);
+}
+
+TEST(SerializedNavRoundtripIntegration, CorruptedSerializedEphemerisCrcFailsExplicitly) {
+    const std::filesystem::path directory = "gnss_sim_serialized_nav_crc";
+    std::string error_message;
+    ASSERT_TRUE(run_case(directory, &error_message)) << error_message;
+    std::vector<std::string> lines = read_lines(directory / "simulated.log");
+    bool corrupted = false;
+    std::ostringstream stream_text;
+    for (std::string line : lines) {
+        if (!corrupted && line.rfind("#GPSEPHEMA,", 0) == 0) {
+            const std::size_t star = line.rfind('*');
+            ASSERT_NE(star, std::string::npos);
+            line.replace(star + 1U, 8U, "00000000");
+            corrupted = true;
+        }
+        stream_text << line << '\n';
+    }
+    ASSERT_TRUE(corrupted);
+    std::istringstream input(stream_text.str());
+    gnss_sim::SerializedNavRoundtripSummary summary{};
+    EXPECT_FALSE(gnss_sim::validate_serialized_nav_roundtrip_stream(&input, 20.0, 120.0, 100.0, 5.0, true, &summary,
+                                                                    &error_message));
+    EXPECT_NE(error_message.find("CRC mismatch"), std::string::npos) << error_message;
+    cleanup(directory);
+}
+
+} // namespace

--- a/tools/rangea_roundtrip/rangea_roundtrip.cpp
+++ b/tools/rangea_roundtrip/rangea_roundtrip.cpp
@@ -411,6 +411,49 @@ bool parse_rangea_line_independent(const std::string& raw_line, ParsedRangeEpoch
     return parse_rangea_line_impl(raw_line, epoch, error_message);
 }
 
+bool solve_parsed_rangea_epoch(const ParsedRangeEpoch& epoch, const RtklibNavStore* nav, double elevation_mask_deg,
+                               bool broadcast_atmosphere, RtklibPositionSolution* solution, int* selected_count,
+                               std::string* error_message) {
+    if (nav == nullptr || solution == nullptr || selected_count == nullptr) {
+        set_error(error_message, "parsed RANGEA solve request has invalid arguments");
+        return false;
+    }
+    std::vector<RtklibRawCodeObservation> selected;
+    if (!select_position_observations(epoch, &selected, error_message)) {
+        return false;
+    }
+    *selected_count = static_cast<int>(selected.size());
+    if (selected.empty()) {
+        *solution = RtklibPositionSolution{};
+        return true;
+    }
+    return rtklib_solve_raw_single_position(nav, epoch.gps_week, epoch.sow_sec, selected.data(),
+                                            static_cast<int>(selected.size()), elevation_mask_deg, broadcast_atmosphere,
+                                            solution, error_message);
+}
+
+bool solve_parsed_rangea_epoch_available_nav(const ParsedRangeEpoch& epoch, const RtklibNavStore* nav,
+                                             double elevation_mask_deg, bool broadcast_atmosphere,
+                                             RtklibPositionSolution* solution, int* selected_count,
+                                             std::string* error_message) {
+    if (nav == nullptr || solution == nullptr || selected_count == nullptr) {
+        set_error(error_message, "parsed RANGEA receiver-NAV solve request has invalid arguments");
+        return false;
+    }
+    std::vector<RtklibRawCodeObservation> selected;
+    if (!select_position_observations(epoch, &selected, error_message)) {
+        return false;
+    }
+    *selected_count = static_cast<int>(selected.size());
+    if (selected.empty()) {
+        *solution = RtklibPositionSolution{};
+        return true;
+    }
+    return rtklib_solve_raw_single_position_available_nav(nav, epoch.gps_week, epoch.sow_sec, selected.data(),
+                                                          static_cast<int>(selected.size()), elevation_mask_deg,
+                                                          broadcast_atmosphere, solution, error_message);
+}
+
 bool validate_rangea_roundtrip_stream(std::istream* input, const char* rinex_nav_path, double truth_latitude_deg,
                                       double truth_longitude_deg, double truth_height_m, double elevation_mask_deg,
                                       bool broadcast_atmosphere, RangeaRoundtripSummary* summary,

--- a/tools/rangea_roundtrip/rangea_roundtrip.h
+++ b/tools/rangea_roundtrip/rangea_roundtrip.h
@@ -8,6 +8,9 @@
 
 namespace gnss_sim {
 
+struct RtklibNavStore;
+struct RtklibPositionSolution;
+
 struct ParsedRangeObservation {
     int satellite_number;
     int signal_id;
@@ -28,6 +31,13 @@ struct ParsedRangeEpoch {
 };
 
 bool parse_rangea_line_independent(const std::string& raw_line, ParsedRangeEpoch* epoch, std::string* error_message);
+bool solve_parsed_rangea_epoch(const ParsedRangeEpoch& epoch, const RtklibNavStore* nav, double elevation_mask_deg,
+                               bool broadcast_atmosphere, RtklibPositionSolution* solution, int* selected_count,
+                               std::string* error_message);
+bool solve_parsed_rangea_epoch_available_nav(const ParsedRangeEpoch& epoch, const RtklibNavStore* nav,
+                                             double elevation_mask_deg, bool broadcast_atmosphere,
+                                             RtklibPositionSolution* solution, int* selected_count,
+                                             std::string* error_message);
 
 struct RangeaRoundtripSummary {
     std::uint64_t range_epochs;

--- a/tools/serialized_nav_roundtrip/main.cpp
+++ b/tools/serialized_nav_roundtrip/main.cpp
@@ -1,0 +1,39 @@
+#include "serialized_nav_roundtrip.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+int main(int argc, char** argv) {
+    if (argc < 5 || argc > 7) {
+        std::cerr << "usage: validate-serialized-nav-roundtrip <log> <lat_deg> <lon_deg> <height_m> "
+                     "[elevation_mask_deg] [broadcast_atmosphere:0|1]\n";
+        return 2;
+    }
+    const double latitude_deg = std::strtod(argv[2], nullptr);
+    const double longitude_deg = std::strtod(argv[3], nullptr);
+    const double height_m = std::strtod(argv[4], nullptr);
+    const double elevation_mask_deg = argc >= 6 ? std::strtod(argv[5], nullptr) : 5.0;
+    const bool broadcast_atmosphere = argc < 7 || std::string(argv[6]) != "0";
+
+    gnss_sim::SerializedNavRoundtripSummary summary{};
+    std::string error_message;
+    if (!gnss_sim::validate_serialized_nav_roundtrip_file(argv[1], latitude_deg, longitude_deg, height_m,
+                                                          elevation_mask_deg, broadcast_atmosphere, &summary,
+                                                          &error_message)) {
+        std::cerr << error_message << '\n';
+        return 1;
+    }
+    std::cout << "nav_records=" << summary.nav_records << '\n';
+    std::cout << "gps_eph=" << summary.gps_ephemeris_records << '\n';
+    std::cout << "glo_eph=" << summary.glonass_ephemeris_records << '\n';
+    std::cout << "gal_eph=" << summary.galileo_ephemeris_records << '\n';
+    std::cout << "bds_eph=" << summary.beidou_ephemeris_records << '\n';
+    std::cout << "qzss_eph=" << summary.qzss_ephemeris_records << '\n';
+    std::cout << "ion=" << summary.ionosphere_records << '\n';
+    std::cout << "range_epochs=" << summary.range_epochs << '\n';
+    std::cout << "valid_position_epochs=" << summary.valid_position_epochs << '\n';
+    std::cout << "max_3d_error_m=" << summary.max_position_error_m << '\n';
+    std::cout << "final_3d_error_m=" << summary.final_position_error_m << '\n';
+    return 0;
+}

--- a/tools/serialized_nav_roundtrip/serialized_nav_roundtrip.cpp
+++ b/tools/serialized_nav_roundtrip/serialized_nav_roundtrip.cpp
@@ -1,0 +1,574 @@
+#include "serialized_nav_roundtrip.h"
+
+#include "gnss/nav_output_record.h"
+#include "gnss/rtklib_adapter.h"
+#include "rangea_roundtrip.h"
+
+#include <cmath>
+#include <cstdint>
+#include <fstream>
+#include <locale>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace gnss_sim {
+namespace {
+
+struct ParsedNavLine {
+    int output_gps_week;
+    double output_sow_sec;
+    NavOutputRecord record;
+};
+
+void set_error(std::string* error_message, const std::string& message) {
+    if (error_message != nullptr) {
+        *error_message = message;
+    }
+}
+
+std::vector<std::string> split(const std::string& text, char delimiter) {
+    std::vector<std::string> fields;
+    std::istringstream stream(text);
+    std::string field;
+    while (std::getline(stream, field, delimiter)) {
+        fields.push_back(field);
+    }
+    if (!text.empty() && text.back() == delimiter) {
+        fields.emplace_back();
+    }
+    return fields;
+}
+
+bool parse_int(const std::string& text, int* value) {
+    if (value == nullptr || text.empty()) {
+        return false;
+    }
+    std::istringstream stream(text);
+    stream.imbue(std::locale::classic());
+    int parsed = 0;
+    stream >> parsed;
+    if (!stream || stream.peek() != std::char_traits<char>::eof()) {
+        return false;
+    }
+    *value = parsed;
+    return true;
+}
+
+bool parse_double(const std::string& text, double* value) {
+    if (value == nullptr || text.empty()) {
+        return false;
+    }
+    std::istringstream stream(text);
+    stream.imbue(std::locale::classic());
+    double parsed = 0.0;
+    stream >> parsed;
+    if (!stream || stream.peek() != std::char_traits<char>::eof() || !std::isfinite(parsed)) {
+        return false;
+    }
+    *value = parsed;
+    return true;
+}
+
+bool parse_hex(const std::string& text, std::uint32_t* value) {
+    if (value == nullptr || text.empty()) {
+        return false;
+    }
+    std::istringstream stream(text);
+    stream.imbue(std::locale::classic());
+    std::uint32_t parsed = 0U;
+    stream >> std::hex >> parsed;
+    if (!stream || stream.peek() != std::char_traits<char>::eof()) {
+        return false;
+    }
+    *value = parsed;
+    return true;
+}
+
+bool parse_bool(const std::string& text, bool* value) {
+    if (value == nullptr) {
+        return false;
+    }
+    if (text == "TRUE") {
+        *value = true;
+        return true;
+    }
+    if (text == "FALSE") {
+        *value = false;
+        return true;
+    }
+    return false;
+}
+
+std::uint32_t crc32(const std::string& payload) {
+    constexpr std::uint32_t kPolynomial = UINT32_C(0xEDB88320);
+    std::uint32_t crc = 0U;
+    for (unsigned char byte : payload) {
+        crc ^= static_cast<std::uint32_t>(byte);
+        for (int bit = 0; bit < 8; ++bit) {
+            crc = (crc & 1U) != 0U ? (crc >> 1U) ^ kPolynomial : crc >> 1U;
+        }
+    }
+    return crc;
+}
+
+bool is_supported_nav_name(const std::string& name) {
+    return name == "GPSEPHEMA" || name == "QZSSEPHEMERISA" || name == "GALEPHEMERISA" || name == "BD2EPHEMA" ||
+           name == "GLOEPHEMERISA" || name == "IONUTCA" || name == "BD2IONUTCA";
+}
+
+int nearest_week(int reference_week, double reference_sow_sec, double target_sow_sec) {
+    int week = reference_week;
+    if (target_sow_sec > reference_sow_sec + 302400.0) {
+        --week;
+    } else if (target_sow_sec < reference_sow_sec - 302400.0) {
+        ++week;
+    }
+    return week;
+}
+
+bool parse_generic_kepler(const std::string& name, const std::vector<std::string>& body, ParsedNavLine* parsed,
+                          std::string* error_message) {
+    const bool qzss = name == "QZSSEPHEMERISA";
+    const bool beidou = name == "BD2EPHEMA";
+    const std::size_t expected = qzss ? 36U : (beidou ? 33U : 32U);
+    if (body.size() != expected) {
+        set_error(error_message, name + " has unexpected field count");
+        return false;
+    }
+
+    KeplerianNavOutputData eph{};
+    eph.system = qzss ? NavOutputSystem::kQzss : (beidou ? NavOutputSystem::kBeidou : NavOutputSystem::kGps);
+    eph.message_family = RtklibBroadcastMessageFamily::kLegacy;
+    int duplicate_iode = 0;
+    int duplicate_week = 0;
+    bool flag = false;
+    if (!parse_int(body[0], &eph.prn) || !parse_double(body[1], &eph.transmit_sow_sec) ||
+        !parse_int(body[2], &eph.svh) || !parse_int(body[3], &eph.iode) || !parse_int(body[4], &duplicate_iode) ||
+        !parse_int(body[5], &eph.toe_week) || !parse_int(body[6], &duplicate_week) ||
+        !parse_double(body[7], &eph.toe_sow_sec) || !parse_double(body[8], &eph.semi_major_axis_m) ||
+        !parse_double(body[9], &eph.delta_mean_motion_radps) || !parse_double(body[10], &eph.mean_anomaly_rad) ||
+        !parse_double(body[11], &eph.eccentricity) || !parse_double(body[12], &eph.argument_of_perigee_rad) ||
+        !parse_double(body[13], &eph.cuc_rad) || !parse_double(body[14], &eph.cus_rad) ||
+        !parse_double(body[15], &eph.crc_m) || !parse_double(body[16], &eph.crs_m) ||
+        !parse_double(body[17], &eph.cic_rad) || !parse_double(body[18], &eph.cis_rad) ||
+        !parse_double(body[19], &eph.inclination_rad) || !parse_double(body[20], &eph.inclination_dot_radps) ||
+        !parse_double(body[21], &eph.omega0_rad) || !parse_double(body[22], &eph.omega_dot_radps) ||
+        !parse_int(body[23], &eph.iodc) || !parse_double(body[24], &eph.toc_sow_sec) ||
+        !parse_double(body[25], &eph.tgd_sec[0])) {
+        set_error(error_message, name + " contains malformed orbital fields");
+        return false;
+    }
+    std::size_t clock_index = 26U;
+    if (beidou) {
+        if (!parse_double(body[26], &eph.tgd_sec[1])) {
+            set_error(error_message, name + " contains malformed secondary group delay");
+            return false;
+        }
+        clock_index = 27U;
+    }
+    if (!parse_double(body[clock_index], &eph.clock_bias_sec) ||
+        !parse_double(body[clock_index + 1U], &eph.clock_drift_sec_per_sec) ||
+        !parse_double(body[clock_index + 2U], &eph.clock_drift_rate_sec_per_sec2) ||
+        !parse_bool(body[clock_index + 3U], &flag) ||
+        !parse_double(body[clock_index + 4U], &eph.corrected_mean_motion_radps) ||
+        !parse_double(body[clock_index + 5U], &eph.sva)) {
+        set_error(error_message, name + " contains malformed clock/status fields");
+        return false;
+    }
+    if (duplicate_iode != eph.iode || duplicate_week != eph.toe_week || eph.prn <= 0 || eph.toe_week < 0 ||
+        eph.toe_sow_sec < 0.0 || eph.toe_sow_sec >= 604800.0 || eph.transmit_sow_sec < 0.0 ||
+        eph.transmit_sow_sec >= 604800.0 || eph.toc_sow_sec < 0.0 || eph.toc_sow_sec >= 604800.0 ||
+        eph.semi_major_axis_m <= 0.0) {
+        set_error(error_message, name + " contains inconsistent required metadata");
+        return false;
+    }
+    eph.flag = flag ? 1 : 0;
+    eph.transmit_week = nearest_week(eph.toe_week, eph.toe_sow_sec, eph.transmit_sow_sec);
+    eph.toc_week = nearest_week(eph.toe_week, eph.toe_sow_sec, eph.toc_sow_sec);
+    parsed->record.kind = RtklibNavRecordKind::kEphemeris;
+    parsed->record.ephemeris = eph;
+    return true;
+}
+
+bool parse_galileo(const std::vector<std::string>& body, ParsedNavLine* parsed, std::string* error_message) {
+    if (body.size() != 38U) {
+        set_error(error_message, "GALEPHEMERISA has unexpected field count");
+        return false;
+    }
+    KeplerianNavOutputData eph{};
+    eph.system = NavOutputSystem::kGalileo;
+    bool fnav_received = false;
+    bool inav_received = false;
+    if (!parse_int(body[0], &eph.prn) || !parse_bool(body[1], &fnav_received) || !parse_bool(body[2], &inav_received) ||
+        !parse_int(body[3], &eph.galileo_e1b_health) || !parse_int(body[4], &eph.galileo_e5a_health) ||
+        !parse_int(body[5], &eph.galileo_e5b_health) || !parse_int(body[6], &eph.galileo_e1b_dvs) ||
+        !parse_int(body[7], &eph.galileo_e5a_dvs) || !parse_int(body[8], &eph.galileo_e5b_dvs) ||
+        !parse_double(body[9], &eph.sva) || !parse_int(body[10], &eph.svh) || !parse_int(body[11], &eph.iode) ||
+        !parse_double(body[12], &eph.toe_sow_sec) || !parse_double(body[13], &eph.sqrt_semi_major_axis_sqrt_m) ||
+        !parse_double(body[14], &eph.delta_mean_motion_radps) || !parse_double(body[15], &eph.mean_anomaly_rad) ||
+        !parse_double(body[16], &eph.eccentricity) || !parse_double(body[17], &eph.argument_of_perigee_rad) ||
+        !parse_double(body[18], &eph.cuc_rad) || !parse_double(body[19], &eph.cus_rad) ||
+        !parse_double(body[20], &eph.crc_m) || !parse_double(body[21], &eph.crs_m) ||
+        !parse_double(body[22], &eph.cic_rad) || !parse_double(body[23], &eph.cis_rad) ||
+        !parse_double(body[24], &eph.inclination_rad) || !parse_double(body[25], &eph.inclination_dot_radps) ||
+        !parse_double(body[26], &eph.omega0_rad) || !parse_double(body[27], &eph.omega_dot_radps) ||
+        !parse_double(body[28], &eph.galileo_fnav_toc_sow_sec) || !parse_double(body[29], &eph.galileo_fnav_clock[0]) ||
+        !parse_double(body[30], &eph.galileo_fnav_clock[1]) || !parse_double(body[31], &eph.galileo_fnav_clock[2]) ||
+        !parse_double(body[32], &eph.galileo_inav_toc_sow_sec) || !parse_double(body[33], &eph.galileo_inav_clock[0]) ||
+        !parse_double(body[34], &eph.galileo_inav_clock[1]) || !parse_double(body[35], &eph.galileo_inav_clock[2]) ||
+        !parse_double(body[36], &eph.tgd_sec[0]) || !parse_double(body[37], &eph.tgd_sec[1])) {
+        set_error(error_message, "GALEPHEMERISA contains malformed fields");
+        return false;
+    }
+    if (!inav_received && !fnav_received) {
+        set_error(error_message, "GALEPHEMERISA carries neither INAV nor FNAV clock data");
+        return false;
+    }
+    eph.galileo_fnav_received = fnav_received;
+    eph.galileo_inav_received = inav_received;
+    eph.message_family =
+        inav_received ? RtklibBroadcastMessageFamily::kGalileoInav : RtklibBroadcastMessageFamily::kGalileoFnav;
+    const double toc_sow = inav_received ? eph.galileo_inav_toc_sow_sec : eph.galileo_fnav_toc_sow_sec;
+    const double* clock = inav_received ? eph.galileo_inav_clock : eph.galileo_fnav_clock;
+    eph.clock_bias_sec = clock[0];
+    eph.clock_drift_sec_per_sec = clock[1];
+    eph.clock_drift_rate_sec_per_sec2 = clock[2];
+    eph.semi_major_axis_m = eph.sqrt_semi_major_axis_sqrt_m * eph.sqrt_semi_major_axis_sqrt_m;
+    eph.iodc = eph.iode;
+    eph.toe_week = nearest_week(parsed->output_gps_week, parsed->output_sow_sec, eph.toe_sow_sec);
+    eph.toc_sow_sec = toc_sow;
+    eph.toc_week = nearest_week(eph.toe_week, eph.toe_sow_sec, toc_sow);
+    // GALEPHEMERISA does not expose the original RINEX transmission epoch. The
+    // receiver log header is the serialized availability time and is therefore
+    // the only non-invented timestamp available for reconstructed ttr.
+    eph.transmit_week = parsed->output_gps_week;
+    eph.transmit_sow_sec = parsed->output_sow_sec;
+    parsed->record.kind = RtklibNavRecordKind::kEphemeris;
+    parsed->record.ephemeris = eph;
+    return true;
+}
+
+bool parse_glonass(const std::vector<std::string>& body, ParsedNavLine* parsed, std::string* error_message) {
+    if (body.size() != 29U) {
+        set_error(error_message, "GLOEPHEMERISA has unexpected field count");
+        return false;
+    }
+    GlonassNavOutputData glo{};
+    int mode = 0;
+    int reserved = 0;
+    int reserved_a = 0;
+    int reserved_b = 0;
+    int duplicate_flags = 0;
+    std::int64_t toe_ms = 0;
+    double toe_ms_double = 0.0;
+    if (!parse_int(body[0], &glo.slot_offset) || !parse_int(body[1], &glo.frequency_offset) ||
+        !parse_int(body[2], &mode) || !parse_int(body[3], &reserved) || !parse_int(body[4], &glo.toe_week) ||
+        !parse_double(body[5], &toe_ms_double) || !parse_int(body[6], &glo.gps_glonass_time_offset_sec) ||
+        !parse_int(body[7], &glo.calendar_day_number) || !parse_int(body[8], &reserved_a) ||
+        !parse_int(body[9], &reserved_b) || !parse_int(body[10], &glo.iode) || !parse_int(body[11], &glo.svh) ||
+        !parse_double(body[12], &glo.position_ecef_m[0]) || !parse_double(body[13], &glo.position_ecef_m[1]) ||
+        !parse_double(body[14], &glo.position_ecef_m[2]) || !parse_double(body[15], &glo.velocity_ecef_mps[0]) ||
+        !parse_double(body[16], &glo.velocity_ecef_mps[1]) || !parse_double(body[17], &glo.velocity_ecef_mps[2]) ||
+        !parse_double(body[18], &glo.acceleration_ecef_mps2[0]) ||
+        !parse_double(body[19], &glo.acceleration_ecef_mps2[1]) ||
+        !parse_double(body[20], &glo.acceleration_ecef_mps2[2]) || !parse_double(body[21], &glo.clock_bias_sec) ||
+        !parse_double(body[22], &glo.relative_frequency_bias) || !parse_double(body[23], &glo.differential_delay_sec) ||
+        !parse_double(body[24], &glo.frame_time_glonass_day_sec) || !parse_int(body[25], &glo.flags) ||
+        !parse_int(body[26], &glo.sva) || !parse_int(body[27], &glo.age_days) ||
+        !parse_int(body[28], &duplicate_flags)) {
+        set_error(error_message, "GLOEPHEMERISA contains malformed fields");
+        return false;
+    }
+    toe_ms = static_cast<std::int64_t>(std::llround(toe_ms_double));
+    if (mode != 1 || reserved != 0 || reserved_a != 0 || reserved_b != 0 || duplicate_flags != glo.flags ||
+        glo.slot_offset <= 37 || glo.frequency_offset < 0 || glo.frequency_offset > 13 || glo.toe_week < 0 ||
+        toe_ms < 0 || toe_ms >= 604800000LL) {
+        set_error(error_message, "GLOEPHEMERISA contains inconsistent metadata");
+        return false;
+    }
+    glo.prn = glo.slot_offset - 37;
+    glo.frequency_channel = glo.frequency_offset - 7;
+    glo.message_family = RtklibBroadcastMessageFamily::kGlonassFdma;
+    glo.message_type = 0;
+    glo.toe_sow_sec = static_cast<double>(toe_ms) / 1000.0;
+    // The ASCII record exposes frame time in GLONASS day seconds but not its
+    // GPS week. For positioning, RTKLIB selects GLONASS ephemeris by toe; use
+    // the receiver availability header as the serialized frame-time anchor.
+    glo.frame_week = parsed->output_gps_week;
+    glo.frame_sow_sec = parsed->output_sow_sec;
+    parsed->record.kind = RtklibNavRecordKind::kGlonassEphemeris;
+    parsed->record.glonass = glo;
+    return true;
+}
+
+bool parse_ionutc(const std::string& name, const std::vector<std::string>& body, ParsedNavLine* parsed,
+                  std::string* error_message) {
+    if (body.size() != 17U) {
+        set_error(error_message, name + " has unexpected field count");
+        return false;
+    }
+    IonosphereNavOutputData ion{};
+    ion.system = name == "IONUTCA" ? NavOutputSystem::kGps : NavOutputSystem::kBeidou;
+    ion.coefficient_count = 8;
+    ion.legacy_metadata = true;
+    for (int index = 0; index < 8; ++index) {
+        if (!parse_double(body[static_cast<std::size_t>(index)], &ion.coefficients[index])) {
+            set_error(error_message, name + " contains malformed ionosphere coefficients");
+            return false;
+        }
+    }
+    int utc_week = 0;
+    int utc_tot = 0;
+    int duplicate_week = 0;
+    int reserved = 0;
+    int leap = 0;
+    int future_leap = 0;
+    int reserved_tail = 0;
+    if (!parse_int(body[8], &utc_week) || !parse_int(body[9], &utc_tot) || !parse_double(body[10], &ion.utc[0]) ||
+        !parse_double(body[11], &ion.utc[1]) || !parse_int(body[12], &duplicate_week) ||
+        !parse_int(body[13], &reserved) || !parse_int(body[14], &leap) || !parse_int(body[15], &future_leap) ||
+        !parse_int(body[16], &reserved_tail) || duplicate_week != utc_week || reserved != 0 || reserved_tail != 0) {
+        set_error(error_message, name + " contains malformed UTC metadata");
+        return false;
+    }
+    ion.utc[2] = static_cast<double>(utc_tot);
+    ion.utc[3] = static_cast<double>(utc_week);
+    ion.leap_seconds = name == "BD2IONUTCA" ? leap + 14 : leap;
+    if (future_leap != leap) {
+        set_error(error_message, name + " leap-second fields are inconsistent");
+        return false;
+    }
+    ion.transmit_week = parsed->output_gps_week;
+    ion.transmit_sow_sec = parsed->output_sow_sec;
+    parsed->record.kind = RtklibNavRecordKind::kIonosphere;
+    parsed->record.ionosphere = ion;
+    return true;
+}
+
+bool parse_nav_line(const std::string& raw_line, ParsedNavLine* parsed, bool* recognized, std::string* error_message) {
+    if (parsed == nullptr || recognized == nullptr) {
+        set_error(error_message, "serialized NAV parser request has invalid arguments");
+        return false;
+    }
+    *recognized = false;
+    std::string line = raw_line;
+    if (!line.empty() && line.back() == '\r') {
+        line.pop_back();
+    }
+    if (line.empty() || line[0] != '#') {
+        return true;
+    }
+    const std::size_t comma = line.find(',');
+    if (comma == std::string::npos) {
+        return true;
+    }
+    const std::string name = line.substr(1, comma - 1U);
+    if (!is_supported_nav_name(name)) {
+        return true;
+    }
+    *recognized = true;
+    const std::size_t star = line.rfind('*');
+    if (star == std::string::npos || star <= 1U || star + 9U != line.size()) {
+        set_error(error_message, name + " has malformed CRC framing");
+        return false;
+    }
+    const std::string payload = line.substr(1, star - 1U);
+    std::uint32_t expected_crc = 0U;
+    if (!parse_hex(line.substr(star + 1U), &expected_crc) || expected_crc != crc32(payload)) {
+        set_error(error_message, name + " CRC mismatch");
+        return false;
+    }
+    const std::size_t semicolon = payload.find(';');
+    if (semicolon == std::string::npos) {
+        set_error(error_message, name + " is missing header/body separator");
+        return false;
+    }
+    const std::vector<std::string> header = split(payload.substr(0, semicolon), ',');
+    if (header.size() != 10U || header[0] != name || !parse_int(header[5], &parsed->output_gps_week) ||
+        !parse_double(header[6], &parsed->output_sow_sec) || parsed->output_gps_week < 0 ||
+        parsed->output_sow_sec < 0.0 || parsed->output_sow_sec >= 604800.0) {
+        set_error(error_message, name + " has invalid receiver header");
+        return false;
+    }
+    const std::vector<std::string> body = split(payload.substr(semicolon + 1U), ',');
+    if (name == "GPSEPHEMA" || name == "QZSSEPHEMERISA" || name == "BD2EPHEMA") {
+        return parse_generic_kepler(name, body, parsed, error_message);
+    }
+    if (name == "GALEPHEMERISA") {
+        return parse_galileo(body, parsed, error_message);
+    }
+    if (name == "GLOEPHEMERISA") {
+        return parse_glonass(body, parsed, error_message);
+    }
+    return parse_ionutc(name, body, parsed, error_message);
+}
+
+void count_nav_record(const NavOutputRecord& record, SerializedNavRoundtripSummary* summary) {
+    ++summary->nav_records;
+    if (record.kind == RtklibNavRecordKind::kIonosphere) {
+        ++summary->ionosphere_records;
+        return;
+    }
+    if (record.kind == RtklibNavRecordKind::kGlonassEphemeris) {
+        ++summary->glonass_ephemeris_records;
+        return;
+    }
+    switch (record.ephemeris.system) {
+        case NavOutputSystem::kGps:
+            ++summary->gps_ephemeris_records;
+            break;
+        case NavOutputSystem::kGalileo:
+            ++summary->galileo_ephemeris_records;
+            break;
+        case NavOutputSystem::kBeidou:
+            ++summary->beidou_ephemeris_records;
+            break;
+        case NavOutputSystem::kQzss:
+            ++summary->qzss_ephemeris_records;
+            break;
+        default:
+            break;
+    }
+}
+
+} // namespace
+
+bool validate_serialized_nav_roundtrip_stream(std::istream* input, double truth_latitude_deg,
+                                              double truth_longitude_deg, double truth_height_m,
+                                              double elevation_mask_deg, bool broadcast_atmosphere,
+                                              SerializedNavRoundtripSummary* summary, std::string* error_message) {
+    if (input == nullptr || summary == nullptr || !std::isfinite(truth_latitude_deg) ||
+        !std::isfinite(truth_longitude_deg) || !std::isfinite(truth_height_m) || !std::isfinite(elevation_mask_deg)) {
+        set_error(error_message, "serialized NAV round-trip request has invalid arguments");
+        return false;
+    }
+    RtklibNavStore* nav = create_rtklib_nav_store();
+    if (nav == nullptr) {
+        set_error(error_message, "cannot allocate serialized receiver NAV store");
+        return false;
+    }
+    double truth_ecef_m[3]{};
+    if (!rtklib_llh_to_ecef(truth_latitude_deg, truth_longitude_deg, truth_height_m, truth_ecef_m)) {
+        destroy_rtklib_nav_store(nav);
+        set_error(error_message, "cannot convert serialized round-trip truth position to ECEF");
+        return false;
+    }
+
+    SerializedNavRoundtripSummary result{};
+    std::string line;
+    std::uint64_t line_number = 0U;
+    std::string last_position_diagnostic;
+    while (std::getline(*input, line)) {
+        ++line_number;
+        ParsedNavLine parsed_nav{};
+        bool recognized_nav = false;
+        std::string parse_error;
+        if (!parse_nav_line(line, &parsed_nav, &recognized_nav, &parse_error)) {
+            destroy_rtklib_nav_store(nav);
+            set_error(error_message, "serialized NAV line " + std::to_string(line_number) + ": " + parse_error);
+            return false;
+        }
+        if (recognized_nav) {
+            if (!rtklib_append_nav_output_record(nav, parsed_nav.record, error_message)) {
+                destroy_rtklib_nav_store(nav);
+                return false;
+            }
+            count_nav_record(parsed_nav.record, &result);
+            continue;
+        }
+        if (line.rfind("#RANGEA,", 0) != 0) {
+            continue;
+        }
+
+        ParsedRangeEpoch epoch{};
+        if (!parse_rangea_line_independent(line, &epoch, &parse_error)) {
+            destroy_rtklib_nav_store(nav);
+            set_error(error_message, "serialized RANGEA line " + std::to_string(line_number) + ": " + parse_error);
+            return false;
+        }
+        ++result.range_epochs;
+        result.parsed_observations += static_cast<std::uint64_t>(epoch.observations.size());
+        RtklibPositionSolution solution{};
+        int selected_count = 0;
+        std::string solve_error;
+        if (!solve_parsed_rangea_epoch(epoch, nav, elevation_mask_deg, broadcast_atmosphere, &solution, &selected_count,
+                                       &solve_error)) {
+            destroy_rtklib_nav_store(nav);
+            set_error(error_message, "serialized self-contained solve failed at GPST " +
+                                         std::to_string(epoch.gps_week) + "/" + std::to_string(epoch.sow_sec) + ": " +
+                                         solve_error);
+            return false;
+        }
+        result.selected_position_observations += static_cast<std::uint64_t>(selected_count);
+        if (!solution.valid) {
+            last_position_diagnostic = solution.diagnostic;
+            continue;
+        }
+        const double dx = solution.position_ecef_m[0] - truth_ecef_m[0];
+        const double dy = solution.position_ecef_m[1] - truth_ecef_m[1];
+        const double dz = solution.position_ecef_m[2] - truth_ecef_m[2];
+        const double error_m = std::sqrt(dx * dx + dy * dy + dz * dz);
+        if (!std::isfinite(error_m)) {
+            destroy_rtklib_nav_store(nav);
+            set_error(error_message, "serialized self-contained solve produced non-finite position error");
+            return false;
+        }
+        if (result.valid_position_epochs == 0U) {
+            result.first_valid_position_gps_week = epoch.gps_week;
+            result.first_valid_position_sow_sec = epoch.sow_sec;
+        }
+        ++result.valid_position_epochs;
+        result.final_position_error_m = error_m;
+        result.final_position_gps_week = epoch.gps_week;
+        result.final_position_sow_sec = epoch.sow_sec;
+        if (error_m > result.max_position_error_m) {
+            result.max_position_error_m = error_m;
+            result.max_error_gps_week = epoch.gps_week;
+            result.max_error_sow_sec = epoch.sow_sec;
+        }
+    }
+
+    destroy_rtklib_nav_store(nav);
+    if (input->bad()) {
+        set_error(error_message, "I/O failure while streaming serialized receiver log");
+        return false;
+    }
+    if (result.nav_records == 0U) {
+        set_error(error_message, "serialized receiver log contains no supported EPHA/IONA records");
+        return false;
+    }
+    if (result.range_epochs == 0U) {
+        set_error(error_message, "serialized receiver log contains no RANGEA epochs");
+        return false;
+    }
+    if (result.valid_position_epochs == 0U) {
+        std::string message = "serialized receiver log produced no valid RTKLIB position epoch";
+        if (!last_position_diagnostic.empty()) {
+            message += ": " + last_position_diagnostic;
+        }
+        set_error(error_message, message);
+        return false;
+    }
+    *summary = result;
+    return true;
+}
+
+bool validate_serialized_nav_roundtrip_file(const char* log_path, double truth_latitude_deg, double truth_longitude_deg,
+                                            double truth_height_m, double elevation_mask_deg, bool broadcast_atmosphere,
+                                            SerializedNavRoundtripSummary* summary, std::string* error_message) {
+    if (log_path == nullptr || log_path[0] == '\0') {
+        set_error(error_message, "serialized NAV round-trip log path is invalid");
+        return false;
+    }
+    std::ifstream input(log_path, std::ios::binary);
+    if (!input) {
+        set_error(error_message, std::string("cannot open serialized receiver log: ") + log_path);
+        return false;
+    }
+    return validate_serialized_nav_roundtrip_stream(&input, truth_latitude_deg, truth_longitude_deg, truth_height_m,
+                                                    elevation_mask_deg, broadcast_atmosphere, summary, error_message);
+}
+
+} // namespace gnss_sim

--- a/tools/serialized_nav_roundtrip/serialized_nav_roundtrip.h
+++ b/tools/serialized_nav_roundtrip/serialized_nav_roundtrip.h
@@ -1,0 +1,43 @@
+#ifndef GNSS_SIM_TOOLS_SERIALIZED_NAV_ROUNDTRIP_SERIALIZED_NAV_ROUNDTRIP_H_
+#define GNSS_SIM_TOOLS_SERIALIZED_NAV_ROUNDTRIP_SERIALIZED_NAV_ROUNDTRIP_H_
+
+#include <cstdint>
+#include <istream>
+#include <string>
+
+namespace gnss_sim {
+
+struct SerializedNavRoundtripSummary {
+    std::uint64_t nav_records;
+    std::uint64_t gps_ephemeris_records;
+    std::uint64_t glonass_ephemeris_records;
+    std::uint64_t galileo_ephemeris_records;
+    std::uint64_t beidou_ephemeris_records;
+    std::uint64_t qzss_ephemeris_records;
+    std::uint64_t ionosphere_records;
+    std::uint64_t range_epochs;
+    std::uint64_t parsed_observations;
+    std::uint64_t selected_position_observations;
+    std::uint64_t valid_position_epochs;
+    int first_valid_position_gps_week;
+    double first_valid_position_sow_sec;
+    double max_position_error_m;
+    int max_error_gps_week;
+    double max_error_sow_sec;
+    double final_position_error_m;
+    int final_position_gps_week;
+    double final_position_sow_sec;
+};
+
+bool validate_serialized_nav_roundtrip_stream(std::istream* input, double truth_latitude_deg,
+                                              double truth_longitude_deg, double truth_height_m,
+                                              double elevation_mask_deg, bool broadcast_atmosphere,
+                                              SerializedNavRoundtripSummary* summary, std::string* error_message);
+
+bool validate_serialized_nav_roundtrip_file(const char* log_path, double truth_latitude_deg, double truth_longitude_deg,
+                                            double truth_height_m, double elevation_mask_deg, bool broadcast_atmosphere,
+                                            SerializedNavRoundtripSummary* summary, std::string* error_message);
+
+} // namespace gnss_sim
+
+#endif // GNSS_SIM_TOOLS_SERIALIZED_NAV_ROUNDTRIP_SERIALIZED_NAV_ROUNDTRIP_H_


### PR DESCRIPTION
Closes #81

## What changed

- Adds an independent NovAtel ASCII NAV parser for the simulator's serialized `GPSEPHEMA`, `QZSSEPHEMERISA`, `GALEPHEMERISA`, `BD2EPHEMA`, `GLOEPHEMERISA`, `IONUTCA`, and `BD2IONUTCA` records.
- Reconstructs an RTKLIB receiver navigation store directly from those serialized records; the post-generation validator never calls `load_rinex_nav_file()` or `readrnx()`.
- Applies NAV records strictly in log order, so future ephemeris/ionosphere records cannot be used before they appear.
- Reuses the independent RANGEA parser and exposes a parsed-epoch solve helper so RANGEA and NAV remain separate serialization-boundary parsers.
- Adds `validate-serialized-nav-roundtrip`, whose only positioning inputs are the generated log, truth LLH for error comparison, and solution options.
- Adds compact real-BRD400 integration tests for five-system NAV recovery, future-NAV ordering, and corrupted NAV CRC rejection.

## Dependency

This PR is intentionally stacked on #83 / Issue #82. #83 prevents GPS/QZSS CNAV/CNAV2 records from being mislabeled as legacy `GPSEPHEMA/QZSSEPHEMERISA`, because those ASCII bodies do not carry a message-family discriminator.

## Serialized-format limits

- GPS/QZSS/BDS decoded EPHA paths are reconstructed only for the legacy families actually representable by the frozen NovAtel ASCII syntax.
- `GALEPHEMERISA` is a combined receiver log. When INAV clock data is present, the validator reconstructs the E1-compatible INAV representation; otherwise it uses FNAV. It does not claim to recover the original RINEX family identity beyond what the serialized log carries.
- `GLOEPHEMERISA` carries Toe but no GPS week for the original frame time; the receiver log header is used as the serialized availability/frame-time anchor. RTKLIB broadcast selection remains Toe-based.
- No missing orbital or bias fields are sourced from the original RINEX during validation.

## Tests

Formal CI will establish the final serialized-only SPP error threshold. The initial compact gate uses the real `brd400dlr_rinex4_acceptance_nav.rnx` only to generate the receiver log, then validates the resulting `simulated.log` without passing any RINEX NAV path to the validator.

## Implementation Notes

This is a project-side ASCII parser feeding RTKLIB `nav_t`, rather than modifying RTKLIB's binary NovAtel decoder. Existing RINEX-backed RANGEA round-trip validation remains unchanged as a separate reference path. No synthetic ephemeris or ionosphere data is introduced.