### PR TITLE
Fix macOS libc++ builds: include C++ headers before RTKLIB macros

### DIFF
--- a/src/gnss/galileo_has_adapter.cpp
+++ b/src/gnss/galileo_has_adapter.cpp
@@ -1,9 +1,5 @@
 #include "gnss/galileo_has_adapter.h"
 
-extern "C" {
-#include <rtklib.h>
-}
-
 #include <cmath>
 #include <cstdio>
 #include <fstream>
@@ -13,6 +9,9 @@ extern "C" {
 #include <utility>
 #include <vector>
 
+extern "C" {
+#include <rtklib.h>
+}
 namespace gnss_sim {
 namespace {
 

--- a/src/gnss/nav_output_metadata.cpp
+++ b/src/gnss/nav_output_metadata.cpp
@@ -1,11 +1,10 @@
 #include "gnss/nav_output_record.h"
 
+#include <cmath>
+
 extern "C" {
 #include <rtklib.h>
 }
-
-#include <cmath>
-
 namespace gnss_sim {
 namespace {
 

--- a/src/gnss/rtklib_adapter.cpp
+++ b/src/gnss/rtklib_adapter.cpp
@@ -1,11 +1,5 @@
 #include "gnss/rtklib_adapter.h"
 
-extern "C" {
-#include <rtklib.h>
-#include <rtklib_obs_ext.h>
-#include <rtklib_signal_bias_ext.h>
-}
-
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
@@ -15,6 +9,11 @@ extern "C" {
 #include <utility>
 #include <vector>
 
+extern "C" {
+#include <rtklib.h>
+#include <rtklib_obs_ext.h>
+#include <rtklib_signal_bias_ext.h>
+}
 namespace gnss_sim {
 
 struct RtklibNavStore {

--- a/src/gnss/rtklib_atmosphere_adapter.cpp
+++ b/src/gnss/rtklib_atmosphere_adapter.cpp
@@ -1,11 +1,10 @@
 #include "gnss/rtklib_adapter.h"
 
+#include <cmath>
+
 extern "C" {
 #include <rtklib.h>
 }
-
-#include <cmath>
-
 namespace gnss_sim {
 
 struct RtklibNavStore {

--- a/src/gnss/rtklib_bias_adapter.cpp
+++ b/src/gnss/rtklib_bias_adapter.cpp
@@ -1,13 +1,12 @@
 #include "gnss/rtklib_adapter.h"
 
+#include <cmath>
+#include <cstring>
+
 extern "C" {
 #include <rtklib.h>
 #include <rtklib_signal_bias_ext.h>
 }
-
-#include <cmath>
-#include <cstring>
-
 namespace gnss_sim {
 
 // RtklibNavStore is intentionally opaque outside the RTKLIB adapter boundary.

--- a/src/gnss/rtklib_nav_input_adapter.cpp
+++ b/src/gnss/rtklib_nav_input_adapter.cpp
@@ -1,14 +1,13 @@
 #include "gnss/nav_output_record.h"
 
-extern "C" {
-#include <rtklib.h>
-}
-
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
 #include <string>
 
+extern "C" {
+#include <rtklib.h>
+}
 namespace gnss_sim {
 
 struct RtklibNavStore {

--- a/src/gnss/rtklib_output_adapter.cpp
+++ b/src/gnss/rtklib_output_adapter.cpp
@@ -1,11 +1,10 @@
 #include "gnss/rtklib_adapter.h"
 
+#include <cstring>
+
 extern "C" {
 #include <rtklib.h>
 }
-
-#include <cstring>
-
 namespace gnss_sim {
 
 bool rtklib_satellite_number_to_id(int satellite_number, char satellite_id[4]) {

--- a/src/gnss/rtklib_raw_position_adapter.cpp
+++ b/src/gnss/rtklib_raw_position_adapter.cpp
@@ -1,13 +1,12 @@
 #include "gnss/rtklib_adapter.h"
 
+#include <cmath>
+#include <cstdio>
+
 extern "C" {
 #include <rtklib.h>
 #include <rtklib_signal_bias_ext.h>
 }
-
-#include <cmath>
-#include <cstdio>
-
 namespace gnss_sim {
 
 struct RtklibNavStore {

--- a/src/gnss/rtklib_solution_adapter.cpp
+++ b/src/gnss/rtklib_solution_adapter.cpp
@@ -1,15 +1,14 @@
 #include "gnss/rtklib_adapter.h"
 
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+
 extern "C" {
 #include <rtklib.h>
 #include <rtklib_pntvel_ext.h>
 #include <rtklib_signal_bias_ext.h>
 }
-
-#include <cmath>
-#include <cstdio>
-#include <cstring>
-
 namespace gnss_sim {
 
 struct RtklibNavStore {

--- a/tests/unit/test_galileo_has_adapter.cpp
+++ b/tests/unit/test_galileo_has_adapter.cpp
@@ -1,14 +1,12 @@
 #include "gnss/galileo_has_adapter.h"
 
+#include <cmath>
 #include <gtest/gtest.h>
+#include <string>
 
 extern "C" {
 #include <rtklib.h>
 }
-
-#include <cmath>
-#include <string>
-
 namespace {
 
 std::string test_data_path(const char* name) {

--- a/tests/unit/test_rinex_obs_stream.cpp
+++ b/tests/unit/test_rinex_obs_stream.cpp
@@ -3,22 +3,20 @@
 #include "model/receiver_truth.h"
 #include "tools/build_cn0_model/rinex_obs_stream.h"
 
-#include <gtest/gtest.h>
-
-extern "C" {
-#include <rtklib.h>
-}
-
 #include <cmath>
 #include <cstdio>
 #include <filesystem>
 #include <fstream>
+#include <gtest/gtest.h>
 #include <iomanip>
 #include <set>
 #include <sstream>
 #include <string>
 #include <vector>
 
+extern "C" {
+#include <rtklib.h>
+}
 namespace {
 
 using gnss_sim::cn0_builder::Cn0SampleValidity;

--- a/tools/residual_validator/residual_validator.cpp
+++ b/tools/residual_validator/residual_validator.cpp
@@ -2,11 +2,6 @@
 
 #include "gnss/signal_definitions.h"
 
-extern "C" {
-#include <rtklib.h>
-#include <rtklib_residual_ext.h>
-}
-
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
@@ -20,6 +15,10 @@ extern "C" {
 #include <utility>
 #include <vector>
 
+extern "C" {
+#include <rtklib.h>
+#include <rtklib_residual_ext.h>
+}
 namespace gnss_sim::residual_validator {
 namespace {
 


### PR DESCRIPTION
## Problem

`rtklib.h` defines function-like macros `lock(f)` / `unlock(f)` (POSIX/Windows shims used by RTKLIB's own C sources). On macOS with recent Xcode SDKs, any translation unit that includes C++ standard headers **after** `rtklib.h` fails to compile, because libc++'s `<mutex>` declares member functions such as `void lock(_L0& __l0, _L1& __l1)` and the macro invocation produces:

```
mutex:354:44: error: too many arguments provided to function-like macro invocation
mutex:415:24: error: use of undeclared identifier '__l0'
```

GCC/libstdc++ (Ubuntu CI) and MSVC (Windows CI) are unaffected, which is why CI stayed green while local macOS builds of 12 translation units were broken.

## What changed

- In the affected translation units, the C++ standard header includes now precede the `extern "C" { #include <rtklib.h> }` block, so libc++ headers are parsed before the macros exist. This matches the existing house pattern in `tests/unit/test_satellite_engine.cpp` (which already handled the collision with `#undef`).
- Include order is the only change: no navigation data, production semantics, or tests are touched. No project C++ code consumes RTKLIB's `lock`/`unlock` macros (verified by grep).
- 12 files: 9 adapter/core sources, 2 unit-test files, 1 tool. Files that already compile (including all `#undef`-style users) are left unchanged.

## Verification

- From-scratch `cmake` configure + build on macOS arm64 with **no other local changes**: clean, zero errors.
- `./build/gnss_sim_unit_tests`: **169/169 pass**; `./build/gnss_sim_integration_tests`: **39/39 pass**.
- `clang-format --dry-run --Werror` clean on all changed files.
- Ubuntu/Windows CI expected unaffected (their std libraries were never affected); CI confirms.