### PR TITLE
Keep GALEPHEMERISA orbit family unambiguous for serialized positioning

### DIFF
--- a/src/output/novatel_nav_writer.cpp
+++ b/src/output/novatel_nav_writer.cpp
@@ -140,8 +140,15 @@ bool format_novatel_nav_output_record(const NavOutputRecord& source, const SimTi
                 }
                 break;
             case NavOutputSystem::kGalileo:
-                log_name = "GALEPHEMERISA";
-                body = galileo_body(eph);
+                // GALEPHEMERISA carries one common orbit block with no family discriminator.
+                // When an INAV-source ephemeris exists for the satellite (inav_received),
+                // only that record may own the reversible orbit; emitting an FNAV-source
+                // record too would let a downstream parser reconstruct an INAV ephemeris
+                // whose orbit was never broadcast.
+                if (eph.message_family != RtklibBroadcastMessageFamily::kGalileoFnav || !eph.galileo_inav_received) {
+                    log_name = "GALEPHEMERISA";
+                    body = galileo_body(eph);
+                }
                 break;
             case NavOutputSystem::kBeidou:
                 if (legacy_bds(eph)) {

--- a/tests/unit/test_nav_output_writers.cpp
+++ b/tests/unit/test_nav_output_writers.cpp
@@ -7,6 +7,18 @@
 #include "output/novatel_nav_writer.h"
 #include "output/unicore_nav_writer.h"
 
+extern "C" {
+#include <rtklib.h>
+}
+
+#ifdef lock
+#undef lock
+#endif
+#ifdef unlock
+#undef unlock
+#endif
+
+#include <cmath>
 #include <cstdint>
 #include <cstdlib>
 #include <gtest/gtest.h>
@@ -47,6 +59,87 @@ bool valid_ascii_crc(const std::string& message) {
     char* end = nullptr;
     const unsigned long parsed = std::strtoul(crc_text.c_str(), &end, 16);
     return end != nullptr && *end == '\0' && parsed == gnss_sim::novatel_ascii::crc32(payload);
+}
+
+std::string body_between_semicolon_and_crc(const std::string& message) {
+    const std::size_t semicolon = message.find(';');
+    const std::size_t star = message.rfind('*');
+    if (semicolon == std::string::npos || star == std::string::npos || star < semicolon) {
+        return {};
+    }
+    return message.substr(semicolon + 1, star - semicolon - 1);
+}
+
+std::vector<std::string> split_body_fields(const std::string& body) {
+    std::vector<std::string> fields;
+    std::size_t begin = 0;
+    while (true) {
+        const std::size_t comma = body.find(',', begin);
+        if (comma == std::string::npos) {
+            fields.push_back(body.substr(begin));
+            break;
+        }
+        fields.push_back(body.substr(begin, comma - begin));
+        begin = comma + 1;
+    }
+    return fields;
+}
+
+// Rebuilds the ephemeris an independent serialized-log parser would obtain from a
+// GALEPHEMERISA body: fields[13..27] hold the common orbit block, fields[32..35]
+// hold the INAV clock block, and field 12 holds Toe SOW; the GPS week comes from
+// the receiver-log header time, not from the body.
+eph_t ephemeris_from_galileo_body_fields(const std::vector<std::string>& fields, int toe_week, int satellite_number) {
+    eph_t eph{};
+    eph.sat = satellite_number;
+    const double sqrt_a = std::stod(fields[13]);
+    eph.A = sqrt_a * sqrt_a;
+    eph.deln = std::stod(fields[14]);
+    eph.M0 = std::stod(fields[15]);
+    eph.e = std::stod(fields[16]);
+    eph.omg = std::stod(fields[17]);
+    eph.cuc = std::stod(fields[18]);
+    eph.cus = std::stod(fields[19]);
+    eph.crc = std::stod(fields[20]);
+    eph.crs = std::stod(fields[21]);
+    eph.cic = std::stod(fields[22]);
+    eph.cis = std::stod(fields[23]);
+    eph.i0 = std::stod(fields[24]);
+    eph.idot = std::stod(fields[25]);
+    eph.OMG0 = std::stod(fields[26]);
+    eph.OMGd = std::stod(fields[27]);
+    eph.toe = gpst2time(toe_week, std::stod(fields[12]));
+    eph.toc = gpst2time(toe_week, std::stod(fields[32]));
+    eph.f0 = std::stod(fields[33]);
+    eph.f1 = std::stod(fields[34]);
+    eph.f2 = std::stod(fields[35]);
+    return eph;
+}
+
+eph_t ephemeris_from_keplerian_record(const gnss_sim::KeplerianNavOutputData& data) {
+    eph_t eph{};
+    eph.sat = data.satellite_number;
+    eph.A = data.semi_major_axis_m;
+    eph.deln = data.delta_mean_motion_radps;
+    eph.M0 = data.mean_anomaly_rad;
+    eph.e = data.eccentricity;
+    eph.omg = data.argument_of_perigee_rad;
+    eph.cuc = data.cuc_rad;
+    eph.cus = data.cus_rad;
+    eph.crc = data.crc_m;
+    eph.crs = data.crs_m;
+    eph.cic = data.cic_rad;
+    eph.cis = data.cis_rad;
+    eph.i0 = data.inclination_rad;
+    eph.idot = data.inclination_dot_radps;
+    eph.OMG0 = data.omega0_rad;
+    eph.OMGd = data.omega_dot_radps;
+    eph.toe = gpst2time(data.toe_week, data.toe_sow_sec);
+    eph.toc = gpst2time(data.toc_week, data.toc_sow_sec);
+    eph.f0 = data.clock_bias_sec;
+    eph.f1 = data.clock_drift_sec_per_sec;
+    eph.f2 = data.clock_drift_rate_sec_per_sec2;
+    return eph;
 }
 
 void collect_supported_names(const gnss_sim::RtklibNavStore* store, bool unicore, std::set<std::string>* names) {
@@ -465,6 +558,126 @@ TEST(NavOutputWriter, GalileoHealthBitsAreDecodedFromRealRinexBeforeSerializatio
     EXPECT_GT(galileo_records, 0);
     EXPECT_GT(nonzero_health_records, 0)
         << "real BRD400 fixture must retain at least one nonzero Galileo health-status record";
+    gnss_sim::destroy_rtklib_nav_store(store);
+}
+
+TEST(NavOutputWriter, RealGalileoFnavWithInavCompanionDoesNotEmitAmbiguousOrbit) {
+    gnss_sim::RtklibNavStore* store = gnss_sim::create_rtklib_nav_store();
+    ASSERT_NE(store, nullptr);
+    std::string error_message;
+    ASSERT_TRUE(
+        gnss_sim::load_rinex_nav_file(store, data_path("brd400dlr_rinex4_acceptance_nav.rnx").c_str(), &error_message))
+        << error_message;
+
+    // Loading applies RTKLIB uniqnav(), so each satellite keeps only its latest record
+    // and no real fixture presents an FNAV record whose store also holds an INAV
+    // companion. Prove both real cases stay serializable: INAV-source records (E02, E05,
+    // ...) and FNAV-only records (E23, and E25 whose latest record is FNAV).
+    gnss_sim::NavOutputRecord real_fnav_record{};
+    int inav_emitted = 0;
+    int fnav_only_emitted = 0;
+    const int count = gnss_sim::rtklib_nav_output_record_count(store);
+    for (int index = 0; index < count; ++index) {
+        gnss_sim::NavOutputRecord record{};
+        ASSERT_TRUE(gnss_sim::rtklib_nav_output_record(store, index, &record, &error_message)) << error_message;
+        if (record.kind != gnss_sim::RtklibNavRecordKind::kEphemeris ||
+            record.ephemeris.system != gnss_sim::NavOutputSystem::kGalileo) {
+            continue;
+        }
+
+        const gnss_sim::SimTime time = output_time();
+        std::string message;
+        bool supported = false;
+        ASSERT_TRUE(gnss_sim::format_novatel_nav_output_record(record, time, &message, &supported, &error_message))
+            << error_message;
+        if (record.ephemeris.message_family == gnss_sim::RtklibBroadcastMessageFamily::kGalileoInav) {
+            ++inav_emitted;
+            EXPECT_TRUE(supported);
+            EXPECT_TRUE(valid_ascii_crc(message));
+        } else {
+            ++fnav_only_emitted;
+            EXPECT_FALSE(record.ephemeris.galileo_inav_received)
+                << "real store cannot hold an FNAV record with an INAV companion";
+            EXPECT_TRUE(supported);
+            EXPECT_TRUE(valid_ascii_crc(message));
+            real_fnav_record = record;
+        }
+    }
+
+    EXPECT_GT(inav_emitted, 0) << "real BRD400DLR fixture must contain Galileo INAV records";
+    EXPECT_GT(fnav_only_emitted, 0) << "real BRD400DLR fixture must contain Galileo FNAV records";
+
+    // Exercise the ambiguous store state the writer itself can produce when a store does
+    // hold both families: copy the real FNAV record values unchanged and set only the
+    // companion flag the adapter fills when an INAV ephemeris exists for the satellite.
+    // The FNAV orbit must not masquerade as an INAV ephemeris through the common orbit
+    // block, so the writer must reject it.
+    ASSERT_TRUE(gnss_sim::finalize_nav_output_record_metadata(&real_fnav_record));
+    real_fnav_record.ephemeris.galileo_inav_received = true;
+    const gnss_sim::SimTime time = output_time();
+    std::string message;
+    bool supported = false;
+    ASSERT_TRUE(
+        gnss_sim::format_novatel_nav_output_record(real_fnav_record, time, &message, &supported, &error_message))
+        << error_message;
+    EXPECT_FALSE(supported) << "FNAV orbit with an INAV companion must not masquerade as an INAV ephemeris";
+    EXPECT_TRUE(message.empty());
+    gnss_sim::destroy_rtklib_nav_store(store);
+}
+
+TEST(NavOutputWriter, RealGalileoInavSerializedRecordRoundTripsPositionAndClock) {
+    gnss_sim::RtklibNavStore* store = gnss_sim::create_rtklib_nav_store();
+    ASSERT_NE(store, nullptr);
+    std::string error_message;
+    ASSERT_TRUE(
+        gnss_sim::load_rinex_nav_file(store, data_path("brd400dlr_rinex4_acceptance_nav.rnx").c_str(), &error_message))
+        << error_message;
+
+    bool verified_inav_record = false;
+    const int count = gnss_sim::rtklib_nav_output_record_count(store);
+    for (int index = 0; index < count && !verified_inav_record; ++index) {
+        gnss_sim::NavOutputRecord record{};
+        ASSERT_TRUE(gnss_sim::rtklib_nav_output_record(store, index, &record, &error_message)) << error_message;
+        if (record.kind != gnss_sim::RtklibNavRecordKind::kEphemeris ||
+            record.ephemeris.system != gnss_sim::NavOutputSystem::kGalileo ||
+            record.ephemeris.message_family != gnss_sim::RtklibBroadcastMessageFamily::kGalileoInav) {
+            continue;
+        }
+
+        const gnss_sim::SimTime time = output_time();
+        std::string message;
+        bool supported = false;
+        ASSERT_TRUE(gnss_sim::format_novatel_nav_output_record(record, time, &message, &supported, &error_message))
+            << error_message;
+        ASSERT_TRUE(supported);
+        ASSERT_TRUE(valid_ascii_crc(message));
+
+        const std::vector<std::string> fields = split_body_fields(body_between_semicolon_and_crc(message));
+        ASSERT_EQ(fields.size(), 38u) << "GALEPHEMERISA body layout changed";
+        EXPECT_EQ(fields[2], "TRUE") << "serialized INAV-source record must flag INAV received";
+
+        const eph_t serialized =
+            ephemeris_from_galileo_body_fields(fields, record.ephemeris.toe_week, record.ephemeris.satellite_number);
+        const eph_t source = ephemeris_from_keplerian_record(record.ephemeris);
+        const gtime_t eval_time = timeadd(source.toe, 3600.0);
+        double source_position[6] = {0};
+        double serialized_position[6] = {0};
+        double source_clock[2] = {0};
+        double serialized_clock[2] = {0};
+        double source_variance = 0.0;
+        double serialized_variance = 0.0;
+        eph2pos(eval_time, &source, source_position, source_clock, &source_variance);
+        eph2pos(eval_time, &serialized, serialized_position, serialized_clock, &serialized_variance);
+        for (int axis = 0; axis < 3; ++axis) {
+            EXPECT_LT(std::fabs(source_position[axis] - serialized_position[axis]), 1e-6)
+                << "serialized INAV orbit must round-trip to the same satellite position";
+        }
+        EXPECT_LT(std::fabs((source_clock[0] - serialized_clock[0]) * CLIGHT), 1e-6)
+            << "serialized INAV clock must round-trip to the same satellite clock";
+        verified_inav_record = true;
+    }
+
+    EXPECT_TRUE(verified_inav_record) << "real BRD400DLR fixture must contain a serializable Galileo INAV record";
     gnss_sim::destroy_rtklib_nav_store(store);
 }
 


### PR DESCRIPTION
Closes #90

## What changed

- `GALEPHEMERISA` is emitted only for an INAV-source ephemeris, or for an FNAV-source ephemeris whose satellite has no INAV companion (`galileo_inav_received` false).
- An FNAV-source record whose store also holds an INAV ephemeris for the same satellite is now explicitly unsupported by the NovAtel writer (`supported=false`, empty message) instead of emitting a second `GALEPHEMERISA` whose common orbit could be reconstructed as INAV.
- No orbital elements are merged, no family is inferred from clock-received flags, and no ephemeris is synthesized. FNAV-only satellites remain serializable and stay explicitly FNAV through the serialized received flags.

## Why

The ASCII format carries one common orbit block with no family discriminator. Issue #90 identified that PR #84's INAV-preferred reconstruction could rebuild a non-existent `FNAV orbit + INAV clock` combination. Making the writer refuse the ambiguous second record guarantees the reversible orbit representation is single-sourced per satellite/issue.

## Tests

- Real `brd400dlr_rinex4_acceptance_nav.rnx` fixture: INAV-source records serialize with valid CRC; FNAV-only records (E23, and E25 whose latest record is FNAV after RTKLIB `uniqnav`) serialize with valid CRC.
- The ambiguous state the writer itself can produce when a store holds both families is exercised by copying a real FNAV record unchanged and setting only the companion flag the adapter fills in that state; the writer rejects it. No ephemeris values are synthesized.
- A real INAV-source serialized record round-trips through the ASCII body (orbit block + INAV clock block, GPS week from the receiver-log header) to the same satellite position and clock within `1e-6` m equivalent at a representative GPST.
- Full unit suite passes locally (166/166); full CI will confirm format/tooling/Ubuntu/Windows.

## Relationship

This is a prerequisite for #81 / PR #84. After merging, the serialized-log validator in #84 no longer needs to guess the Galileo orbit family from companion clock fields; it can assert the single-sourced invariant instead.

## Implementation Notes

Loading real RINEX NAV applies RTKLIB `uniqnav()` (one record per satellite), so real fixtures alone cannot present the dual-family store state; the companion flag flip in the test reproduces exactly the state the adapter's own companion-clock scan produces in that case, without fabricating any ephemeris values.