### PR TITLE
Keep IONUTCA aligned with legacy RTKLIB ionosphere state

### DIFF
--- a/src/output/novatel_nav_writer.cpp
+++ b/src/output/novatel_nav_writer.cpp
@@ -154,7 +154,7 @@ bool format_novatel_nav_output_record(const NavOutputRecord& source, const SimTi
         }
     } else if (record.kind == RtklibNavRecordKind::kIonosphere) {
         const IonosphereNavOutputData& ion = record.ionosphere;
-        if (ion.system == NavOutputSystem::kGps && ion.coefficient_count >= 8) {
+        if (ion.system == NavOutputSystem::kGps && ion.coefficient_count >= 8 && ion.legacy_metadata) {
             log_name = "IONUTCA";
             body = ionutc_body(ion, false);
         } else if (ion.system == NavOutputSystem::kBeidou && ion.coefficient_count >= 8 && ion.legacy_metadata) {

--- a/tests/unit/test_nav_output_writers.cpp
+++ b/tests/unit/test_nav_output_writers.cpp
@@ -370,6 +370,47 @@ TEST(NavOutputWriter, RealRinex4BeiDouLegacyIonSerializesWithoutModernFamilyMasq
     gnss_sim::destroy_rtklib_nav_store(store);
 }
 
+TEST(NavOutputWriter, RealRinex4ExplicitGpsIonDoesNotMasqueradeAsLegacyIonutca) {
+    gnss_sim::RtklibNavStore* store = gnss_sim::create_rtklib_nav_store();
+    ASSERT_NE(store, nullptr);
+    std::string error_message;
+    ASSERT_TRUE(
+        gnss_sim::load_rinex_nav_file(store, data_path("brd400dlr_rinex4_acceptance_nav.rnx").c_str(), &error_message))
+        << error_message;
+
+    int explicit_gps_ion_count = 0;
+    int legacy_gps_ion_count = 0;
+    const int count = gnss_sim::rtklib_nav_output_record_count(store);
+    for (int index = 0; index < count; ++index) {
+        gnss_sim::NavOutputRecord record{};
+        ASSERT_TRUE(gnss_sim::rtklib_nav_output_record(store, index, &record, &error_message)) << error_message;
+        if (record.kind != gnss_sim::RtklibNavRecordKind::kIonosphere ||
+            record.ionosphere.system != gnss_sim::NavOutputSystem::kGps) {
+            continue;
+        }
+
+        std::string message;
+        bool supported = false;
+        const gnss_sim::SimTime time = output_time();
+        ASSERT_TRUE(gnss_sim::format_novatel_nav_output_record(record, time, &message, &supported, &error_message))
+            << error_message;
+        if (record.ionosphere.legacy_metadata) {
+            ++legacy_gps_ion_count;
+            EXPECT_TRUE(supported);
+            EXPECT_EQ(log_name(message), "IONUTCA");
+            EXPECT_TRUE(valid_ascii_crc(message));
+        } else {
+            ++explicit_gps_ion_count;
+            EXPECT_FALSE(supported) << "explicit RINEX4 GPS ION must not masquerade as legacy IONUTCA";
+            EXPECT_TRUE(message.empty());
+        }
+    }
+
+    EXPECT_GT(explicit_gps_ion_count, 0) << "real BRD400DLR fixture must contain explicit GPS ION records";
+    EXPECT_EQ(legacy_gps_ion_count, 0) << "BRD400DLR nav.ion_gps stays at the zero/fallback state";
+    gnss_sim::destroy_rtklib_nav_store(store);
+}
+
 TEST(NavOutputWriter, Bd3IonHasByteLevelGoldenRecord) {
     gnss_sim::NavOutputRecord record{};
     record.kind = gnss_sim::RtklibNavRecordKind::kIonosphere;


### PR DESCRIPTION
Closes #88

## What changed

- `IONUTCA` is emitted only for GPS ionosphere records marked as legacy metadata.
- RINEX4 explicit GPS ION records that are not the pinned RTKLIB `nav.ion_gps` solver state are no longer mislabeled as legacy `IONUTCA`.
- Existing legacy GPS header ION/UTC metadata remains serializable.
- BeiDou behavior remains the separate #85 contract.

## Why

The pinned RTKLIB `IONOOPT_BRDC` SPP path and simulator atmosphere model use `nav.ion_gps`. Promoting an unrelated explicit RINEX4 ION record into `IONUTCA` changes the downstream solver ionosphere model after ASCII round-trip and breaks #81 self-contained positioning.

## Tests

The existing real-RINEX legacy ionosphere writer coverage continues to require GPS `IONUTCA`. Full CI will be run on this stacked branch. #81 will additionally prove that the serialized-NAV round-trip no longer changes the solver ionosphere state.

## Implementation Notes

No coefficients are inferred or synthesized. This only narrows which real RINEX-derived ionosphere records may claim the legacy NovAtel `IONUTCA` syntax.