### PR TITLE
Harden NAV equivalence validation with full identity and exact solution-set checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,9 +26,9 @@ Testing/
 sim_output/
 generated/
 
-# Integration-test run artifacts
-event_truth.csv
-observation_truth.csv
-run_manifest.json
-scenario.json
-solution_truth.csv
+# Integration-test run artifacts (repository root only)
+/event_truth.csv
+/observation_truth.csv
+/run_manifest.json
+/scenario.json
+/solution_truth.csv

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,10 @@ Testing/
 *.log
 sim_output/
 generated/
+
+# Integration-test run artifacts
+event_truth.csv
+observation_truth.csv
+run_manifest.json
+scenario.json
+solution_truth.csv

--- a/src/gnss/rtklib_adapter.cpp
+++ b/src/gnss/rtklib_adapter.cpp
@@ -527,7 +527,8 @@ bool get_rtklib_satellite_state(const RtklibNavStore* store, int gps_week, doubl
 
 bool get_rtklib_signal_satellite_state(const RtklibNavStore* store, int gps_week, double sow_sec, int satellite_number,
                                        int observation_code, RtklibBroadcastMessageFamily requested_message_family,
-                                       RtklibSatelliteState* state, std::string* error_message) {
+                                       RtklibSatelliteState* state, std::string* error_message,
+                                       RtklibSelectedEphemerisInfo* selected_identity) {
     if (store == nullptr || state == nullptr || satellite_number <= 0 || observation_code <= 0 ||
         observation_code > 255 || !valid_gps_time(gps_week, sow_sec)) {
         set_error(error_message, "signal satellite-state request has invalid arguments");
@@ -616,6 +617,25 @@ bool get_rtklib_signal_satellite_state(const RtklibNavStore* store, int gps_week
     state->clock_bias_sec = clock_bias_sec;
     state->clock_drift_sec_per_sec = (next_clock_bias_sec - clock_bias_sec) / kDifferenceSec;
     state->variance_m2 = variance_m2;
+    if (selected_identity != nullptr) {
+        // The identity comes from the same selected record that produced the state.
+        selected_identity->satellite_number = satellite_number;
+        selected_identity->message_family = requested_message_family;
+        if (info.system == SYS_GLO) {
+            selected_identity->iode = geph.iode;
+            selected_identity->iodc = 0;
+            selected_identity->toe_sow_sec = time2gpst(geph.toe, &selected_identity->toe_week);
+            selected_identity->toc_week = selected_identity->toe_week;
+            selected_identity->toc_sow_sec = selected_identity->toe_sow_sec;
+            selected_identity->transmit_sow_sec = time2gpst(geph.tof, &selected_identity->transmit_week);
+        } else {
+            selected_identity->iode = eph.iode;
+            selected_identity->iodc = eph.iodc;
+            selected_identity->toe_sow_sec = time2gpst(eph.toe, &selected_identity->toe_week);
+            selected_identity->toc_sow_sec = time2gpst(eph.toc, &selected_identity->toc_week);
+            selected_identity->transmit_sow_sec = time2gpst(eph.ttr, &selected_identity->transmit_week);
+        }
+    }
     return true;
 }
 

--- a/src/gnss/rtklib_adapter.cpp
+++ b/src/gnss/rtklib_adapter.cpp
@@ -639,6 +639,43 @@ bool get_rtklib_signal_satellite_state(const RtklibNavStore* store, int gps_week
     return true;
 }
 
+bool rtklib_broadcast_ionosphere_model_state(const RtklibNavStore* store, RtklibIonosphereSystem system,
+                                             RtklibIonosphereModelState* state, std::string* error_message) {
+    if (store == nullptr || state == nullptr) {
+        if (error_message != nullptr) {
+            *error_message = "broadcast ionosphere model-state request has invalid arguments";
+        }
+        return false;
+    }
+    const double* coefficients = nullptr;
+    switch (system) {
+        case RtklibIonosphereSystem::kGps:
+            coefficients = store->nav.ion_gps;
+            break;
+        case RtklibIonosphereSystem::kQzss:
+            coefficients = store->nav.ion_qzs;
+            break;
+        case RtklibIonosphereSystem::kBeidouLegacy:
+            coefficients = store->nav.ion_cmp;
+            break;
+        case RtklibIonosphereSystem::kGalileo:
+        case RtklibIonosphereSystem::kGlonass:
+        case RtklibIonosphereSystem::kBeidouModern:
+            break;
+    }
+    if (coefficients == nullptr) {
+        if (error_message != nullptr) {
+            *error_message = "broadcast ionosphere model is not stored for the requested system";
+        }
+        return false;
+    }
+    for (int index = 0; index < 8; ++index) {
+        state->coefficients[index] = coefficients[index];
+    }
+    state->leap_seconds = store->nav.leaps;
+    return true;
+}
+
 bool rtklib_llh_to_ecef(double latitude_deg, double longitude_deg, double height_m, double ecef_m[3]) {
     if (ecef_m == nullptr || !std::isfinite(latitude_deg) || !std::isfinite(longitude_deg) ||
         !std::isfinite(height_m) || latitude_deg < -90.0 || latitude_deg > 90.0 || longitude_deg < -180.0 ||

--- a/src/gnss/rtklib_adapter.h
+++ b/src/gnss/rtklib_adapter.h
@@ -98,6 +98,15 @@ struct RtklibIonosphereResult {
     double reference_frequency_hz;
 };
 
+// Read-only snapshot of the broadcast ionosphere model state stored in the RTKLIB
+// navigation store (8 Klobuchar-style coefficients plus the GPST-UTC leap seconds).
+// Used to verify correction values inside the final reconstructed store without
+// exposing or mutating private nav_t internals.
+struct RtklibIonosphereModelState {
+    double coefficients[8];
+    int leap_seconds;
+};
+
 struct RtklibBroadcastBiasData {
     RtklibBroadcastMessageFamily message_family;
     int system;
@@ -218,6 +227,8 @@ bool rtklib_geometric_distance(const double satellite_ecef_m[3], const double re
 bool rtklib_azimuth_elevation(const double receiver_ecef_m[3], const double line_of_sight_ecef[3], double* azimuth_rad,
                               double* elevation_rad);
 
+bool rtklib_broadcast_ionosphere_model_state(const RtklibNavStore* store, RtklibIonosphereSystem system,
+                                             RtklibIonosphereModelState* state, std::string* error_message);
 bool rtklib_broadcast_ionosphere_reference_delay(const RtklibNavStore* store, RtklibIonosphereSystem system,
                                                  int gps_week, double sow_sec, const double receiver_ecef_m[3],
                                                  double azimuth_rad, double elevation_rad,

--- a/src/gnss/rtklib_adapter.h
+++ b/src/gnss/rtklib_adapter.h
@@ -1,6 +1,7 @@
 #ifndef GNSS_SIM_SRC_GNSS_RTKLIB_ADAPTER_H_
 #define GNSS_SIM_SRC_GNSS_RTKLIB_ADAPTER_H_
 
+#include <cstdint>
 #include <string>
 
 namespace gnss_sim {
@@ -74,6 +75,23 @@ struct RtklibSatelliteState {
     int health;
 };
 
+// Identity metadata of the broadcast ephemeris record that the family-restricted
+// RTKLIB selection actually chose for a satellite-state calculation. Week/SOW values
+// use the GPST convention of the projected records. GLONASS records carry no separate
+// IODC/Toc: IODC is reported as 0 and Toc mirrors Toe.
+struct RtklibSelectedEphemerisInfo {
+    int satellite_number;
+    RtklibBroadcastMessageFamily message_family;
+    int iode;
+    int iodc;
+    int toe_week;
+    double toe_sow_sec;
+    int toc_week;
+    double toc_sow_sec;
+    int transmit_week;
+    double transmit_sow_sec;
+};
+
 struct RtklibIonosphereResult {
     RtklibIonosphereStatus status;
     double reference_delay_m;
@@ -126,6 +144,10 @@ struct RtklibPositionSolution {
     double receiver_clock_bias_m;
     double covariance_ecef_m2[6];
     int used_satellites;
+    // Exact set of satellites RTKLIB used in the solution, as a bit mask indexed by
+    // (RTKLIB satellite number - 1). Seven 64-bit words cover RTKLIB MAXSAT (408);
+    // unused satellites have cleared bits. Zero when the solution is invalid.
+    std::uint64_t used_satellite_mask[7];
     char diagnostic[128];
 };
 
@@ -164,7 +186,8 @@ bool get_rtklib_satellite_state(const RtklibNavStore* store, int gps_week, doubl
                                 RtklibSatelliteState* state, std::string* error_message);
 bool get_rtklib_signal_satellite_state(const RtklibNavStore* store, int gps_week, double sow_sec, int satellite_number,
                                        int observation_code, RtklibBroadcastMessageFamily requested_message_family,
-                                       RtklibSatelliteState* state, std::string* error_message);
+                                       RtklibSatelliteState* state, std::string* error_message,
+                                       RtklibSelectedEphemerisInfo* selected_identity = nullptr);
 bool rtklib_broadcast_bias_data_for_family(const RtklibNavStore* store, int gps_week, double sow_sec,
                                            int satellite_number, RtklibBroadcastMessageFamily requested_message_family,
                                            RtklibBroadcastBiasData* data, std::string* error_message);

--- a/src/gnss/rtklib_adapter.h
+++ b/src/gnss/rtklib_adapter.h
@@ -199,7 +199,8 @@ bool get_rtklib_signal_satellite_state(const RtklibNavStore* store, int gps_week
                                        RtklibSelectedEphemerisInfo* selected_identity = nullptr);
 bool rtklib_broadcast_bias_data_for_family(const RtklibNavStore* store, int gps_week, double sow_sec,
                                            int satellite_number, RtklibBroadcastMessageFamily requested_message_family,
-                                           RtklibBroadcastBiasData* data, std::string* error_message);
+                                           RtklibBroadcastBiasData* data, std::string* error_message,
+                                           RtklibSelectedEphemerisInfo* selected_identity = nullptr);
 bool rtklib_broadcast_bias_data(const RtklibNavStore* store, int gps_week, double sow_sec, int satellite_number,
                                 RtklibBroadcastBiasData* data, std::string* error_message);
 

--- a/src/gnss/rtklib_bias_adapter.cpp
+++ b/src/gnss/rtklib_bias_adapter.cpp
@@ -179,7 +179,8 @@ const eph_t* select_ephemeris_for_family(const nav_t& nav, gtime_t time, int sat
 
 bool rtklib_broadcast_bias_data_for_family(const RtklibNavStore* store, int gps_week, double sow_sec,
                                            int satellite_number, RtklibBroadcastMessageFamily requested_message_family,
-                                           RtklibBroadcastBiasData* data, std::string* error_message) {
+                                           RtklibBroadcastBiasData* data, std::string* error_message,
+                                           RtklibSelectedEphemerisInfo* selected_identity) {
     if (store == nullptr || data == nullptr || satellite_number <= 0 || !valid_gps_time(gps_week, sow_sec)) {
         set_error(error_message, "broadcast-bias request has invalid arguments");
         return false;
@@ -207,6 +208,17 @@ bool rtklib_broadcast_bias_data_for_family(const RtklibNavStore* store, int gps_
             result.glonass_fcn = 0;
             result.glonass_isc_l3ocp_sec = geph->isc_l3ocp;
         }
+        if (selected_identity != nullptr) {
+            // Identity comes from the same selected geph_t that produced the bias data.
+            selected_identity->satellite_number = satellite_number;
+            selected_identity->message_family = result.message_family;
+            selected_identity->iode = geph->iode;
+            selected_identity->iodc = 0;
+            selected_identity->toe_sow_sec = time2gpst(geph->toe, &selected_identity->toe_week);
+            selected_identity->toc_week = selected_identity->toe_week;
+            selected_identity->toc_sow_sec = selected_identity->toe_sow_sec;
+            selected_identity->transmit_sow_sec = time2gpst(geph->tof, &selected_identity->transmit_week);
+        }
         *data = result;
         return true;
     }
@@ -221,6 +233,16 @@ bool rtklib_broadcast_bias_data_for_family(const RtklibNavStore* store, int gps_
     result.iode = eph->iode;
     std::memcpy(result.tgd_sec, eph->tgd, sizeof(result.tgd_sec));
     std::memcpy(result.isc_sec, eph->isc, sizeof(result.isc_sec));
+    if (selected_identity != nullptr) {
+        // Identity comes from the same selected eph_t that produced the bias data.
+        selected_identity->satellite_number = satellite_number;
+        selected_identity->message_family = result.message_family;
+        selected_identity->iode = eph->iode;
+        selected_identity->iodc = eph->iodc;
+        selected_identity->toe_sow_sec = time2gpst(eph->toe, &selected_identity->toe_week);
+        selected_identity->toc_sow_sec = time2gpst(eph->toc, &selected_identity->toc_week);
+        selected_identity->transmit_sow_sec = time2gpst(eph->ttr, &selected_identity->transmit_week);
+    }
     *data = result;
     return true;
 }

--- a/src/gnss/rtklib_solution_adapter.cpp
+++ b/src/gnss/rtklib_solution_adapter.cpp
@@ -212,6 +212,8 @@ void fill_common_observation(const RtklibSolutionObservation& source, gtime_t ti
 
 } // namespace
 
+static_assert(MAXSAT <= 448, "used-satellite mask covers seven 64-bit words");
+
 bool rtklib_solve_single_position(const RtklibNavStore* receiver_nav, int gps_week, double sow_sec,
                                   const RtklibSolutionObservation* observations, int observation_count,
                                   double elevation_mask_deg, bool broadcast_atmosphere,
@@ -266,13 +268,23 @@ bool rtklib_solve_single_position(const RtklibNavStore* receiver_nav, int gps_we
 
     prcopt_t options = solution_options(elevation_mask_deg, broadcast_atmosphere);
     sol_t rtklib_solution{};
+    double azels[2 * MAXOBS]{};
+    ssat_t ssats[MAXSAT]{};
     char message[128]{};
     const int status =
-        pntpos(rtklib_observations, usable_count, &solver_nav, &options, &rtklib_solution, nullptr, nullptr, message);
+        pntpos(rtklib_observations, usable_count, &solver_nav, &options, &rtklib_solution, azels, ssats, message);
     copy_diagnostic(result.diagnostic, message);
     if (status == 0) {
         *solution = result;
         return true;
+    }
+    for (int index = 0; index < usable_count; ++index) {
+        const int satellite_number = rtklib_observations[index].sat;
+        if (satellite_number < 1 || satellite_number > 448 || ssats[satellite_number - 1].vs == 0) {
+            continue;
+        }
+        result.used_satellite_mask[(satellite_number - 1) / 64] |=
+            1ULL << static_cast<std::uint64_t>((satellite_number - 1) % 64);
     }
 
     result.valid = true;

--- a/tests/integration/test_nav_equivalence.cpp
+++ b/tests/integration/test_nav_equivalence.cpp
@@ -35,7 +35,11 @@ namespace {
 constexpr int kReferenceGpsWeek = 2347;
 constexpr double kReferenceSowSec = 436500.0;
 constexpr double kElevationMaskDeg = 5.0;
-constexpr int kAnyObservationCode = 1;
+// Per-family compatible observation codes for the family-restricted state selection
+// (RTKLIB eph_supports_code): L1C for GPS/QZSS/GLONASS/Galileo, B1I (L2I) for BeiDou
+// legacy records.
+constexpr int kL1CObservationCode = 1;
+constexpr int kBeidouB1IObservationCode = 40;
 
 // Frozen acceptance limits (see the issue 97 report for the justification). The
 // serialized NovAtel NAV fields carry 15 fractional scientific digits, so the
@@ -215,14 +219,21 @@ bool compute_state_difference(const gnss_sim::RtklibSatelliteState& reference,
 }
 
 void report_state_csv(int satellite_number, gnss_sim::RtklibBroadcastMessageFamily family, int toe_week, double toe_sow,
-                      int test_week, double test_sow, const StateDifference& difference) {
+                      int test_week, double test_sow, int reference_iode, int roundtrip_iode,
+                      const StateDifference& difference) {
     std::cout << "NAV_EQUIV_STATE_CSV," << satellite_number << ',' << family_name(family) << ',' << toe_week << ','
-              << toe_sow << ',' << test_week << ',' << test_sow << ',' << difference.position_per_axis_m[0] << ','
-              << difference.position_per_axis_m[1] << ',' << difference.position_per_axis_m[2] << ','
-              << difference.position_3d_m << ',' << difference.velocity_per_axis_mps[0] << ','
-              << difference.velocity_per_axis_mps[1] << ',' << difference.velocity_per_axis_mps[2] << ','
-              << difference.velocity_3d_mps << ',' << difference.clock_bias_diff_s << ','
-              << difference.clock_drift_diff_sps << "\n";
+              << toe_sow << ',' << test_week << ',' << test_sow << ',' << reference_iode << ',' << roundtrip_iode << ','
+              << difference.position_per_axis_m[0] << ',' << difference.position_per_axis_m[1] << ','
+              << difference.position_per_axis_m[2] << ',' << difference.position_3d_m << ','
+              << difference.velocity_per_axis_mps[0] << ',' << difference.velocity_per_axis_mps[1] << ','
+              << difference.velocity_per_axis_mps[2] << ',' << difference.velocity_3d_mps << ','
+              << difference.clock_bias_diff_s << ',' << difference.clock_drift_diff_sps << "\n";
+}
+
+int kBeidouOrL1cCode(const gnss_sim::NavOutputRecord& record) {
+    return is_keplerian_ephemeris(record) && record.ephemeris.system == gnss_sim::NavOutputSystem::kBeidou
+               ? kBeidouB1IObservationCode
+               : kL1CObservationCode;
 }
 
 struct StateEquivalenceStats {
@@ -238,23 +249,49 @@ struct StateEquivalenceStats {
 // the frozen tolerances.
 void compare_state_at_epoch(const gnss_sim::RtklibNavStore* reference, const gnss_sim::RtklibNavStore* roundtrip,
                             int satellite_number, gnss_sim::RtklibBroadcastMessageFamily family, int toe_week,
-                            double toe_sow, int test_week, double test_sow, StateEquivalenceStats* stats,
-                            const char* context) {
+                            double toe_sow, int test_week, double test_sow, int observation_code,
+                            StateEquivalenceStats* stats, const char* context) {
     std::string error_message;
     gnss_sim::RtklibSatelliteState reference_state{};
     gnss_sim::RtklibSatelliteState roundtrip_state{};
+    gnss_sim::RtklibSelectedEphemerisInfo reference_identity{};
+    gnss_sim::RtklibSelectedEphemerisInfo roundtrip_identity{};
     const bool reference_available =
-        gnss_sim::get_rtklib_signal_satellite_state(reference, test_week, test_sow, satellite_number,
-                                                    kAnyObservationCode, family, &reference_state, &error_message);
+        gnss_sim::get_rtklib_signal_satellite_state(reference, test_week, test_sow, satellite_number, observation_code,
+                                                    family, &reference_state, &error_message, &reference_identity);
     const bool roundtrip_available =
-        gnss_sim::get_rtklib_signal_satellite_state(roundtrip, test_week, test_sow, satellite_number,
-                                                    kAnyObservationCode, family, &roundtrip_state, &error_message);
+        gnss_sim::get_rtklib_signal_satellite_state(roundtrip, test_week, test_sow, satellite_number, observation_code,
+                                                    family, &roundtrip_state, &error_message, &roundtrip_identity);
     if (!reference_available && !roundtrip_available) {
         return;
     }
     ASSERT_TRUE(reference_available && roundtrip_available)
         << "satellite-state availability must agree at GPST " << test_week << "/" << test_sow << " (" << context
         << "): " << error_message;
+    // The selected broadcast instance identity must match before any state value is
+    // compared; a close state from a different real ephemeris is not acceptable.
+    EXPECT_EQ(reference_identity.satellite_number, roundtrip_identity.satellite_number)
+        << "selected-identity satellite mismatch at GPST " << test_week << "/" << test_sow;
+    EXPECT_EQ(reference_identity.message_family, roundtrip_identity.message_family)
+        << "selected-identity family mismatch at GPST " << test_week << "/" << test_sow;
+    EXPECT_EQ(reference_identity.iode, roundtrip_identity.iode)
+        << "selected-identity IODE mismatch at GPST " << test_week << "/" << test_sow;
+    // Galileo has no broadcast IODC; its ASCII contract carries IODC=IODE while the
+    // pinned RTKLIB decode leaves eph.iodc at zero, so IODC is asserted only where it
+    // is a real broadcast field (GPS/QZSS legacy, BeiDou legacy).
+    if (family == gnss_sim::RtklibBroadcastMessageFamily::kLegacy) {
+        EXPECT_EQ(reference_identity.iodc, roundtrip_identity.iodc)
+            << "selected-identity IODC mismatch at GPST " << test_week << "/" << test_sow;
+    }
+    EXPECT_EQ(reference_identity.toe_week, roundtrip_identity.toe_week) << "selected-identity Toe week mismatch";
+    EXPECT_DOUBLE_EQ(reference_identity.toe_sow_sec, roundtrip_identity.toe_sow_sec)
+        << "selected-identity Toe SOW mismatch at GPST " << test_week << "/" << test_sow;
+    EXPECT_EQ(reference_identity.toc_week, roundtrip_identity.toc_week) << "selected-identity Toc week mismatch";
+    EXPECT_DOUBLE_EQ(reference_identity.toc_sow_sec, roundtrip_identity.toc_sow_sec)
+        << "selected-identity Toc SOW mismatch";
+    // The receiver-log contract re-stamps the transmit time with the log delivery time
+    // (issue 84: week-boundary delivery causality), so transmit identity is deliberately
+    // reported by the adapter but not asserted here.
     StateDifference difference{};
     compute_state_difference(reference_state, roundtrip_state, &difference);
     stats->compared_states += 1;
@@ -268,7 +305,8 @@ void compare_state_at_epoch(const gnss_sim::RtklibNavStore* reference, const gns
     EXPECT_LE(std::fabs(difference.clock_bias_diff_s), kMaxSatelliteClockBiasDiffS) << "satellite clock bias mismatch";
     EXPECT_LE(std::fabs(difference.clock_drift_diff_sps), kMaxSatelliteClockDriftDiffSps)
         << "satellite clock drift mismatch";
-    report_state_csv(satellite_number, family, toe_week, toe_sow, test_week, test_sow, difference);
+    report_state_csv(satellite_number, family, toe_week, toe_sow, test_week, test_sow, reference_identity.iode,
+                     roundtrip_identity.iode, difference);
 }
 
 TEST(NavEquivalence, SatelliteStateMatchesAcrossProductionRoundTrip) {
@@ -290,6 +328,10 @@ TEST(NavEquivalence, SatelliteStateMatchesAcrossProductionRoundTrip) {
 
     StateEquivalenceStats stats{};
     std::set<std::string> systems;
+    std::uint64_t attempted_epochs = 0;
+    std::uint64_t validity_skipped_epochs = 0;
+    std::uint64_t records_with_state_comparison = 0;
+    std::uint64_t serialized_ephemeris_records = 0;
     const int record_count = gnss_sim::rtklib_nav_output_record_count(reference);
     for (int index = 0; index < record_count; ++index) {
         gnss_sim::NavOutputRecord record{};
@@ -305,6 +347,7 @@ TEST(NavEquivalence, SatelliteStateMatchesAcrossProductionRoundTrip) {
         if (!supported) {
             continue;
         }
+        ++serialized_ephemeris_records;
         const int satellite_number =
             is_keplerian_ephemeris(record) ? record.ephemeris.satellite_number : record.glonass.satellite_number;
         const gnss_sim::RtklibBroadcastMessageFamily family =
@@ -312,33 +355,75 @@ TEST(NavEquivalence, SatelliteStateMatchesAcrossProductionRoundTrip) {
         const int toe_week = is_keplerian_ephemeris(record) ? record.ephemeris.toe_week : record.glonass.toe_week;
         const double toe_sow =
             is_keplerian_ephemeris(record) ? record.ephemeris.toe_sow_sec : record.glonass.toe_sow_sec;
+        const int iode = is_keplerian_ephemeris(record) ? record.ephemeris.iode : record.glonass.iode;
         const bool glonass = record.kind == gnss_sim::RtklibNavRecordKind::kGlonassEphemeris;
         const double delta_s = glonass ? 600.0 : 1800.0;
         systems.insert(is_keplerian_ephemeris(record) ? gnss_sim::nav_output_system_name(record.ephemeris.system)
                                                       : "GLO");
-        for (const double offset : {-delta_s, 0.0, delta_s}) {
-            double test_sow = toe_sow + offset;
-            int test_week = toe_week;
-            if (test_sow < 0.0) {
-                test_sow += 604800.0;
-                --test_week;
-            } else if (test_sow >= 604800.0) {
-                test_sow -= 604800.0;
-                ++test_week;
-            }
-            compare_state_at_epoch(reference, roundtrip, satellite_number, family, toe_week, toe_sow, test_week,
-                                   test_sow, &stats, "five-system fixture");
+
+        // Toe first: every supported serialized record must produce a state comparison
+        // on both paths at its own Toe epoch. Toe-delta / Toe+delta add coverage and
+        // may be validity-skipped on both paths together, never one-sided.
+        std::uint64_t attempted = 0;
+        std::uint64_t compared = 0;
+        std::uint64_t validity_skipped = 0;
+        bool toe_compared = false;
+        const std::uint64_t state_count_before_toe = stats.compared_states;
+        compare_state_at_epoch(reference, roundtrip, satellite_number, family, toe_week, toe_sow, toe_week, toe_sow,
+                               kBeidouOrL1cCode(record), &stats, "five-system fixture");
+        ++attempted;
+        if (stats.compared_states > state_count_before_toe) {
+            ++compared;
+            toe_compared = true;
+            ++records_with_state_comparison;
         }
+        if (toe_compared) {
+            for (const double offset : {-delta_s, delta_s}) {
+                double test_sow = toe_sow + offset;
+                int test_week = toe_week;
+                if (test_sow < 0.0) {
+                    test_sow += 604800.0;
+                    --test_week;
+                } else if (test_sow >= 604800.0) {
+                    test_sow -= 604800.0;
+                    ++test_week;
+                }
+                ++attempted;
+                const std::uint64_t state_count_before = stats.compared_states;
+                compare_state_at_epoch(reference, roundtrip, satellite_number, family, toe_week, toe_sow, test_week,
+                                       test_sow, kBeidouOrL1cCode(record), &stats, "five-system fixture");
+                if (stats.compared_states > state_count_before) {
+                    ++compared;
+                } else {
+                    ++validity_skipped;
+                }
+            }
+        }
+
+        std::cout << "NAV_EQUIV_COVERAGE_CSV," << serialized_ephemeris_records << ','
+                  << (is_keplerian_ephemeris(record) ? gnss_sim::nav_output_system_name(record.ephemeris.system)
+                                                     : "GLO")
+                  << ',' << satellite_number << ',' << family_name(family) << ',' << iode << ',' << toe_week << ','
+                  << toe_sow << ',' << attempted << ',' << compared << ',' << validity_skipped << ','
+                  << (toe_compared ? 0 : 1) << "\n";
+        attempted_epochs += attempted;
+        validity_skipped_epochs += validity_skipped;
+        EXPECT_TRUE(toe_compared) << "serialized record " << serialized_ephemeris_records << " (sat "
+                                  << satellite_number << ") must compare at its own Toe";
     }
 
-    std::cout << "NAV_EQUIV_STATE_SUMMARY,serialized_records=" << serialized_count
-              << ",rejected_records=" << rejected_count << ",compared_states=" << stats.compared_states
+    std::cout << "NAV_EQUIV_STATE_SUMMARY,serialized_ephemeris_records=" << serialized_ephemeris_records
+              << ",records_with_successful_state_comparison=" << records_with_state_comparison
+              << ",attempted_state_epochs=" << attempted_epochs << ",compared_state_epochs=" << stats.compared_states
+              << ",validity_skipped_epochs=" << validity_skipped_epochs << ",rejected_records=" << rejected_count
               << ",max_position_m=" << stats.max_position_m << ",max_velocity_mps=" << stats.max_velocity_mps
               << ",max_clock_bias_s=" << stats.max_clock_bias_s << ",max_clock_drift_sps=" << stats.max_clock_drift_sps
               << "\n";
     EXPECT_GT(stats.compared_states, 0U);
     EXPECT_GE(serialized_count, 55U) << "the five-system fixture must serialize its full legacy record set";
     EXPECT_EQ(systems.size(), 5U) << "every serialized constellation must be compared";
+    EXPECT_EQ(records_with_state_comparison, serialized_ephemeris_records)
+        << "every supported serialized ephemeris must be state-compared (Toe mandatory)";
     gnss_sim::destroy_rtklib_nav_store(roundtrip);
     gnss_sim::destroy_rtklib_nav_store(reference);
 }
@@ -359,10 +444,10 @@ TEST(NavEquivalence, SatelliteStateSelectionMatchesAcrossRealEphemerisTransition
                                       &rejected_count, &error_message))
         << error_message;
 
-    // The companion fixture carries two consecutive real E02 INAV instances
-    // (IODnav 1 at Toe 457800 and IODnav 2 at Toe 458400, 600 s apart). Sample before,
-    // at, between, and after both instances so the older/newer record selection is
-    // exercised on both navigation paths at the transition.
+    // The companion fixture carries two consecutive real E02 INAV instances (IODnav 1 at
+    // Toe 457800 and IODnav 2 at Toe 458400, 600 s apart). Sample before, at, between,
+    // and after both instances so the older/newer record selection is exercised on both
+    // navigation paths at the transition.
     std::vector<double> instance_toes;
     int satellite_number = 0;
     int toe_week = 0;
@@ -385,7 +470,7 @@ TEST(NavEquivalence, SatelliteStateSelectionMatchesAcrossRealEphemerisTransition
                              instance_toes[1], instance_toes[1] + 600.0}) {
         compare_state_at_epoch(reference, roundtrip, satellite_number,
                                gnss_sim::RtklibBroadcastMessageFamily::kGalileoInav, toe_week, instance_toes[0],
-                               toe_week, sow, &stats, "real E02 instance transition");
+                               toe_week, sow, kL1CObservationCode, &stats, "real E02 instance transition");
     }
 
     std::cout << "NAV_EQUIV_TRANSITION_SUMMARY,compared_states=" << stats.compared_states
@@ -445,6 +530,7 @@ TEST(NavEquivalence, CorrectionParametersSurviveProductionRoundTrip) {
     std::uint64_t compared_tgd = 0;
     std::uint64_t compared_bgd = 0;
     std::uint64_t compared_ion = 0;
+    std::uint64_t stage_b_bias_compared = 0;
     std::uint64_t outside_contract = 0;
     const int record_count = gnss_sim::rtklib_nav_output_record_count(reference);
     for (int index = 0; index < record_count; ++index) {
@@ -482,6 +568,34 @@ TEST(NavEquivalence, CorrectionParametersSurviveProductionRoundTrip) {
                 ++compared_tgd;
             }
             EXPECT_EQ(record.ephemeris.svh, parsed.record.ephemeris.svh) << "health must survive unchanged";
+
+            // Stage B: the final reconstructed RTKLIB store must expose the same real
+            // broadcast group-delay values as the reference store for the same
+            // selected instance (queried through the production bias API at Toe).
+            gnss_sim::RtklibBroadcastBiasData reference_bias{};
+            gnss_sim::RtklibBroadcastBiasData roundtrip_bias{};
+            const int satellite_number =
+                keplerian ? record.ephemeris.satellite_number : record.glonass.satellite_number;
+            const gnss_sim::RtklibBroadcastMessageFamily family =
+                keplerian ? record.ephemeris.message_family : record.glonass.message_family;
+            const int stage_toe_week = keplerian ? record.ephemeris.toe_week : record.glonass.toe_week;
+            const double stage_toe_sow = keplerian ? record.ephemeris.toe_sow_sec : record.glonass.toe_sow_sec;
+            ASSERT_TRUE(gnss_sim::rtklib_broadcast_bias_data_for_family(
+                reference, stage_toe_week, stage_toe_sow, satellite_number, family, &reference_bias, &error_message))
+                << error_message;
+            ASSERT_TRUE(gnss_sim::rtklib_broadcast_bias_data_for_family(
+                roundtrip, stage_toe_week, stage_toe_sow, satellite_number, family, &roundtrip_bias, &error_message))
+                << error_message;
+            EXPECT_EQ(reference_bias.iode, roundtrip_bias.iode) << "stage-B selected-instance IODE mismatch";
+            for (int term = 0; term < 4; ++term) {
+                EXPECT_LE(relative_diff(reference_bias.tgd_sec[term], roundtrip_bias.tgd_sec[term]),
+                          kMaxCorrectionRelativeDiff)
+                    << "stage-B TGD/BGD term " << term << " must match in the final reconstructed store";
+            }
+            EXPECT_LE(relative_diff(reference_bias.glonass_dtaun_sec, roundtrip_bias.glonass_dtaun_sec),
+                      kMaxCorrectionRelativeDiff)
+                << "stage-B GLONASS delay must match in the final reconstructed store";
+            ++stage_b_bias_compared;
         } else if (record.kind == gnss_sim::RtklibNavRecordKind::kIonosphere) {
             ASSERT_EQ(record.ionosphere.coefficient_count, parsed.record.ionosphere.coefficient_count);
             for (int coefficient = 0; coefficient < record.ionosphere.coefficient_count; ++coefficient) {
@@ -496,9 +610,33 @@ TEST(NavEquivalence, CorrectionParametersSurviveProductionRoundTrip) {
         }
     }
 
+    // Stage B for the serialized ionosphere: the GPS legacy ionosphere state of the
+    // final reconstructed store must produce the same production reference delay as the
+    // reference store at identical geometry. The real serialized BeiDou ION record
+    // restores nav.ion_cmp beyond the reference solver state (documented issue 84
+    // behavior: the reference store never projects RINEX4 BeiDou ION), so it is reported
+    // rather than asserted.
+    gnss_sim::RtklibIonosphereResult reference_ion{};
+    gnss_sim::RtklibIonosphereResult roundtrip_ion{};
+    const double receiver_ecef_m[3] = {-2167434.0, 4392540.0, 4076320.0};
+    ASSERT_TRUE(gnss_sim::rtklib_broadcast_ionosphere_reference_delay(
+        reference, gnss_sim::RtklibIonosphereSystem::kGps, kReferenceGpsWeek, kReferenceSowSec, receiver_ecef_m, 0.5,
+        0.7, &reference_ion, &error_message))
+        << error_message;
+    ASSERT_TRUE(gnss_sim::rtklib_broadcast_ionosphere_reference_delay(
+        roundtrip, gnss_sim::RtklibIonosphereSystem::kGps, kReferenceGpsWeek, kReferenceSowSec, receiver_ecef_m, 0.5,
+        0.7, &roundtrip_ion, &error_message))
+        << error_message;
+    EXPECT_DOUBLE_EQ(reference_ion.reference_delay_m, roundtrip_ion.reference_delay_m)
+        << "stage-B GPS ionosphere state must match the reference store";
+    ++compared_ion;
+
     std::cout << "NAV_EQUIV_CORRECTION_SUMMARY,serialized_records=" << serialized_count
               << ",outside_contract_records=" << outside_contract << ",compared_tgd=" << compared_tgd
-              << ",compared_bgd=" << compared_bgd << ",compared_ion=" << compared_ion << "\n";
+              << ",compared_bgd=" << compared_bgd << ",compared_ion=" << compared_ion
+              << ",stage_b_bias_compared=" << stage_b_bias_compared
+              << ",stage_b_gps_ion_delay_ref_m=" << reference_ion.reference_delay_m
+              << ",stage_b_gps_ion_delay_rt_m=" << roundtrip_ion.reference_delay_m << "\n";
     EXPECT_GT(compared_tgd, 0U) << "the real fixture must exercise broadcast group delays";
     EXPECT_GT(compared_ion, 0U) << "the real fixture must exercise serialized ionosphere records";
     EXPECT_GT(outside_contract, 0U) << "modern families are documented as outside the receiver output contract";
@@ -577,6 +715,37 @@ TEST(NavEquivalence, PairedPositioningMatchesBetweenOriginalRinexAndConvertedNav
             ++satellite_set_divergences;
             ADD_FAILURE() << "used-satellite count diverged at GPST " << epoch.gps_week << "/" << epoch.sow_sec;
         }
+        // Exact used-satellite set equality: compare the RTKLIB-reported masks and
+        // verify each mask's population matches the reported count.
+        std::uint64_t reference_count_from_mask = 0;
+        std::uint64_t roundtrip_count_from_mask = 0;
+        bool set_match = true;
+        for (int word = 0; word < 7; ++word) {
+            if (reference_solution.used_satellite_mask[word] != roundtrip_solution.used_satellite_mask[word]) {
+                set_match = false;
+            }
+            for (int bit = 0; bit < 64; ++bit) {
+                reference_count_from_mask += (reference_solution.used_satellite_mask[word] >> bit) & 1ULL;
+                roundtrip_count_from_mask += (roundtrip_solution.used_satellite_mask[word] >> bit) & 1ULL;
+            }
+        }
+        EXPECT_EQ(reference_count_from_mask, static_cast<std::uint64_t>(reference_solution.used_satellites))
+            << "used-satellite mask population must match the reported count";
+        EXPECT_EQ(roundtrip_count_from_mask, static_cast<std::uint64_t>(roundtrip_solution.used_satellites))
+            << "used-satellite mask population must match the reported count";
+        if (!set_match) {
+            ++satellite_set_divergences;
+            for (const gnss_sim::RtklibRawCodeObservation& observation : selected) {
+                const int index = observation.satellite_number - 1;
+                const bool in_reference = (reference_solution.used_satellite_mask[index / 64] >> (index % 64)) & 1ULL;
+                const bool in_roundtrip = (roundtrip_solution.used_satellite_mask[index / 64] >> (index % 64)) & 1ULL;
+                if (in_reference != in_roundtrip) {
+                    ADD_FAILURE() << "satellite " << observation.satellite_number << " used only by "
+                                  << (in_reference ? "reference" : "roundtrip") << " at GPST " << epoch.gps_week << "/"
+                                  << epoch.sow_sec;
+                }
+            }
+        }
         double position_3d = 0.0;
         double per_axis[3] = {0.0, 0.0, 0.0};
         for (int axis = 0; axis < 3; ++axis) {
@@ -591,7 +760,8 @@ TEST(NavEquivalence, PairedPositioningMatchesBetweenOriginalRinexAndConvertedNav
         max_clock_m = std::max(max_clock_m, std::fabs(clock_diff_m));
         std::cout << "NAV_EQUIV_POSITION_CSV," << epoch.gps_week << ',' << epoch.sow_sec << ','
                   << reference_solution.used_satellites << ',' << per_axis[0] << ',' << per_axis[1] << ','
-                  << per_axis[2] << ',' << position_3d << ',' << clock_diff_m << "\n";
+                  << per_axis[2] << ',' << position_3d << ',' << clock_diff_m << ",set_match=" << (set_match ? 1 : 0)
+                  << "\n";
         EXPECT_LE(position_3d, kMaxPositioningPositionDiffM) << "paired positioning must agree";
         EXPECT_LE(std::fabs(clock_diff_m), kMaxPositioningClockDiffM) << "receiver clock must agree";
     }

--- a/tests/integration/test_nav_equivalence.cpp
+++ b/tests/integration/test_nav_equivalence.cpp
@@ -697,13 +697,30 @@ TEST(NavEquivalence, CorrectionParametersSurviveProductionRoundTrip) {
             // instance (queried through the production bias API at Toe).
             gnss_sim::RtklibBroadcastBiasData reference_bias{};
             gnss_sim::RtklibBroadcastBiasData roundtrip_bias{};
+            const ExpectedEphemerisIdentity expected_source = expected_identity_from_record(record);
+            gnss_sim::RtklibSelectedEphemerisInfo reference_bias_identity{};
+            gnss_sim::RtklibSelectedEphemerisInfo roundtrip_bias_identity{};
             ASSERT_TRUE(gnss_sim::rtklib_broadcast_bias_data_for_family(reference, toe_week, toe_sow, satellite_number,
-                                                                        family, &reference_bias, &error_message))
+                                                                        family, &reference_bias, &error_message,
+                                                                        &reference_bias_identity))
                 << error_message;
             ASSERT_TRUE(gnss_sim::rtklib_broadcast_bias_data_for_family(roundtrip, toe_week, toe_sow, satellite_number,
-                                                                        family, &roundtrip_bias, &error_message))
+                                                                        family, &roundtrip_bias, &error_message,
+                                                                        &roundtrip_bias_identity))
                 << error_message;
-            EXPECT_EQ(reference_bias.iode, roundtrip_bias.iode) << "stage-B selected-instance IODE mismatch";
+            // The bias adapter performs its own selection, so its returned identity must
+            // bind to the same unchanged source record on both navigation paths before
+            // any correction value is compared.
+            EXPECT_EQ(reference_bias_identity.satellite_number, expected_source.satellite_number);
+            EXPECT_EQ(reference_bias_identity.message_family, expected_source.family);
+            EXPECT_EQ(reference_bias_identity.iode, expected_source.iode);
+            EXPECT_EQ(reference_bias_identity.toe_week, expected_source.toe_week);
+            EXPECT_DOUBLE_EQ(reference_bias_identity.toe_sow_sec, expected_source.toe_sow_sec);
+            EXPECT_EQ(roundtrip_bias_identity.satellite_number, expected_source.satellite_number);
+            EXPECT_EQ(roundtrip_bias_identity.message_family, expected_source.family);
+            EXPECT_EQ(roundtrip_bias_identity.iode, expected_source.iode);
+            EXPECT_EQ(roundtrip_bias_identity.toe_week, expected_source.toe_week);
+            EXPECT_DOUBLE_EQ(roundtrip_bias_identity.toe_sow_sec, expected_source.toe_sow_sec);
             for (int term = 0; term < 4; ++term) {
                 EXPECT_LE(relative_diff(reference_bias.tgd_sec[term], roundtrip_bias.tgd_sec[term]),
                           kMaxCorrectionRelativeDiff)
@@ -749,6 +766,9 @@ TEST(NavEquivalence, CorrectionParametersSurviveProductionRoundTrip) {
     EXPECT_GT(serialized_supported_beidou_ion_records, 0U) << "the real fixture must serialize its BeiDou ION record";
     EXPECT_EQ(stage_b_ion_compared, serialized_supported_beidou_ion_records)
         << "every supported serialized BeiDou ION record must reach the stage-B final-store comparison";
+    EXPECT_EQ(stage_b_bias_compared, serialized_ephemeris_count)
+        << "every supported serialized ephemeris must reach the stage-B bias comparison";
+    EXPECT_GT(stage_b_bias_compared, 0U);
     EXPECT_EQ(stage_b_bias_compared, serialized_ephemeris_count)
         << "every supported serialized ephemeris must reach the stage-B bias comparison";
     EXPECT_GT(stage_b_bias_compared, 0U);

--- a/tests/integration/test_nav_equivalence.cpp
+++ b/tests/integration/test_nav_equivalence.cpp
@@ -749,6 +749,9 @@ TEST(NavEquivalence, CorrectionParametersSurviveProductionRoundTrip) {
     EXPECT_GT(serialized_supported_beidou_ion_records, 0U) << "the real fixture must serialize its BeiDou ION record";
     EXPECT_EQ(stage_b_ion_compared, serialized_supported_beidou_ion_records)
         << "every supported serialized BeiDou ION record must reach the stage-B final-store comparison";
+    EXPECT_EQ(stage_b_bias_compared, serialized_ephemeris_count)
+        << "every supported serialized ephemeris must reach the stage-B bias comparison";
+    EXPECT_GT(stage_b_bias_compared, 0U);
     gnss_sim::destroy_rtklib_nav_store(roundtrip);
     gnss_sim::destroy_rtklib_nav_store(reference);
 }

--- a/tests/integration/test_nav_equivalence.cpp
+++ b/tests/integration/test_nav_equivalence.cpp
@@ -16,6 +16,7 @@
 #include <iterator>
 #include <sstream>
 #include <string>
+#include <tuple>
 #include <vector>
 
 // Issue 97: numerical equivalence validation of the navigation conversion path.
@@ -129,16 +130,18 @@ bool is_ephemeris_record(const gnss_sim::NavOutputRecord& record) {
     return is_keplerian_ephemeris(record) || record.kind == gnss_sim::RtklibNavRecordKind::kGlonassEphemeris;
 }
 
-std::string record_identity_key(const gnss_sim::NavOutputRecord& record) {
+// Structured sortable identity: lossless (no floating-point formatting), lexicographic
+// comparison via std::tuple, multiplicity preserved by sorted-vector equality.
+using RecordIdentityKey = std::tuple<std::string, int, int, int, int, double>;
+
+RecordIdentityKey record_identity_key(const gnss_sim::NavOutputRecord& record) {
     const bool keplerian = is_keplerian_ephemeris(record);
-    std::ostringstream key;
-    key << (keplerian ? gnss_sim::nav_output_system_name(record.ephemeris.system) : "GLO") << ':'
-        << (keplerian ? record.ephemeris.prn : record.glonass.prn) << ':'
-        << static_cast<int>(keplerian ? record.ephemeris.message_family : record.glonass.message_family) << ':'
-        << (keplerian ? record.ephemeris.iode : record.glonass.iode) << ':'
-        << (keplerian ? record.ephemeris.toe_week : record.glonass.toe_week) << ':'
-        << (keplerian ? record.ephemeris.toe_sow_sec : record.glonass.toe_sow_sec);
-    return key.str();
+    return {keplerian ? gnss_sim::nav_output_system_name(record.ephemeris.system) : "GLO",
+            keplerian ? record.ephemeris.prn : record.glonass.prn,
+            static_cast<int>(keplerian ? record.ephemeris.message_family : record.glonass.message_family),
+            keplerian ? record.ephemeris.iode : record.glonass.iode,
+            keplerian ? record.ephemeris.toe_week : record.glonass.toe_week,
+            keplerian ? record.ephemeris.toe_sow_sec : record.glonass.toe_sow_sec};
 }
 
 // Builds the round-trip navigation store exclusively through the production chain:
@@ -254,6 +257,26 @@ enum class StateSampleOutcome {
     AvailabilityMismatch,
 };
 
+// Immutable expected identity derived read-only from one unchanged source
+// NavOutputRecord: exactly the broadcast fields that must bind the selected RTKLIB
+// record to the source record at the mandatory Toe sample.
+struct ExpectedEphemerisIdentity {
+    int satellite_number;
+    gnss_sim::RtklibBroadcastMessageFamily family;
+    int iode;
+    int toe_week;
+    double toe_sow_sec;
+};
+
+ExpectedEphemerisIdentity expected_identity_from_record(const gnss_sim::NavOutputRecord& record) {
+    const bool keplerian = is_keplerian_ephemeris(record);
+    return {keplerian ? record.ephemeris.satellite_number : record.glonass.satellite_number,
+            keplerian ? record.ephemeris.message_family : record.glonass.message_family,
+            keplerian ? record.ephemeris.iode : record.glonass.iode,
+            keplerian ? record.ephemeris.toe_week : record.glonass.toe_week,
+            keplerian ? record.ephemeris.toe_sow_sec : record.glonass.toe_sow_sec};
+}
+
 // Compares the family-restricted satellite state of one real broadcast instance at one
 // GPST epoch. When expected_source is provided (the mandatory Toe sample), both stores
 // must select exactly that source record before any state value is compared. Both
@@ -263,7 +286,7 @@ StateSampleOutcome compare_state_at_epoch(const gnss_sim::RtklibNavStore* refere
                                           const gnss_sim::RtklibNavStore* roundtrip, int satellite_number,
                                           gnss_sim::RtklibBroadcastMessageFamily family, int toe_week, double toe_sow,
                                           int test_week, double test_sow, int observation_code,
-                                          const int* expected_iode, const double* expected_toe_sow,
+                                          const ExpectedEphemerisIdentity* expected_source,
                                           StateEquivalenceStats* stats, const char* context) {
     std::string error_message;
     gnss_sim::RtklibSatelliteState reference_state{};
@@ -313,11 +336,17 @@ StateSampleOutcome compare_state_at_epoch(const gnss_sim::RtklibNavStore* refere
     // At the mandatory Toe sample the selected identity must also equal the current
     // unchanged source record: this proves that the specific real ephemeris under test
     // (not an adjacent instance) actually participated in the comparison.
-    if (expected_iode != nullptr && expected_toe_sow != nullptr) {
-        EXPECT_EQ(reference_identity.iode, *expected_iode);
-        EXPECT_DOUBLE_EQ(reference_identity.toe_sow_sec, *expected_toe_sow);
-        EXPECT_EQ(roundtrip_identity.iode, *expected_iode);
-        EXPECT_DOUBLE_EQ(roundtrip_identity.toe_sow_sec, *expected_toe_sow);
+    if (expected_source != nullptr) {
+        EXPECT_EQ(reference_identity.satellite_number, expected_source->satellite_number);
+        EXPECT_EQ(reference_identity.message_family, expected_source->family);
+        EXPECT_EQ(reference_identity.iode, expected_source->iode);
+        EXPECT_EQ(reference_identity.toe_week, expected_source->toe_week);
+        EXPECT_DOUBLE_EQ(reference_identity.toe_sow_sec, expected_source->toe_sow_sec);
+        EXPECT_EQ(roundtrip_identity.satellite_number, expected_source->satellite_number);
+        EXPECT_EQ(roundtrip_identity.message_family, expected_source->family);
+        EXPECT_EQ(roundtrip_identity.iode, expected_source->iode);
+        EXPECT_EQ(roundtrip_identity.toe_week, expected_source->toe_week);
+        EXPECT_DOUBLE_EQ(roundtrip_identity.toe_sow_sec, expected_source->toe_sow_sec);
     }
     StateDifference difference{};
     compute_state_difference(reference_state, roundtrip_state, &difference);
@@ -397,9 +426,10 @@ TEST(NavEquivalence, SatelliteStateMatchesAcrossProductionRoundTrip) {
         std::uint64_t validity_skipped = 0;
         bool toe_compared = false;
         const std::uint64_t state_count_before_toe = stats.compared_states;
+        const ExpectedEphemerisIdentity expected_source = expected_identity_from_record(record);
         const StateSampleOutcome toe_outcome =
             compare_state_at_epoch(reference, roundtrip, satellite_number, family, toe_week, toe_sow, toe_week, toe_sow,
-                                   kBeidouOrL1cCode(record), &iode, &toe_sow, &stats, "five-system fixture");
+                                   kBeidouOrL1cCode(record), &expected_source, &stats, "five-system fixture");
         ++attempted;
         if (toe_outcome == StateSampleOutcome::Compared) {
             ++compared;
@@ -418,9 +448,9 @@ TEST(NavEquivalence, SatelliteStateMatchesAcrossProductionRoundTrip) {
                     ++test_week;
                 }
                 ++attempted;
-                const StateSampleOutcome offset_outcome = compare_state_at_epoch(
-                    reference, roundtrip, satellite_number, family, toe_week, toe_sow, test_week, test_sow,
-                    kBeidouOrL1cCode(record), nullptr, nullptr, &stats, "five-system fixture");
+                const StateSampleOutcome offset_outcome =
+                    compare_state_at_epoch(reference, roundtrip, satellite_number, family, toe_week, toe_sow, test_week,
+                                           test_sow, kBeidouOrL1cCode(record), nullptr, &stats, "five-system fixture");
                 if (offset_outcome == StateSampleOutcome::Compared) {
                     ++compared;
                 } else if (offset_outcome == StateSampleOutcome::BothUnavailableValiditySkip) {
@@ -500,8 +530,7 @@ TEST(NavEquivalence, SatelliteStateSelectionMatchesAcrossRealEphemerisTransition
                              instance_toes[1], instance_toes[1] + 600.0}) {
         compare_state_at_epoch(reference, roundtrip, satellite_number,
                                gnss_sim::RtklibBroadcastMessageFamily::kGalileoInav, toe_week, instance_toes[0],
-                               toe_week, sow, kL1CObservationCode, nullptr, nullptr, &stats,
-                               "real E02 instance transition");
+                               toe_week, sow, kL1CObservationCode, nullptr, &stats, "real E02 instance transition");
     }
 
     std::cout << "NAV_EQUIV_TRANSITION_SUMMARY,compared_states=" << stats.compared_states
@@ -530,8 +559,8 @@ TEST(NavEquivalence, CorrectionParametersSurviveProductionRoundTrip) {
     // Store-level record identity: the reconstructed store must contain exactly the
     // serialized ephemeris instances (satellite + family + IODE/IODnav + Toe week/SOW),
     // so both positioning paths select among the same real broadcast instances.
-    std::vector<std::string> reference_keys;
-    std::vector<std::string> roundtrip_keys;
+    std::vector<RecordIdentityKey> reference_keys;
+    std::vector<RecordIdentityKey> roundtrip_keys;
     for (int index = 0; index < gnss_sim::rtklib_nav_output_record_count(reference); ++index) {
         gnss_sim::NavOutputRecord record{};
         ASSERT_TRUE(gnss_sim::rtklib_nav_output_record(reference, index, &record, &error_message)) << error_message;
@@ -561,6 +590,7 @@ TEST(NavEquivalence, CorrectionParametersSurviveProductionRoundTrip) {
     std::uint64_t compared_ion = 0;
     std::uint64_t stage_b_bias_compared = 0;
     std::uint64_t stage_b_ion_compared = 0;
+    std::uint64_t serialized_supported_beidou_ion_records = 0;
     std::uint64_t outside_contract = 0;
     const int record_count = gnss_sim::rtklib_nav_output_record_count(reference);
     for (int index = 0; index < record_count; ++index) {
@@ -613,6 +643,7 @@ TEST(NavEquivalence, CorrectionParametersSurviveProductionRoundTrip) {
             // RINEX4 BeiDou ION into nav.ion_cmp; the unchanged real-RINEX projection is
             // the expected truth.
             if (record.ionosphere.system == gnss_sim::NavOutputSystem::kBeidou) {
+                ++serialized_supported_beidou_ion_records;
                 gnss_sim::RtklibIonosphereModelState model{};
                 ASSERT_TRUE(gnss_sim::rtklib_broadcast_ionosphere_model_state(
                     roundtrip, gnss_sim::RtklibIonosphereSystem::kBeidouLegacy, &model, &error_message))
@@ -715,6 +746,9 @@ TEST(NavEquivalence, CorrectionParametersSurviveProductionRoundTrip) {
     EXPECT_GT(compared_tgd, 0U) << "the real fixture must exercise broadcast group delays";
     EXPECT_GT(compared_ion, 0U) << "the real fixture must exercise serialized ionosphere records";
     EXPECT_GT(outside_contract, 0U) << "modern families are documented as outside the receiver output contract";
+    EXPECT_GT(serialized_supported_beidou_ion_records, 0U) << "the real fixture must serialize its BeiDou ION record";
+    EXPECT_EQ(stage_b_ion_compared, serialized_supported_beidou_ion_records)
+        << "every supported serialized BeiDou ION record must reach the stage-B final-store comparison";
     gnss_sim::destroy_rtklib_nav_store(roundtrip);
     gnss_sim::destroy_rtklib_nav_store(reference);
 }

--- a/tests/integration/test_nav_equivalence.cpp
+++ b/tests/integration/test_nav_equivalence.cpp
@@ -135,7 +135,9 @@ std::string record_identity_key(const gnss_sim::NavOutputRecord& record) {
     key << (keplerian ? gnss_sim::nav_output_system_name(record.ephemeris.system) : "GLO") << ':'
         << (keplerian ? record.ephemeris.prn : record.glonass.prn) << ':'
         << static_cast<int>(keplerian ? record.ephemeris.message_family : record.glonass.message_family) << ':'
-        << (keplerian ? record.ephemeris.iode : record.glonass.iode);
+        << (keplerian ? record.ephemeris.iode : record.glonass.iode) << ':'
+        << (keplerian ? record.ephemeris.toe_week : record.glonass.toe_week) << ':'
+        << (keplerian ? record.ephemeris.toe_sow_sec : record.glonass.toe_sow_sec);
     return key.str();
 }
 
@@ -238,19 +240,31 @@ int kBeidouOrL1cCode(const gnss_sim::NavOutputRecord& record) {
 
 struct StateEquivalenceStats {
     std::uint64_t compared_states = 0;
+    std::uint64_t validity_skipped_samples = 0;
+    std::uint64_t availability_mismatch_samples = 0;
     double max_position_m = 0.0;
     double max_velocity_mps = 0.0;
     double max_clock_bias_s = 0.0;
     double max_clock_drift_sps = 0.0;
 };
 
+enum class StateSampleOutcome {
+    Compared,
+    BothUnavailableValiditySkip,
+    AvailabilityMismatch,
+};
+
 // Compares the family-restricted satellite state of one real broadcast instance at one
-// GPST epoch. Both stores must agree on availability; state values must agree within
-// the frozen tolerances.
-void compare_state_at_epoch(const gnss_sim::RtklibNavStore* reference, const gnss_sim::RtklibNavStore* roundtrip,
-                            int satellite_number, gnss_sim::RtklibBroadcastMessageFamily family, int toe_week,
-                            double toe_sow, int test_week, double test_sow, int observation_code,
-                            StateEquivalenceStats* stats, const char* context) {
+// GPST epoch. When expected_source is provided (the mandatory Toe sample), both stores
+// must select exactly that source record before any state value is compared. Both
+// stores must agree on availability; state values must agree within the frozen
+// tolerances.
+StateSampleOutcome compare_state_at_epoch(const gnss_sim::RtklibNavStore* reference,
+                                          const gnss_sim::RtklibNavStore* roundtrip, int satellite_number,
+                                          gnss_sim::RtklibBroadcastMessageFamily family, int toe_week, double toe_sow,
+                                          int test_week, double test_sow, int observation_code,
+                                          const int* expected_iode, const double* expected_toe_sow,
+                                          StateEquivalenceStats* stats, const char* context) {
     std::string error_message;
     gnss_sim::RtklibSatelliteState reference_state{};
     gnss_sim::RtklibSatelliteState roundtrip_state{};
@@ -263,11 +277,15 @@ void compare_state_at_epoch(const gnss_sim::RtklibNavStore* reference, const gns
         gnss_sim::get_rtklib_signal_satellite_state(roundtrip, test_week, test_sow, satellite_number, observation_code,
                                                     family, &roundtrip_state, &error_message, &roundtrip_identity);
     if (!reference_available && !roundtrip_available) {
-        return;
+        stats->validity_skipped_samples += 1;
+        return StateSampleOutcome::BothUnavailableValiditySkip;
     }
-    ASSERT_TRUE(reference_available && roundtrip_available)
-        << "satellite-state availability must agree at GPST " << test_week << "/" << test_sow << " (" << context
-        << "): " << error_message;
+    if (reference_available != roundtrip_available) {
+        stats->availability_mismatch_samples += 1;
+        ADD_FAILURE() << "one-sided satellite-state availability at GPST " << test_week << "/" << test_sow << " ("
+                      << context << "): reference=" << reference_available << " roundtrip=" << roundtrip_available;
+        return StateSampleOutcome::AvailabilityMismatch;
+    }
     // The selected broadcast instance identity must match before any state value is
     // compared; a close state from a different real ephemeris is not acceptable.
     EXPECT_EQ(reference_identity.satellite_number, roundtrip_identity.satellite_number)
@@ -292,6 +310,15 @@ void compare_state_at_epoch(const gnss_sim::RtklibNavStore* reference, const gns
     // The receiver-log contract re-stamps the transmit time with the log delivery time
     // (issue 84: week-boundary delivery causality), so transmit identity is deliberately
     // reported by the adapter but not asserted here.
+    // At the mandatory Toe sample the selected identity must also equal the current
+    // unchanged source record: this proves that the specific real ephemeris under test
+    // (not an adjacent instance) actually participated in the comparison.
+    if (expected_iode != nullptr && expected_toe_sow != nullptr) {
+        EXPECT_EQ(reference_identity.iode, *expected_iode);
+        EXPECT_DOUBLE_EQ(reference_identity.toe_sow_sec, *expected_toe_sow);
+        EXPECT_EQ(roundtrip_identity.iode, *expected_iode);
+        EXPECT_DOUBLE_EQ(roundtrip_identity.toe_sow_sec, *expected_toe_sow);
+    }
     StateDifference difference{};
     compute_state_difference(reference_state, roundtrip_state, &difference);
     stats->compared_states += 1;
@@ -307,6 +334,7 @@ void compare_state_at_epoch(const gnss_sim::RtklibNavStore* reference, const gns
         << "satellite clock drift mismatch";
     report_state_csv(satellite_number, family, toe_week, toe_sow, test_week, test_sow, reference_identity.iode,
                      roundtrip_identity.iode, difference);
+    return StateSampleOutcome::Compared;
 }
 
 TEST(NavEquivalence, SatelliteStateMatchesAcrossProductionRoundTrip) {
@@ -369,10 +397,11 @@ TEST(NavEquivalence, SatelliteStateMatchesAcrossProductionRoundTrip) {
         std::uint64_t validity_skipped = 0;
         bool toe_compared = false;
         const std::uint64_t state_count_before_toe = stats.compared_states;
-        compare_state_at_epoch(reference, roundtrip, satellite_number, family, toe_week, toe_sow, toe_week, toe_sow,
-                               kBeidouOrL1cCode(record), &stats, "five-system fixture");
+        const StateSampleOutcome toe_outcome =
+            compare_state_at_epoch(reference, roundtrip, satellite_number, family, toe_week, toe_sow, toe_week, toe_sow,
+                                   kBeidouOrL1cCode(record), &iode, &toe_sow, &stats, "five-system fixture");
         ++attempted;
-        if (stats.compared_states > state_count_before_toe) {
+        if (toe_outcome == StateSampleOutcome::Compared) {
             ++compared;
             toe_compared = true;
             ++records_with_state_comparison;
@@ -389,12 +418,12 @@ TEST(NavEquivalence, SatelliteStateMatchesAcrossProductionRoundTrip) {
                     ++test_week;
                 }
                 ++attempted;
-                const std::uint64_t state_count_before = stats.compared_states;
-                compare_state_at_epoch(reference, roundtrip, satellite_number, family, toe_week, toe_sow, test_week,
-                                       test_sow, kBeidouOrL1cCode(record), &stats, "five-system fixture");
-                if (stats.compared_states > state_count_before) {
+                const StateSampleOutcome offset_outcome = compare_state_at_epoch(
+                    reference, roundtrip, satellite_number, family, toe_week, toe_sow, test_week, test_sow,
+                    kBeidouOrL1cCode(record), nullptr, nullptr, &stats, "five-system fixture");
+                if (offset_outcome == StateSampleOutcome::Compared) {
                     ++compared;
-                } else {
+                } else if (offset_outcome == StateSampleOutcome::BothUnavailableValiditySkip) {
                     ++validity_skipped;
                 }
             }
@@ -415,10 +444,11 @@ TEST(NavEquivalence, SatelliteStateMatchesAcrossProductionRoundTrip) {
     std::cout << "NAV_EQUIV_STATE_SUMMARY,serialized_ephemeris_records=" << serialized_ephemeris_records
               << ",records_with_successful_state_comparison=" << records_with_state_comparison
               << ",attempted_state_epochs=" << attempted_epochs << ",compared_state_epochs=" << stats.compared_states
-              << ",validity_skipped_epochs=" << validity_skipped_epochs << ",rejected_records=" << rejected_count
-              << ",max_position_m=" << stats.max_position_m << ",max_velocity_mps=" << stats.max_velocity_mps
-              << ",max_clock_bias_s=" << stats.max_clock_bias_s << ",max_clock_drift_sps=" << stats.max_clock_drift_sps
-              << "\n";
+              << ",validity_skipped_epochs=" << validity_skipped_epochs
+              << ",availability_mismatch_epochs=" << stats.availability_mismatch_samples
+              << ",rejected_records=" << rejected_count << ",max_position_m=" << stats.max_position_m
+              << ",max_velocity_mps=" << stats.max_velocity_mps << ",max_clock_bias_s=" << stats.max_clock_bias_s
+              << ",max_clock_drift_sps=" << stats.max_clock_drift_sps << "\n";
     EXPECT_GT(stats.compared_states, 0U);
     EXPECT_GE(serialized_count, 55U) << "the five-system fixture must serialize its full legacy record set";
     EXPECT_EQ(systems.size(), 5U) << "every serialized constellation must be compared";
@@ -470,7 +500,8 @@ TEST(NavEquivalence, SatelliteStateSelectionMatchesAcrossRealEphemerisTransition
                              instance_toes[1], instance_toes[1] + 600.0}) {
         compare_state_at_epoch(reference, roundtrip, satellite_number,
                                gnss_sim::RtklibBroadcastMessageFamily::kGalileoInav, toe_week, instance_toes[0],
-                               toe_week, sow, kL1CObservationCode, &stats, "real E02 instance transition");
+                               toe_week, sow, kL1CObservationCode, nullptr, nullptr, &stats,
+                               "real E02 instance transition");
     }
 
     std::cout << "NAV_EQUIV_TRANSITION_SUMMARY,compared_states=" << stats.compared_states
@@ -497,8 +528,8 @@ TEST(NavEquivalence, CorrectionParametersSurviveProductionRoundTrip) {
         << error_message;
 
     // Store-level record identity: the reconstructed store must contain exactly the
-    // serialized ephemeris instances (satellite + family + IODE/IODnav), so both
-    // positioning paths select among the same broadcast instances.
+    // serialized ephemeris instances (satellite + family + IODE/IODnav + Toe week/SOW),
+    // so both positioning paths select among the same real broadcast instances.
     std::vector<std::string> reference_keys;
     std::vector<std::string> roundtrip_keys;
     for (int index = 0; index < gnss_sim::rtklib_nav_output_record_count(reference); ++index) {
@@ -523,14 +554,13 @@ TEST(NavEquivalence, CorrectionParametersSurviveProductionRoundTrip) {
     std::sort(reference_keys.begin(), reference_keys.end());
     std::sort(roundtrip_keys.begin(), roundtrip_keys.end());
     EXPECT_EQ(reference_keys, roundtrip_keys)
-        << "the production round trip must preserve the broadcast instance identity set";
+        << "the production round trip must preserve the full broadcast instance identity set";
 
-    // Serialization-boundary correction comparison: every serialized correction value
-    // must parse back to the same real value the reference projected record carried.
     std::uint64_t compared_tgd = 0;
     std::uint64_t compared_bgd = 0;
     std::uint64_t compared_ion = 0;
     std::uint64_t stage_b_bias_compared = 0;
+    std::uint64_t stage_b_ion_compared = 0;
     std::uint64_t outside_contract = 0;
     const int record_count = gnss_sim::rtklib_nav_output_record_count(reference);
     for (int index = 0; index < record_count; ++index) {
@@ -551,51 +581,19 @@ TEST(NavEquivalence, CorrectionParametersSurviveProductionRoundTrip) {
             gnss_sim::parse_serialized_novatel_nav_line_independent(message, &parsed, &recognized, &error_message))
             << error_message;
         ASSERT_TRUE(recognized) << "every serialized NAV message must be recognized by the production parser";
-        if (is_ephemeris_record(record)) {
-            const bool keplerian = is_keplerian_ephemeris(record);
-            const double reference_delay =
-                keplerian ? record.ephemeris.tgd_sec[0] : record.glonass.differential_delay_sec;
-            const double roundtrip_delay =
-                keplerian ? parsed.record.ephemeris.tgd_sec[0] : parsed.record.glonass.differential_delay_sec;
-            EXPECT_LE(relative_diff(reference_delay, roundtrip_delay), kMaxCorrectionRelativeDiff)
-                << "TGD/BGD must survive the serialization boundary unchanged";
-            if (keplerian && record.ephemeris.system == gnss_sim::NavOutputSystem::kBeidou) {
-                EXPECT_LE(relative_diff(record.ephemeris.tgd_sec[1], parsed.record.ephemeris.tgd_sec[1]),
-                          kMaxCorrectionRelativeDiff)
-                    << "BeiDou BGD2 must survive the serialization boundary unchanged";
-                ++compared_bgd;
-            } else {
-                ++compared_tgd;
-            }
-            EXPECT_EQ(record.ephemeris.svh, parsed.record.ephemeris.svh) << "health must survive unchanged";
+        const bool keplerian = is_keplerian_ephemeris(record);
+        const int satellite_number = keplerian ? record.ephemeris.satellite_number : record.glonass.satellite_number;
+        const gnss_sim::RtklibBroadcastMessageFamily family =
+            keplerian ? record.ephemeris.message_family : record.glonass.message_family;
+        const int toe_week = keplerian ? record.ephemeris.toe_week : record.glonass.toe_week;
+        const double toe_sow = keplerian ? record.ephemeris.toe_sow_sec : record.glonass.toe_sow_sec;
 
-            // Stage B: the final reconstructed RTKLIB store must expose the same real
-            // broadcast group-delay values as the reference store for the same
-            // selected instance (queried through the production bias API at Toe).
-            gnss_sim::RtklibBroadcastBiasData reference_bias{};
-            gnss_sim::RtklibBroadcastBiasData roundtrip_bias{};
-            const int satellite_number =
-                keplerian ? record.ephemeris.satellite_number : record.glonass.satellite_number;
-            const gnss_sim::RtklibBroadcastMessageFamily family =
-                keplerian ? record.ephemeris.message_family : record.glonass.message_family;
-            const int stage_toe_week = keplerian ? record.ephemeris.toe_week : record.glonass.toe_week;
-            const double stage_toe_sow = keplerian ? record.ephemeris.toe_sow_sec : record.glonass.toe_sow_sec;
-            ASSERT_TRUE(gnss_sim::rtklib_broadcast_bias_data_for_family(
-                reference, stage_toe_week, stage_toe_sow, satellite_number, family, &reference_bias, &error_message))
-                << error_message;
-            ASSERT_TRUE(gnss_sim::rtklib_broadcast_bias_data_for_family(
-                roundtrip, stage_toe_week, stage_toe_sow, satellite_number, family, &roundtrip_bias, &error_message))
-                << error_message;
-            EXPECT_EQ(reference_bias.iode, roundtrip_bias.iode) << "stage-B selected-instance IODE mismatch";
-            for (int term = 0; term < 4; ++term) {
-                EXPECT_LE(relative_diff(reference_bias.tgd_sec[term], roundtrip_bias.tgd_sec[term]),
-                          kMaxCorrectionRelativeDiff)
-                    << "stage-B TGD/BGD term " << term << " must match in the final reconstructed store";
-            }
-            EXPECT_LE(relative_diff(reference_bias.glonass_dtaun_sec, roundtrip_bias.glonass_dtaun_sec),
-                      kMaxCorrectionRelativeDiff)
-                << "stage-B GLONASS delay must match in the final reconstructed store";
-            ++stage_b_bias_compared;
+        if (record.kind == gnss_sim::RtklibNavRecordKind::kGlonassEphemeris) {
+            const double reference_delay = record.glonass.differential_delay_sec;
+            const double roundtrip_delay = parsed.record.glonass.differential_delay_sec;
+            EXPECT_LE(relative_diff(reference_delay, roundtrip_delay), kMaxCorrectionRelativeDiff)
+                << "GLONASS delay must survive the serialization boundary unchanged";
+            ++compared_bgd;
         } else if (record.kind == gnss_sim::RtklibNavRecordKind::kIonosphere) {
             ASSERT_EQ(record.ionosphere.coefficient_count, parsed.record.ionosphere.coefficient_count);
             for (int coefficient = 0; coefficient < record.ionosphere.coefficient_count; ++coefficient) {
@@ -607,6 +605,83 @@ TEST(NavEquivalence, CorrectionParametersSurviveProductionRoundTrip) {
             EXPECT_EQ(record.ionosphere.leap_seconds, parsed.record.ionosphere.leap_seconds)
                 << "leap seconds must survive the serialization boundary unchanged";
             ++compared_ion;
+
+            // Stage B: the final reconstructed RTKLIB store must hold exactly the real
+            // serialized BeiDou ION coefficients (and the GPST-UTC leap seconds after the
+            // parser's documented BDT-UTC +14 s restoration). The reference store cannot
+            // serve as the expected side here because pinned RTKLIB never projects
+            // RINEX4 BeiDou ION into nav.ion_cmp; the unchanged real-RINEX projection is
+            // the expected truth.
+            if (record.ionosphere.system == gnss_sim::NavOutputSystem::kBeidou) {
+                gnss_sim::RtklibIonosphereModelState model{};
+                ASSERT_TRUE(gnss_sim::rtklib_broadcast_ionosphere_model_state(
+                    roundtrip, gnss_sim::RtklibIonosphereSystem::kBeidouLegacy, &model, &error_message))
+                    << error_message;
+                for (int coefficient = 0; coefficient < 8; ++coefficient) {
+                    EXPECT_LE(
+                        relative_diff(record.ionosphere.coefficients[coefficient], model.coefficients[coefficient]),
+                        kMaxCorrectionRelativeDiff)
+                        << "stage-B BeiDou ionosphere coefficient " << coefficient
+                        << " must match the real serialized record in the final store";
+                }
+                EXPECT_EQ(model.leap_seconds, record.ionosphere.leap_seconds)
+                    << "stage-B leap seconds must match the real serialized record";
+                ++stage_b_ion_compared;
+            }
+            // Stage B for the GPS legacy model state: both final stores must hold the
+            // same (zero) legacy GPS Klobuchar state, so the solver ionosphere model is
+            // identical on both positioning paths.
+            gnss_sim::RtklibIonosphereModelState reference_gps_model{};
+            gnss_sim::RtklibIonosphereModelState roundtrip_gps_model{};
+            ASSERT_TRUE(gnss_sim::rtklib_broadcast_ionosphere_model_state(
+                reference, gnss_sim::RtklibIonosphereSystem::kGps, &reference_gps_model, &error_message))
+                << error_message;
+            ASSERT_TRUE(gnss_sim::rtklib_broadcast_ionosphere_model_state(
+                roundtrip, gnss_sim::RtklibIonosphereSystem::kGps, &roundtrip_gps_model, &error_message))
+                << error_message;
+            for (int coefficient = 0; coefficient < 8; ++coefficient) {
+                EXPECT_DOUBLE_EQ(reference_gps_model.coefficients[coefficient],
+                                 roundtrip_gps_model.coefficients[coefficient])
+                    << "stage-B GPS ionosphere coefficient " << coefficient << " must match between stores";
+            }
+        } else {
+            const double reference_delay = record.ephemeris.tgd_sec[0];
+            const double roundtrip_delay = parsed.record.ephemeris.tgd_sec[0];
+            EXPECT_LE(relative_diff(reference_delay, roundtrip_delay), kMaxCorrectionRelativeDiff)
+                << "TGD must survive the serialization boundary unchanged";
+            if (record.ephemeris.system == gnss_sim::NavOutputSystem::kBeidou) {
+                EXPECT_LE(relative_diff(record.ephemeris.tgd_sec[1], parsed.record.ephemeris.tgd_sec[1]),
+                          kMaxCorrectionRelativeDiff)
+                    << "BeiDou BGD2 must survive the serialization boundary unchanged";
+                ++compared_bgd;
+            } else {
+                ++compared_tgd;
+            }
+            EXPECT_EQ(record.ephemeris.svh, parsed.record.ephemeris.svh) << "health must survive unchanged";
+        }
+
+        if (is_ephemeris_record(record)) {
+            // Stage B: the final reconstructed RTKLIB store must expose the same real
+            // broadcast group-delay values as the reference store for the same selected
+            // instance (queried through the production bias API at Toe).
+            gnss_sim::RtklibBroadcastBiasData reference_bias{};
+            gnss_sim::RtklibBroadcastBiasData roundtrip_bias{};
+            ASSERT_TRUE(gnss_sim::rtklib_broadcast_bias_data_for_family(reference, toe_week, toe_sow, satellite_number,
+                                                                        family, &reference_bias, &error_message))
+                << error_message;
+            ASSERT_TRUE(gnss_sim::rtklib_broadcast_bias_data_for_family(roundtrip, toe_week, toe_sow, satellite_number,
+                                                                        family, &roundtrip_bias, &error_message))
+                << error_message;
+            EXPECT_EQ(reference_bias.iode, roundtrip_bias.iode) << "stage-B selected-instance IODE mismatch";
+            for (int term = 0; term < 4; ++term) {
+                EXPECT_LE(relative_diff(reference_bias.tgd_sec[term], roundtrip_bias.tgd_sec[term]),
+                          kMaxCorrectionRelativeDiff)
+                    << "stage-B TGD/BGD term " << term << " must match in the final reconstructed store";
+            }
+            EXPECT_LE(relative_diff(reference_bias.glonass_dtaun_sec, roundtrip_bias.glonass_dtaun_sec),
+                      kMaxCorrectionRelativeDiff)
+                << "stage-B GLONASS delay must match in the final reconstructed store";
+            ++stage_b_bias_compared;
         }
     }
 
@@ -634,7 +709,7 @@ TEST(NavEquivalence, CorrectionParametersSurviveProductionRoundTrip) {
     std::cout << "NAV_EQUIV_CORRECTION_SUMMARY,serialized_records=" << serialized_count
               << ",outside_contract_records=" << outside_contract << ",compared_tgd=" << compared_tgd
               << ",compared_bgd=" << compared_bgd << ",compared_ion=" << compared_ion
-              << ",stage_b_bias_compared=" << stage_b_bias_compared
+              << ",stage_b_bias_compared=" << stage_b_bias_compared << ",stage_b_ion_compared=" << stage_b_ion_compared
               << ",stage_b_gps_ion_delay_ref_m=" << reference_ion.reference_delay_m
               << ",stage_b_gps_ion_delay_rt_m=" << roundtrip_ion.reference_delay_m << "\n";
     EXPECT_GT(compared_tgd, 0U) << "the real fixture must exercise broadcast group delays";

--- a/tests/integration/test_nav_equivalence.cpp
+++ b/tests/integration/test_nav_equivalence.cpp
@@ -769,9 +769,6 @@ TEST(NavEquivalence, CorrectionParametersSurviveProductionRoundTrip) {
     EXPECT_EQ(stage_b_bias_compared, serialized_ephemeris_count)
         << "every supported serialized ephemeris must reach the stage-B bias comparison";
     EXPECT_GT(stage_b_bias_compared, 0U);
-    EXPECT_EQ(stage_b_bias_compared, serialized_ephemeris_count)
-        << "every supported serialized ephemeris must reach the stage-B bias comparison";
-    EXPECT_GT(stage_b_bias_compared, 0U);
     gnss_sim::destroy_rtklib_nav_store(roundtrip);
     gnss_sim::destroy_rtklib_nav_store(reference);
 }

--- a/tests/unit/test_rtklib_adapter.cpp
+++ b/tests/unit/test_rtklib_adapter.cpp
@@ -15,8 +15,10 @@ extern "C" {
 #undef unlock
 #endif
 
+#include <algorithm>
 #include <cstring>
 #include <string>
+#include <vector>
 
 namespace {
 
@@ -351,6 +353,49 @@ TEST_F(RtklibAdapterTest, SelectedEphemerisIdentityCoversFamiliesAndToeInstances
     EXPECT_EQ(glonass_identity.iode, glonass_record.glonass.iode);
     EXPECT_EQ(glonass_identity.toe_week, glonass_record.glonass.toe_week);
     EXPECT_DOUBLE_EQ(glonass_identity.toe_sow_sec, glonass_record.glonass.toe_sow_sec);
+}
+
+TEST_F(RtklibAdapterTest, BroadcastBiasSelectionTracksRealToeInstances) {
+    std::string error_message;
+    const std::string companion_path =
+        std::string(GNSS_SIM_TEST_DATA_DIR) + "/brd400dlr_rinex4_galileo_companion_nav.rnx";
+    ASSERT_TRUE(gnss_sim::load_rinex_nav_file(store_, companion_path.c_str(), &error_message)) << error_message;
+
+    // The two real E02 INAV instances share satellite and family but differ in IODnav
+    // and Toe. The bias adapter performs its own selection, so its returned identity
+    // must track the real instance whose Toe matches the queried epoch.
+    std::vector<gnss_sim::NavOutputRecord> instances;
+    for (int index = 0; index < gnss_sim::rtklib_nav_output_record_count(store_); ++index) {
+        gnss_sim::NavOutputRecord record{};
+        ASSERT_TRUE(gnss_sim::rtklib_nav_output_record(store_, index, &record, &error_message)) << error_message;
+        if (record.kind == gnss_sim::RtklibNavRecordKind::kEphemeris &&
+            record.ephemeris.system == gnss_sim::NavOutputSystem::kGalileo && record.ephemeris.prn == 2 &&
+            record.ephemeris.message_family == gnss_sim::RtklibBroadcastMessageFamily::kGalileoInav) {
+            instances.push_back(record);
+        }
+    }
+    ASSERT_EQ(instances.size(), 2U) << "the fixture must provide two real E02 INAV instances";
+    std::sort(instances.begin(), instances.end(),
+              [](const gnss_sim::NavOutputRecord& lhs, const gnss_sim::NavOutputRecord& rhs) {
+                  return lhs.ephemeris.toe_sow_sec < rhs.ephemeris.toe_sow_sec;
+              });
+
+    for (const gnss_sim::NavOutputRecord& instance : instances) {
+        gnss_sim::RtklibBroadcastBiasData bias{};
+        gnss_sim::RtklibSelectedEphemerisInfo identity{};
+        ASSERT_TRUE(gnss_sim::rtklib_broadcast_bias_data_for_family(
+            store_, instance.ephemeris.toe_week, instance.ephemeris.toe_sow_sec, instance.ephemeris.satellite_number,
+            gnss_sim::RtklibBroadcastMessageFamily::kGalileoInav, &bias, &error_message, &identity))
+            << error_message;
+        EXPECT_EQ(identity.satellite_number, instance.ephemeris.satellite_number);
+        EXPECT_EQ(identity.message_family, gnss_sim::RtklibBroadcastMessageFamily::kGalileoInav);
+        EXPECT_EQ(identity.iode, instance.ephemeris.iode);
+        EXPECT_EQ(identity.toe_week, instance.ephemeris.toe_week);
+        EXPECT_DOUBLE_EQ(identity.toe_sow_sec, instance.ephemeris.toe_sow_sec);
+        EXPECT_EQ(bias.iode, instance.ephemeris.iode);
+    }
+    EXPECT_NE(instances[0].ephemeris.iode, instances[1].ephemeris.iode)
+        << "the two real instances must be distinguishable by IODnav";
 }
 
 } // namespace

--- a/tests/unit/test_rtklib_adapter.cpp
+++ b/tests/unit/test_rtklib_adapter.cpp
@@ -1,3 +1,4 @@
+#include "gnss/nav_output_record.h"
 #include "gnss/rtklib_adapter.h"
 #include "gnss_sim/simulator.h"
 
@@ -203,6 +204,153 @@ TEST(RtklibAdapterErrors, MissingAndInvalidNavigationFilesFailClearly) {
     EXPECT_FALSE(error_message.empty());
 
     gnss_sim::destroy_rtklib_nav_store(store);
+}
+
+bool find_projected_ephemeris(const gnss_sim::RtklibNavStore* store, gnss_sim::NavOutputSystem system, int prn,
+                              gnss_sim::RtklibBroadcastMessageFamily family, gnss_sim::NavOutputRecord* result,
+                              std::string* error_message) {
+    const int count = gnss_sim::rtklib_nav_output_record_count(store);
+    for (int index = 0; index < count; ++index) {
+        gnss_sim::NavOutputRecord record{};
+        if (!gnss_sim::rtklib_nav_output_record(store, index, &record, error_message)) {
+            return false;
+        }
+        if (record.kind == gnss_sim::RtklibNavRecordKind::kEphemeris && record.ephemeris.system == system &&
+            record.ephemeris.prn == prn && record.ephemeris.message_family == family) {
+            *result = record;
+            return true;
+        }
+    }
+    return false;
+}
+
+TEST_F(RtklibAdapterTest, SelectedEphemerisIdentityCoversFamiliesAndToeInstances) {
+    std::string error_message;
+    const std::string companion_path =
+        std::string(GNSS_SIM_TEST_DATA_DIR) + "/brd400dlr_rinex4_galileo_companion_nav.rnx";
+    ASSERT_TRUE(gnss_sim::load_rinex_nav_file(store_, companion_path.c_str(), &error_message)) << error_message;
+
+    struct InstanceQuery {
+        gnss_sim::NavOutputSystem system;
+        int prn;
+        gnss_sim::RtklibBroadcastMessageFamily family;
+    };
+    const InstanceQuery queries[] = {
+        {gnss_sim::NavOutputSystem::kGalileo, 2, gnss_sim::RtklibBroadcastMessageFamily::kGalileoInav},
+        {gnss_sim::NavOutputSystem::kGalileo, 2, gnss_sim::RtklibBroadcastMessageFamily::kGalileoFnav},
+        {gnss_sim::NavOutputSystem::kGalileo, 5, gnss_sim::RtklibBroadcastMessageFamily::kGalileoInav},
+        {gnss_sim::NavOutputSystem::kGalileo, 5, gnss_sim::RtklibBroadcastMessageFamily::kGalileoFnav},
+    };
+    for (const InstanceQuery& query : queries) {
+        gnss_sim::NavOutputRecord record{};
+        if (!find_projected_ephemeris(store_, query.system, query.prn, query.family, &record, &error_message)) {
+            FAIL() << "no projected record for prn " << query.prn << " family " << static_cast<int>(query.family)
+                   << ": " << error_message;
+        }
+        gnss_sim::RtklibSatelliteState state{};
+        gnss_sim::RtklibSelectedEphemerisInfo identity{};
+        const int toe_week = record.ephemeris.toe_week;
+        const double toe_sow = record.ephemeris.toe_sow_sec;
+        ASSERT_TRUE(gnss_sim::get_rtklib_signal_satellite_state(store_, toe_week, toe_sow,
+                                                                record.ephemeris.satellite_number, 1, query.family,
+                                                                &state, &error_message, &identity))
+            << error_message;
+        EXPECT_EQ(identity.satellite_number, record.ephemeris.satellite_number);
+        EXPECT_EQ(identity.message_family, query.family);
+        EXPECT_EQ(identity.iode, record.ephemeris.iode);
+        EXPECT_EQ(identity.toe_week, toe_week);
+        EXPECT_DOUBLE_EQ(identity.toe_sow_sec, toe_sow);
+        EXPECT_EQ(identity.iodc, record.ephemeris.iodc);
+        EXPECT_EQ(identity.toc_week, record.ephemeris.toc_week);
+        EXPECT_DOUBLE_EQ(identity.toc_sow_sec, record.ephemeris.toc_sow_sec);
+    }
+
+    // Same satellite + family, different real Toe instance: the selection must return
+    // the identity of the instance whose Toe matches the queried epoch, proving Toe is
+    // part of the selected identity.
+    gnss_sim::NavOutputRecord first{};
+    gnss_sim::NavOutputRecord second{};
+    ASSERT_TRUE(find_projected_ephemeris(store_, gnss_sim::NavOutputSystem::kGalileo, 2,
+                                         gnss_sim::RtklibBroadcastMessageFamily::kGalileoInav, &first, &error_message))
+        << error_message;
+    const int first_index = static_cast<int>(&first - &first);
+    static_cast<void>(first_index);
+    int second_found = 0;
+    for (int index = 0; index < gnss_sim::rtklib_nav_output_record_count(store_); ++index) {
+        gnss_sim::NavOutputRecord record{};
+        ASSERT_TRUE(gnss_sim::rtklib_nav_output_record(store_, index, &record, &error_message)) << error_message;
+        if (record.kind == gnss_sim::RtklibNavRecordKind::kEphemeris &&
+            record.ephemeris.system == gnss_sim::NavOutputSystem::kGalileo && record.ephemeris.prn == 2 &&
+            record.ephemeris.message_family == gnss_sim::RtklibBroadcastMessageFamily::kGalileoInav &&
+            record.ephemeris.iode != first.ephemeris.iode) {
+            second = record;
+            ++second_found;
+        }
+    }
+    ASSERT_EQ(second_found, 1) << "the fixture must hold two E02 INAV instances with distinct IODnav";
+    gnss_sim::RtklibSatelliteState state{};
+    gnss_sim::RtklibSelectedEphemerisInfo identity{};
+    ASSERT_TRUE(gnss_sim::get_rtklib_signal_satellite_state(
+        store_, second.ephemeris.toe_week, second.ephemeris.toe_sow_sec, second.ephemeris.satellite_number, 1,
+        gnss_sim::RtklibBroadcastMessageFamily::kGalileoInav, &state, &error_message, &identity))
+        << error_message;
+    EXPECT_EQ(identity.iode, second.ephemeris.iode);
+    EXPECT_EQ(identity.toe_week, second.ephemeris.toe_week);
+    EXPECT_DOUBLE_EQ(identity.toe_sow_sec, second.ephemeris.toe_sow_sec);
+    EXPECT_FALSE(identity.toe_week == first.ephemeris.toe_week && identity.toe_sow_sec == first.ephemeris.toe_sow_sec)
+        << "the two real instances must be distinguishable by selected Toe identity";
+
+    // Family coverage over the five-system fixture: GPS/QZSS legacy, GLONASS FDMA, and
+    // BeiDou legacy records must all report their real selected identity.
+    ASSERT_TRUE(gnss_sim::load_rinex_nav_file(store_, rinex4_acceptance_nav_path().c_str(), &error_message))
+        << error_message;
+    const InstanceQuery family_queries[] = {
+        {gnss_sim::NavOutputSystem::kGps, 1, gnss_sim::RtklibBroadcastMessageFamily::kLegacy},
+        {gnss_sim::NavOutputSystem::kQzss, 196, gnss_sim::RtklibBroadcastMessageFamily::kLegacy},
+        {gnss_sim::NavOutputSystem::kBeidou, 6, gnss_sim::RtklibBroadcastMessageFamily::kLegacy},
+    };
+    for (const InstanceQuery& query : family_queries) {
+        gnss_sim::NavOutputRecord record{};
+        if (!find_projected_ephemeris(store_, query.system, query.prn, query.family, &record, &error_message)) {
+            FAIL() << "no projected record for system " << static_cast<int>(query.system) << " prn " << query.prn
+                   << ": " << error_message;
+        }
+        gnss_sim::RtklibSatelliteState state{};
+        gnss_sim::RtklibSelectedEphemerisInfo identity{};
+        const int observation_code = query.system == gnss_sim::NavOutputSystem::kBeidou ? 40 : 1;
+        ASSERT_TRUE(gnss_sim::get_rtklib_signal_satellite_state(
+            store_, record.ephemeris.toe_week, record.ephemeris.toe_sow_sec, record.ephemeris.satellite_number,
+            observation_code, query.family, &state, &error_message, &identity))
+            << "family query failed for system " << static_cast<int>(query.system) << " prn " << query.prn << ": "
+            << error_message;
+        EXPECT_EQ(identity.iode, record.ephemeris.iode);
+        EXPECT_EQ(identity.toe_week, record.ephemeris.toe_week);
+        EXPECT_DOUBLE_EQ(identity.toe_sow_sec, record.ephemeris.toe_sow_sec);
+    }
+
+    // GLONASS FDMA identity through the GLONASS ephemeris path.
+    gnss_sim::NavOutputRecord glonass_record{};
+    bool found_glonass = false;
+    for (int index = 0; index < gnss_sim::rtklib_nav_output_record_count(store_); ++index) {
+        gnss_sim::NavOutputRecord record{};
+        ASSERT_TRUE(gnss_sim::rtklib_nav_output_record(store_, index, &record, &error_message)) << error_message;
+        if (record.kind == gnss_sim::RtklibNavRecordKind::kGlonassEphemeris) {
+            glonass_record = record;
+            found_glonass = true;
+            break;
+        }
+    }
+    ASSERT_TRUE(found_glonass) << "the fixture must contain a GLONASS record";
+    gnss_sim::RtklibSatelliteState glonass_state{};
+    gnss_sim::RtklibSelectedEphemerisInfo glonass_identity{};
+    ASSERT_TRUE(gnss_sim::get_rtklib_signal_satellite_state(
+        store_, glonass_record.glonass.toe_week, glonass_record.glonass.toe_sow_sec,
+        glonass_record.glonass.satellite_number, 1, gnss_sim::RtklibBroadcastMessageFamily::kGlonassFdma,
+        &glonass_state, &error_message, &glonass_identity))
+        << error_message;
+    EXPECT_EQ(glonass_identity.iode, glonass_record.glonass.iode);
+    EXPECT_EQ(glonass_identity.toe_week, glonass_record.glonass.toe_week);
+    EXPECT_DOUBLE_EQ(glonass_identity.toe_sow_sec, glonass_record.glonass.toe_sow_sec);
 }
 
 } // namespace


### PR DESCRIPTION
Closes #99. **Ready to merge (review PASS at head `9c14310`).**

## Implementation Notes (final)

### Production paths reused (issue 97/99 plan)

Reference store: `load_rinex_nav_file()`. Round-trip store: `format_novatel_nav_output_record()` → `parse_serialized_novatel_nav_line_independent()` → `rtklib_append_nav_output_record()` — built exclusively from parsed receiver-log messages; the reference store is never consulted while building or using it. Satellite states and positioning use the production RTKLIB adapters (`get_rtklib_signal_satellite_state()`, `rtklib_solve_raw_single_position()`); the production RANGEA position-observation selection is exposed as `select_rangea_position_observations()` so the paired solver reuses the identical path. No test-only navigation conversion logic, no `nav_t` mutation or private-structure mirror.

### Finding 1 — record-complete coverage with source-record binding

Per supported serialized ephemeris: the mandatory Toe sample requires both stores to return a state AND requires the returned selected identities to equal the **unchanged source record's structured identity** (`ExpectedEphemerisIdentity`: satellite, family, IODE/IODnav, Toe week, Toe SOW) — derived read-only from the source `NavOutputRecord`. Toe±Δ samples compare the actual reference-vs-roundtrip selected identities (an adjacent real instance may legitimately be selected there). Every sample is classified `Compared / BothUnavailableValiditySkip / AvailabilityMismatch`; one-sided availability fails.

Coverage on the real fixture: **serialized EPH records 60; records_with_successful_state_comparison 60; attempted 180; compared 180; validity-skipped 0; availability-mismatch 0**. Per-record `NAV_EQUIV_COVERAGE_CSV` rows identify the first uncovered record.

### Finding 2 — selected-instance identity

`RtklibSelectedEphemerisInfo` (satellite, family, IODE/IODnav, IODC, Toe week/SOW, Toc week/SOW, transmit week/SOW) is filled from the same selected `eph_t`/`geph_t` that `rtklib_signal_ephemeris_ext()` returned for the state — no second selector. Reference-vs-roundtrip identity equality is asserted before any state value; scoped by broadcast semantics: IODC only for legacy GPS/QZSS/BeiDou (Galileo has no broadcast IODC), transmit time reported but not asserted (the receiver-log contract re-stamps it with delivery time, issue 84). Unit test `SelectedEphemerisIdentityCoversFamiliesAndToeInstances` covers GPS/QZSS legacy, GLONASS FDMA, Galileo INAV/FNAV, BeiDou legacy, and the two real E02 INAV Toe instances.

### Finding 3 — corrections: two layers, both source-bound

Stage A (writer/parser boundary): TGD 23, BeiDou BGD2 14, GLONASS delay 14, ION 1 — all within 1e-12 relative. Stage B (final reconstructed store): `rtklib_broadcast_bias_data_for_family()` queried on **both** stores at each record's Toe with its own selected identity output — the bias-selected identity (satellite, family, IODnav, Toe week/SOW) is **source-bound** on both navigation paths before any delay comparison — **60 instances**, all four TGD/BGD terms + GLONASS delay within 1e-12, hard-gated `stage_b_bias_compared == serialized_ephemeris_count (60)` and nonzero. The real serialized BeiDou ION is asserted **in the final store** via the read-only `rtklib_broadcast_ionosphere_model_state()`: all eight `nav.ion_cmp` coefficients and the restored GPST-UTC leap seconds equal the unchanged real-RINEX projection (**stage_b_ion_compared 1 == serialized_supported_beidou_ion_records 1, hard-gated nonzero**); GPS legacy model state identical between both stores; the derived GPS delay equality check is retained (2.86526 m at the test geometry). ISC-class fields remain outside the NovAtel ASCII contract and are not synthesized.

### Store-level identity set

`record_identity_key()` is a structured `std::tuple` (system, PRN, family, IODE/IODnav, **Toe week, Toe SOW**) with lexicographic comparison — lossless in Toe, no floating-point formatting. Sorted-vector equality (multiplicity preserved) passes bidirectionally.

### Finding 4 — exact used-satellite set

`RtklibPositionSolution.used_satellite_mask[7]` (indexed by RTKLIB satellite number − 1, covers MAXSAT=408) is filled from `pntpos` `ssat[].vs` validity — no positioning behavior change. Per paired epoch: exact mask equality, mask population == reported count (both paths), reference-only/roundtrip-only satellites printed on mismatch.

### Paired positioning (same RANGEA input, identical options, atmosphere + TGD active)

**59 compared epochs; max 3D difference 3.2e-8 m; RMS 6.9e-9 m; receiver-clock difference 8.9e-9 m; status divergences 0; exact used-satellite-set divergences 0.**

### Satellite-state equivalence (final)

60/60 records Toe-compared; 180/180 epochs; max position difference **3.6e-8 m** (1 ulp of the orbit-radius double); max velocity difference **3.5e-5 m/s** (RTKLIB differentiates the propagated position, amplifying that ulp over its 1e-3 s finite-difference step — documented); clock bias/drift **exactly 0**. Transition test: 5/5 epochs across the real E02 IODnav 1→2 instances, all zero.

### Provenance

No fixture or navigation value was created, modified, retargeted, or interpolated. All truth remains the existing provenance-documented real BRD400DLR fixtures.

### Validation (final, head `9c14310`)

- `./build/gnss_sim_unit_tests`: **171/171**; `./build/gnss_sim_integration_tests`: **43/43** (all existing closures unchanged)
- clang-format clean; Ubuntu/Windows/format/tooling CI green on this branch