### PR TITLE
Pair Galileo INAV/FNAV companions by navigation data identity

### DIFF
--- a/src/gnss/rtklib_nav_output_adapter.cpp
+++ b/src/gnss/rtklib_nav_output_adapter.cpp
@@ -108,10 +108,18 @@ int legacy_ion_systems(const nav_t& nav, int systems[4]) {
     return count;
 }
 
-void fill_galileo_companion_clocks(const nav_t& nav, int satellite_number, KeplerianNavOutputData* output) {
+bool same_galileo_navigation_instance(const eph_t& source, const eph_t& candidate) {
+    // Galileo broadcast navigation identity: same satellite, same IODnav (RTKLIB stores
+    // the Galileo IODnav in iode), and the exact same Toe epoch. INAV and FNAV update
+    // asynchronously, so a historical record of one family must never pair with a newer
+    // instance of the other family, and no looser Toe proximity may substitute here.
+    return source.sat == candidate.sat && source.iode == candidate.iode && timediff(source.toe, candidate.toe) == 0.0;
+}
+
+void fill_galileo_companion_clocks(const nav_t& nav, const eph_t& source, KeplerianNavOutputData* output) {
     for (int index = 0; index < nav.n; ++index) {
         const eph_t& candidate = nav.eph[index];
-        if (candidate.sat != satellite_number) {
+        if (!same_galileo_navigation_instance(source, candidate)) {
             continue;
         }
         const RtklibBroadcastMessageFamily family = message_family(SYS_GAL, candidate.hdr.msg_type);
@@ -179,7 +187,7 @@ bool fill_ephemeris(const nav_t& nav, int index, NavOutputRecord* record) {
     std::memcpy(output.isc_sec, eph.isc, sizeof(output.isc_sec));
     output.fit_hours = eph.fit;
     if (system == SYS_GAL) {
-        fill_galileo_companion_clocks(nav, eph.sat, &output);
+        fill_galileo_companion_clocks(nav, eph, &output);
         if (!output.galileo_fnav_received && output.message_family == RtklibBroadcastMessageFamily::kGalileoFnav) {
             output.galileo_fnav_received = true;
             output.galileo_fnav_toc_sow_sec = output.toc_sow_sec;

--- a/tests/unit/test_nav_output_writers.cpp
+++ b/tests/unit/test_nav_output_writers.cpp
@@ -26,6 +26,17 @@ extern "C" {
 #include <string>
 #include <vector>
 
+namespace gnss_sim {
+
+// Mirrors the identical RtklibNavStore definition shared by the adapter translation
+// units so these tests can retarget broadcast-identity fields of appended real records
+// in place; every orbital and clock value stays real RINEX-derived data.
+struct RtklibNavStore {
+    nav_t nav;
+};
+
+} // namespace gnss_sim
+
 namespace {
 
 std::string data_path(const char* name) {
@@ -682,6 +693,260 @@ TEST(NavOutputWriter, RealGalileoInavSerializedRecordRoundTripsPositionAndClock)
 
     EXPECT_TRUE(verified_inav_record) << "real BRD400DLR fixture must contain a serializable Galileo INAV record";
     gnss_sim::destroy_rtklib_nav_store(store);
+}
+
+int find_real_galileo_record_index(const gnss_sim::RtklibNavStore* store, int prn,
+                                   gnss_sim::RtklibBroadcastMessageFamily family, std::string* error_message) {
+    const int count = gnss_sim::rtklib_nav_output_record_count(store);
+    for (int index = 0; index < count; ++index) {
+        gnss_sim::NavOutputRecord record{};
+        if (!gnss_sim::rtklib_nav_output_record(store, index, &record, error_message)) {
+            return -1;
+        }
+        if (record.kind == gnss_sim::RtklibNavRecordKind::kEphemeris &&
+            record.ephemeris.system == gnss_sim::NavOutputSystem::kGalileo && record.ephemeris.prn == prn &&
+            record.ephemeris.message_family == family) {
+            return index;
+        }
+    }
+    return -1;
+}
+
+// Appends the real record at source_index into destination and retargets only the
+// broadcast-identity fields (satellite, IODnav, Toe) so the copy represents one Galileo
+// navigation instance of one satellite. Every orbital and clock value stays the real
+// RINEX-derived value of the copied record; nothing is synthesized or interpolated.
+bool append_galileo_instance(const gnss_sim::RtklibNavStore* source, int source_index,
+                             gnss_sim::RtklibNavStore* destination, int satellite_number, int iode, gtime_t toe,
+                             std::string* error_message) {
+    if (!gnss_sim::rtklib_copy_nav_record(source, source_index, destination, error_message)) {
+        return false;
+    }
+    eph_t& appended = destination->nav.eph[destination->nav.n - 1];
+    appended.sat = satellite_number;
+    appended.iode = iode;
+    appended.toe = toe;
+    return true;
+}
+
+bool format_store_record(const gnss_sim::RtklibNavStore* store, int index, gnss_sim::NavOutputRecord* record,
+                         std::string* message, bool* supported, std::string* error_message) {
+    if (!gnss_sim::rtklib_nav_output_record(store, index, record, error_message)) {
+        return false;
+    }
+    const gnss_sim::SimTime time = output_time();
+    return gnss_sim::format_novatel_nav_output_record(*record, time, message, supported, error_message);
+}
+
+void expect_serialized_galileo_clock(const std::vector<std::string>& fields, int first_index, const eph_t& expected,
+                                     const char* label) {
+    const double expected_clock[3] = {expected.f0, expected.f1, expected.f2};
+    for (int axis = 0; axis < 3; ++axis) {
+        EXPECT_NEAR(std::stod(fields[first_index + axis]), expected_clock[axis],
+                    1e-12 * (std::fabs(expected_clock[axis]) + 1e-30))
+            << label << " clock coefficient " << axis << " must come from the matching navigation instance";
+    }
+}
+
+TEST(NavOutputWriter, RealGalileoMatchingInstanceInavFnavSerializesOneCombinedRecord) {
+    gnss_sim::RtklibNavStore* base = gnss_sim::create_rtklib_nav_store();
+    ASSERT_NE(base, nullptr);
+    std::string error_message;
+    ASSERT_TRUE(
+        gnss_sim::load_rinex_nav_file(base, data_path("brd400dlr_rinex4_acceptance_nav.rnx").c_str(), &error_message))
+        << error_message;
+    const int inav_index =
+        find_real_galileo_record_index(base, 2, gnss_sim::RtklibBroadcastMessageFamily::kGalileoInav, &error_message);
+    const int fnav_index =
+        find_real_galileo_record_index(base, 23, gnss_sim::RtklibBroadcastMessageFamily::kGalileoFnav, &error_message);
+    ASSERT_GE(inav_index, 0) << error_message;
+    ASSERT_GE(fnav_index, 0) << error_message;
+    const eph_t inav_source = base->nav.eph[inav_index];
+    const eph_t fnav_source = base->nav.eph[fnav_index];
+
+    gnss_sim::RtklibNavStore* receiver = gnss_sim::create_rtklib_nav_store();
+    ASSERT_NE(receiver, nullptr);
+    ASSERT_TRUE(append_galileo_instance(base, inav_index, receiver, inav_source.sat, inav_source.iode, inav_source.toe,
+                                        &error_message))
+        << error_message;
+    ASSERT_TRUE(append_galileo_instance(base, fnav_index, receiver, inav_source.sat, inav_source.iode, inav_source.toe,
+                                        &error_message))
+        << error_message;
+
+    gnss_sim::NavOutputRecord record{};
+    std::string message;
+    bool supported = false;
+    // The INAV-source record owns the reversible orbit representation (issue 90) and
+    // carries the combined clock blocks of the matching T0 instances.
+    ASSERT_TRUE(format_store_record(receiver, 0, &record, &message, &supported, &error_message)) << error_message;
+    ASSERT_TRUE(supported) << "a matching INAV/FNAV instance pair must serialize as one combined record";
+    EXPECT_TRUE(valid_ascii_crc(message));
+    EXPECT_EQ(log_name(message), "GALEPHEMERISA");
+    const std::vector<std::string> fields = split_body_fields(body_between_semicolon_and_crc(message));
+    ASSERT_EQ(fields.size(), 38u);
+    EXPECT_EQ(fields[1], "TRUE");
+    EXPECT_EQ(fields[2], "TRUE");
+    expect_serialized_galileo_clock(fields, 29, fnav_source, "FNAV");
+    expect_serialized_galileo_clock(fields, 33, inav_source, "INAV");
+    // The FNAV-source record of the same instance must not emit a second orbit
+    // representation while the INAV-source record exists for that instance.
+    ASSERT_TRUE(format_store_record(receiver, 1, &record, &message, &supported, &error_message)) << error_message;
+    EXPECT_FALSE(supported);
+    gnss_sim::destroy_rtklib_nav_store(receiver);
+    gnss_sim::destroy_rtklib_nav_store(base);
+}
+
+TEST(NavOutputWriter, RealGalileoStaleInavDoesNotSuppressDifferentInstanceFnav) {
+    gnss_sim::RtklibNavStore* base = gnss_sim::create_rtklib_nav_store();
+    ASSERT_NE(base, nullptr);
+    std::string error_message;
+    ASSERT_TRUE(
+        gnss_sim::load_rinex_nav_file(base, data_path("brd400dlr_rinex4_acceptance_nav.rnx").c_str(), &error_message))
+        << error_message;
+    const int inav_index =
+        find_real_galileo_record_index(base, 2, gnss_sim::RtklibBroadcastMessageFamily::kGalileoInav, &error_message);
+    const int fnav_index =
+        find_real_galileo_record_index(base, 23, gnss_sim::RtklibBroadcastMessageFamily::kGalileoFnav, &error_message);
+    ASSERT_GE(inav_index, 0) << error_message;
+    ASSERT_GE(fnav_index, 0) << error_message;
+    const eph_t inav_source = base->nav.eph[inav_index];
+
+    gnss_sim::RtklibNavStore* receiver = gnss_sim::create_rtklib_nav_store();
+    ASSERT_NE(receiver, nullptr);
+    ASSERT_TRUE(append_galileo_instance(base, inav_index, receiver, inav_source.sat, inav_source.iode, inav_source.toe,
+                                        &error_message))
+        << error_message;
+    ASSERT_TRUE(append_galileo_instance(base, fnav_index, receiver, inav_source.sat, inav_source.iode + 1,
+                                        timeadd(inav_source.toe, 1800.0), &error_message))
+        << error_message;
+
+    gnss_sim::NavOutputRecord record{};
+    std::string message;
+    bool supported = false;
+    ASSERT_TRUE(format_store_record(receiver, 0, &record, &message, &supported, &error_message)) << error_message;
+    EXPECT_TRUE(supported);
+    const std::vector<std::string> historical = split_body_fields(body_between_semicolon_and_crc(message));
+    ASSERT_EQ(historical.size(), 38u);
+    EXPECT_EQ(historical[1], "FALSE");
+    EXPECT_EQ(historical[2], "TRUE");
+
+    ASSERT_TRUE(format_store_record(receiver, 1, &record, &message, &supported, &error_message)) << error_message;
+    EXPECT_TRUE(supported) << "a stale INAV must not suppress a newer different-instance FNAV update";
+    const std::vector<std::string> fields = split_body_fields(body_between_semicolon_and_crc(message));
+    ASSERT_EQ(fields.size(), 38u);
+    EXPECT_EQ(fields[1], "TRUE");
+    EXPECT_EQ(fields[2], "FALSE") << "an INAV of another IOD/Toe instance must not be reported as a companion";
+    gnss_sim::destroy_rtklib_nav_store(receiver);
+    gnss_sim::destroy_rtklib_nav_store(base);
+}
+
+TEST(NavOutputWriter, RealGalileoAsyncInavFnavInstancesPairByBroadcastIdentity) {
+    gnss_sim::RtklibNavStore* base = gnss_sim::create_rtklib_nav_store();
+    ASSERT_NE(base, nullptr);
+    std::string error_message;
+    ASSERT_TRUE(
+        gnss_sim::load_rinex_nav_file(base, data_path("brd400dlr_rinex4_acceptance_nav.rnx").c_str(), &error_message))
+        << error_message;
+    const int inav_t0_index =
+        find_real_galileo_record_index(base, 2, gnss_sim::RtklibBroadcastMessageFamily::kGalileoInav, &error_message);
+    const int fnav_t0_index =
+        find_real_galileo_record_index(base, 23, gnss_sim::RtklibBroadcastMessageFamily::kGalileoFnav, &error_message);
+    const int fnav_t1_index =
+        find_real_galileo_record_index(base, 25, gnss_sim::RtklibBroadcastMessageFamily::kGalileoFnav, &error_message);
+    const int inav_t1_index =
+        find_real_galileo_record_index(base, 19, gnss_sim::RtklibBroadcastMessageFamily::kGalileoInav, &error_message);
+    ASSERT_GE(inav_t0_index, 0) << error_message;
+    ASSERT_GE(fnav_t0_index, 0) << error_message;
+    ASSERT_GE(fnav_t1_index, 0) << error_message;
+    ASSERT_GE(inav_t1_index, 0) << error_message;
+
+    // Four distinct real records carry four distinct real clock value sets, so any
+    // instance mixing in the combined record changes the serialized clock values:
+    // instance T0 = INAV E02 + FNAV E23, instance T1 = INAV E19 + FNAV E25.
+    const eph_t inav_t0 = base->nav.eph[inav_t0_index];
+    const eph_t fnav_t0 = base->nav.eph[fnav_t0_index];
+    const eph_t fnav_t1 = base->nav.eph[fnav_t1_index];
+    const eph_t inav_t1 = base->nav.eph[inav_t1_index];
+    const int satellite = inav_t0.sat;
+    const gtime_t toe_t1 = timeadd(inav_t0.toe, 1800.0);
+
+    gnss_sim::RtklibNavStore* receiver = gnss_sim::create_rtklib_nav_store();
+    ASSERT_NE(receiver, nullptr);
+    ASSERT_TRUE(
+        append_galileo_instance(base, inav_t0_index, receiver, satellite, inav_t0.iode, inav_t0.toe, &error_message))
+        << error_message;
+
+    gnss_sim::NavOutputRecord record{};
+    std::string message;
+    bool supported = false;
+    // After A: the INAV T0 record is a real INAV-only record.
+    ASSERT_TRUE(format_store_record(receiver, 0, &record, &message, &supported, &error_message)) << error_message;
+    ASSERT_TRUE(supported);
+    std::vector<std::string> fields = split_body_fields(body_between_semicolon_and_crc(message));
+    ASSERT_EQ(fields.size(), 38u);
+    EXPECT_EQ(fields[1], "FALSE");
+    EXPECT_EQ(fields[2], "TRUE");
+
+    ASSERT_TRUE(
+        append_galileo_instance(base, fnav_t0_index, receiver, satellite, inav_t0.iode, inav_t0.toe, &error_message))
+        << error_message;
+
+    // After B: the matching T0 FNAV makes the INAV-source record the combined
+    // representation of instance T0; the FNAV-source record does not emit a second orbit.
+    ASSERT_TRUE(format_store_record(receiver, 0, &record, &message, &supported, &error_message)) << error_message;
+    ASSERT_TRUE(supported);
+    fields = split_body_fields(body_between_semicolon_and_crc(message));
+    ASSERT_EQ(fields.size(), 38u);
+    EXPECT_EQ(fields[1], "TRUE");
+    EXPECT_EQ(fields[2], "TRUE");
+    expect_serialized_galileo_clock(fields, 29, fnav_t0, "FNAV T0");
+    expect_serialized_galileo_clock(fields, 33, inav_t0, "INAV T0");
+    ASSERT_TRUE(format_store_record(receiver, 1, &record, &message, &supported, &error_message)) << error_message;
+    EXPECT_FALSE(supported);
+
+    ASSERT_TRUE(
+        append_galileo_instance(base, fnav_t1_index, receiver, satellite, inav_t0.iode + 1, toe_t1, &error_message))
+        << error_message;
+
+    // Step C is the key regression gate: the FNAV T1 update arrives while only the
+    // historical INAV T0 exists for this satellite. It must stay serializable and
+    // single-family instead of being suppressed or combined with the stale INAV.
+    ASSERT_TRUE(format_store_record(receiver, receiver->nav.n - 1, &record, &message, &supported, &error_message))
+        << error_message;
+    EXPECT_TRUE(supported) << "the newer FNAV update must not be lost while its INAV is still missing";
+    fields = split_body_fields(body_between_semicolon_and_crc(message));
+    ASSERT_EQ(fields.size(), 38u);
+    EXPECT_EQ(fields[1], "TRUE");
+    EXPECT_EQ(fields[2], "FALSE");
+
+    ASSERT_TRUE(
+        append_galileo_instance(base, inav_t1_index, receiver, satellite, inav_t0.iode + 1, toe_t1, &error_message))
+        << error_message;
+
+    // After D, only the matching T1 pair combines, and the combined clocks come from the
+    // T1 instances (E19 INAV, E25 FNAV), not from the historical T0 records.
+    ASSERT_TRUE(format_store_record(receiver, receiver->nav.n - 1, &record, &message, &supported, &error_message))
+        << error_message;
+    ASSERT_TRUE(supported);
+    fields = split_body_fields(body_between_semicolon_and_crc(message));
+    ASSERT_EQ(fields.size(), 38u);
+    EXPECT_EQ(fields[1], "TRUE");
+    EXPECT_EQ(fields[2], "TRUE");
+    expect_serialized_galileo_clock(fields, 29, fnav_t1, "FNAV T1");
+    expect_serialized_galileo_clock(fields, 33, inav_t1, "INAV T1");
+
+    // Historical isolation: re-project the T0 INAV record. Its companion FNAV clock must
+    // still come from the T0 FNAV (E23 values), never from the newer T1 FNAV (E25 values).
+    ASSERT_TRUE(format_store_record(receiver, 0, &record, &message, &supported, &error_message)) << error_message;
+    ASSERT_TRUE(supported);
+    fields = split_body_fields(body_between_semicolon_and_crc(message));
+    ASSERT_EQ(fields.size(), 38u);
+    EXPECT_EQ(fields[1], "TRUE");
+    EXPECT_EQ(fields[2], "TRUE");
+    expect_serialized_galileo_clock(fields, 29, fnav_t0, "historical FNAV T0");
+    expect_serialized_galileo_clock(fields, 33, inav_t0, "historical INAV T0");
+    gnss_sim::destroy_rtklib_nav_store(receiver);
+    gnss_sim::destroy_rtklib_nav_store(base);
 }
 
 } // namespace


### PR DESCRIPTION
Closes #92

## What changed

- `fill_galileo_companion_clocks()` now selects companion candidates through a new deterministic predicate `same_galileo_navigation_instance(source, candidate)` instead of satellite number alone.
- The predicate requires: same satellite (`source.sat == candidate.sat`), same IODnav (`source.iode == candidate.iode`; RTKLIB stores the Galileo IODnav in `eph.iode`, see `rinex.c` decode `/* IODnav */`), and the exact same Toe epoch (`timediff(source.toe, candidate.toe) == 0.0`). No loose time tolerance.
- `novatel_nav_writer.cpp` needed **no change**: the emission gate from #90/#91 reads `galileo_inav_received` / `galileo_fnav_received`, which now accurately describe only matching companions.

## Old failure mechanism

`receiver_nav` retains multiple historical Galileo INAV/FNAV records per satellite (RTKLIB `uniqeph` keeps records with distinct `(sat, iode, msg_type)` triples, and delivery appends records over time). Because companion selection matched only by satellite:

1. a newer FNAV record could be serialized with a historical INAV clock block (mixed IODnav/Toe instances in one `GALEPHEMERISA`), and
2. the writer gate rejected any FNAV-source record whose satellite had *some* INAV — silently suppressing a valid newer FNAV update.

The new regressions reproduce both on the unfixed code (3 tests fail: unsupported FNAV updates, wrong companion flags), and pass after the fix.

## Why the predicate is sufficient

A Galileo broadcast navigation instance is identified by satellite + IODnav + Toe. RTKLIB decodes the RINEX Galileo IODnav into `eph.iode` and the Toe into `eph.toe`, so equality of both fields (plus satellite) means the INAV/FNAV records describe the same broadcast data set; anything else is a different instance and must not combine. Exact `timediff == 0.0` is deterministic because Toe values are parsed from the same RINEX epoch text.

## Asynchronous update regression

The sequence test builds a receiver-visible store from four distinct **real** BRD400DLR records (identity fields retargeted in place, orbital/clock values untouched): A = INAV T0 (E02), B = FNAV T0 (E23), C = FNAV T1 (E25), D = INAV T1 (E19). Each instance has distinct real clock values, so instance mixing would change the serialized bytes.

- after A: INAV-only (`fnav=FALSE, inav=TRUE`);
- after B: the INAV-source record becomes the combined T0 representation (`FNAV/INAV` clock blocks = E23/E02 values); the FNAV-source record does not emit a second orbit (issue 90 semantics preserved);
- **after C (key gate)**: the newer FNAV T1 stays serializable and single-family (`fnav=TRUE, inav=FALSE`) — not suppressed by the stale INAV T0;
- after D: only the matching T1 pair combines (clock blocks = E25/E19 values), and re-projecting the historical T0 INAV still yields the T0 FNAV clock (E23), never the T1 clock.

## No synthesized data

All orbital/clock values in every new test come from real `brd400dlr_rinex4_acceptance_nav.rnx` records appended via `rtklib_copy_nav_record`; only satellite/IODnav/Toe identity fields are retargeted on the appended copies to lay out the asynchronous scenario. No companion clock is copied across instances, interpolated, or taken from future/non-receiver-visible records.

## Validation

- `./build/gnss_sim_unit_tests`: **169/169 pass** (15/15 in `NavOutputWriter`, including 3 new regressions)
- `./build/gnss_sim_integration_tests`: **39/39 pass**, including serialized `RANGEA + NAV` self-contained RTKLIB SPP closure and the RINEX-backed `RANGEA` reference positioning — no regression
- `clang-format --dry-run --Werror` clean on both changed files