### PR TITLE
Define normalized CN0 model schema and receiver baseline config

### DIFF
--- a/docs/CN0_MODEL_SEMANTICS.md
+++ b/docs/CN0_MODEL_SEMANTICS.md
@@ -1,0 +1,71 @@
+# CN0 model semantic contract
+
+This document freezes the compatibility contract introduced by issue #105, the first implementation step of parent issue #104.
+
+## Why two semantics are required
+
+The legacy CN0 calibration model stores **absolute station-specific C/N0 in dB-Hz**. A normalized portable model instead stores an **elevation-dependent offset in dB**. These are different physical quantities and must never share an ambiguous schema.
+
+## `gnss-cn0-model-v1` — `ABSOLUTE_STATION_CN0`
+
+The existing v1 CSV header and row format are retained byte-for-byte. `p50_dbhz` is an absolute station/receiver/antenna C/N0 value. Existing interpolation and built-in fallback behavior remain unchanged.
+
+Loading a v1 model sets:
+
+```text
+semantic = ABSOLUTE_STATION_CN0
+```
+
+No v1 file is silently reinterpreted as a normalized model.
+
+## `gnss-cn0-model-v2` — `NORMALIZED_ELEVATION_SHAPE`
+
+The normalized runtime CSV contract is intentionally compact:
+
+```text
+schema_version,model_semantic,constellation,signal,elevation_min_deg,elevation_max_deg,upper_edge_inclusive,status,contributing_source_count,delta_p50_db
+```
+
+Rows must use:
+
+```text
+schema_version = gnss-cn0-model-v2
+model_semantic = NORMALIZED_ELEVATION_SHAPE
+```
+
+`delta_p50_db` is a relative C/N0 offset in **dB**, not an absolute dB-Hz value. `contributing_source_count` records how many eligible normalized calibration sources contributed to the aggregate bin. `EMPTY` rows have zero contributing sources and an empty delta value. `SPARSE`/`READY` rows require a positive source count and a finite delta value.
+
+Issue #105 only introduces the explicit semantic/schema boundary. A normalized model is deliberately **not** interpreted as absolute C/N0 by `cn0_model_estimate_dbhz()` until issue #107 composes it with a receiver-specific high-elevation baseline.
+
+## Receiver high-elevation baseline configuration
+
+Receiver/antenna-specific absolute levels are configured independently in simulator JSON:
+
+```json
+{
+  "cn0_high_dbhz": {
+    "GPS L1 C/A": 47.25,
+    "GPS L5Q": 49.00,
+    "Galileo E1": 48.00
+  }
+}
+```
+
+Keys must exactly match `SignalDefinition::name` from the repository's central signal-definition table. Unknown signals, duplicate keys, non-numeric values, and non-finite values are rejected deterministically.
+
+The default baseline list is empty. The simulator does **not** invent receiver-specific absolute C/N0 values. Production values must be configured or calibrated from suitable real receiver/antenna observations.
+
+## Compatibility rules
+
+- Explicitly selected malformed/unknown model schemas fail; there is no silent fallback to a different semantic.
+- `gnss-cn0-model-v1` remains the legacy absolute-station format.
+- `gnss-cn0-model-v2` is reserved for normalized elevation-shape output produced by issue #106.
+- A normalized delta must never be treated as dB-Hz.
+- An absolute built-in/station CN0 value must never be treated as an elevation delta.
+- Fixed model/config/input bytes remain deterministic and reproducible.
+
+## Follow-on issues
+
+- #106 produces v2 normalized elevation-shape models by normalizing each real calibration source before cross-station aggregation.
+- #107 composes `CN0_high_dbhz(signal) + Delta_CN0_elevation(signal,elevation)` at runtime.
+- #108 validates the abstraction with deterministic fixtures and multiple real WHU/IGS stations.

--- a/include/gnss_sim/sim_config.h
+++ b/include/gnss_sim/sim_config.h
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 namespace gnss_sim {
 
@@ -72,6 +73,15 @@ struct MeasurementErrorConfig {
     MeasurementFadeErrorConfig rea_fade;
 };
 
+// Receiver/antenna-specific absolute high-elevation C/N0 calibration.
+// signal_name must match SignalDefinition::name from the central signal table.
+// The list is intentionally empty by default: production values must be
+// calibrated/configured rather than fabricated by the simulator.
+struct Cn0HighBaselineConfig {
+    std::string signal_name;
+    double cn0_dbhz;
+};
+
 struct SimConfig {
     int schema_version;
     ScenarioType scenario;
@@ -91,6 +101,7 @@ struct SimConfig {
     ReaConfig rea;
     BestposRtkConfig bestpos_rtk;
     MeasurementErrorConfig measurement_error;
+    std::vector<Cn0HighBaselineConfig> cn0_high_dbhz;
     std::uint64_t seed;
 };
 

--- a/src/core/sim_config.cpp
+++ b/src/core/sim_config.cpp
@@ -1,5 +1,6 @@
 #include "gnss_sim/sim_config.h"
 
+#include "gnss/signal_definitions.h"
 #include "gnss_sim/sim_time.h"
 
 #include <cJSON.h>
@@ -175,6 +176,20 @@ bool parse_atmosphere_mode(const char* value, AtmosphereMode* atmosphere_mode, s
     return false;
 }
 
+const SignalDefinition* find_signal_definition_by_name(const char* name) {
+    if (name == nullptr) {
+        return nullptr;
+    }
+    std::size_t count = 0;
+    const SignalDefinition* definitions = signal_definitions(&count);
+    for (std::size_t index = 0; index < count; ++index) {
+        if (std::strcmp(definitions[index].name, name) == 0) {
+            return &definitions[index];
+        }
+    }
+    return nullptr;
+}
+
 bool parse_receiver(const cJSON* root, SimConfig* config, std::string* error_message) {
     const cJSON* receiver = cJSON_GetObjectItemCaseSensitive(root, "receiver");
     if (receiver == nullptr) {
@@ -312,6 +327,38 @@ bool parse_measurement_error(const cJSON* root, SimConfig* config, std::string* 
            parse_measurement_fade(object, &config->measurement_error.rea_fade, error_message);
 }
 
+bool parse_cn0_high_dbhz(const cJSON* root, SimConfig* config, std::string* error_message) {
+    const cJSON* object = cJSON_GetObjectItemCaseSensitive(root, "cn0_high_dbhz");
+    if (object == nullptr) {
+        return true;
+    }
+    if (!cJSON_IsObject(object)) {
+        set_error(error_message, "cn0_high_dbhz must be a JSON object keyed by central signal name");
+        return false;
+    }
+
+    config->cn0_high_dbhz.clear();
+    for (const cJSON* item = object->child; item != nullptr; item = item->next) {
+        if (item->string == nullptr || find_signal_definition_by_name(item->string) == nullptr) {
+            set_error(error_message, std::string("cn0_high_dbhz contains unknown central signal name: ") +
+                                         (item->string == nullptr ? "<null>" : item->string));
+            return false;
+        }
+        if (!cJSON_IsNumber(item) || !std::isfinite(item->valuedouble)) {
+            set_error(error_message, std::string("cn0_high_dbhz value must be finite for signal: ") + item->string);
+            return false;
+        }
+        for (const Cn0HighBaselineConfig& previous : config->cn0_high_dbhz) {
+            if (previous.signal_name == item->string) {
+                set_error(error_message, std::string("duplicate cn0_high_dbhz signal: ") + item->string);
+                return false;
+            }
+        }
+        config->cn0_high_dbhz.push_back({item->string, item->valuedouble});
+    }
+    return true;
+}
+
 bool parse_seed(const cJSON* root, SimConfig* config, std::string* error_message) {
     const cJSON* seed = cJSON_GetObjectItemCaseSensitive(root, "seed");
     if (seed == nullptr) {
@@ -354,6 +401,21 @@ bool valid_measurement_error_config(const MeasurementErrorConfig& config) {
            valid_measurement_transient(config.ttff_hot) && valid_measurement_transient(config.ttff_warm) &&
            valid_measurement_transient(config.ttff_cold) && valid_measurement_transient(config.rea_reacquisition) &&
            valid_measurement_fade(config.rea_fade);
+}
+
+bool valid_cn0_high_baselines(const std::vector<Cn0HighBaselineConfig>& baselines) {
+    for (std::size_t index = 0; index < baselines.size(); ++index) {
+        const Cn0HighBaselineConfig& baseline = baselines[index];
+        if (!std::isfinite(baseline.cn0_dbhz) || find_signal_definition_by_name(baseline.signal_name.c_str()) == nullptr) {
+            return false;
+        }
+        for (std::size_t previous = 0; previous < index; ++previous) {
+            if (baselines[previous].signal_name == baseline.signal_name) {
+                return false;
+            }
+        }
+    }
+    return true;
 }
 
 bool valid_atmosphere_mode(AtmosphereMode atmosphere_mode) {
@@ -433,6 +495,10 @@ bool validate_sim_config(const SimConfig& config, std::string* error_message) {
         set_error(error_message, "measurement_error configuration is invalid");
         return false;
     }
+    if (!valid_cn0_high_baselines(config.cn0_high_dbhz)) {
+        set_error(error_message, "cn0_high_dbhz configuration is invalid");
+        return false;
+    }
     if (config.multipath_enabled) {
         set_error(error_message, "multipath is not supported in V1");
         return false;
@@ -506,6 +572,7 @@ bool load_sim_config_json(const char* file_path, SimConfig* config, std::string*
                                         "measurement_noise_enabled",
                                         "bestpos_rtk",
                                         "measurement_error",
+                                        "cn0_high_dbhz",
                                         "multipath_enabled",
                                         "receiver_clock_bias_m",
                                         "receiver_clock_drift_mps",
@@ -516,7 +583,7 @@ bool load_sim_config_json(const char* file_path, SimConfig* config, std::string*
                                         "seed"};
 
     SimConfig parsed = default_sim_config();
-    bool success = validate_object_keys(root, "root", allowed_keys, 19U, error_message);
+    bool success = validate_object_keys(root, "root", allowed_keys, 20U, error_message);
 
     double duration_sec = static_cast<double>(parsed.duration_ns) / static_cast<double>(NANOSECONDS_PER_SECOND);
     const char* scenario_name = scenario_type_name(parsed.scenario);
@@ -548,7 +615,8 @@ bool load_sim_config_json(const char* file_path, SimConfig* config, std::string*
             parse_atmosphere_mode(atmosphere_name, &parsed.atmosphere_mode, error_message) &&
             parse_receiver(root, &parsed, error_message) && parse_ttff(root, &parsed, error_message) &&
             parse_rea(root, &parsed, error_message) && parse_bestpos_rtk(root, &parsed, error_message) &&
-            parse_measurement_error(root, &parsed, error_message) && parse_seed(root, &parsed, error_message) &&
+            parse_measurement_error(root, &parsed, error_message) &&
+            parse_cn0_high_dbhz(root, &parsed, error_message) && parse_seed(root, &parsed, error_message) &&
             validate_sim_config(parsed, error_message);
     }
 

--- a/src/core/sim_config.cpp
+++ b/src/core/sim_config.cpp
@@ -406,7 +406,8 @@ bool valid_measurement_error_config(const MeasurementErrorConfig& config) {
 bool valid_cn0_high_baselines(const std::vector<Cn0HighBaselineConfig>& baselines) {
     for (std::size_t index = 0; index < baselines.size(); ++index) {
         const Cn0HighBaselineConfig& baseline = baselines[index];
-        if (!std::isfinite(baseline.cn0_dbhz) || find_signal_definition_by_name(baseline.signal_name.c_str()) == nullptr) {
+        if (!std::isfinite(baseline.cn0_dbhz) ||
+            find_signal_definition_by_name(baseline.signal_name.c_str()) == nullptr) {
             return false;
         }
         for (std::size_t previous = 0; previous < index; ++previous) {

--- a/src/model/cn0_model.cpp
+++ b/src/model/cn0_model.cpp
@@ -24,11 +24,21 @@ constexpr double kSlowAmplitudeDb = 0.50;
 constexpr double kBinToleranceDeg = 1.0e-9;
 constexpr std::uint64_t kFnvOffsetBasis = 14695981039346656037ULL;
 constexpr std::uint64_t kFnvPrime = 1099511628211ULL;
-constexpr const char* kModelSchemaVersion = "gnss-cn0-model-v1";
-constexpr const char* kModelHeader =
+constexpr const char* kAbsoluteModelSchemaVersion = "gnss-cn0-model-v1";
+constexpr const char* kNormalizedModelSchemaVersion = "gnss-cn0-model-v2";
+constexpr const char* kNormalizedSemantic = "NORMALIZED_ELEVATION_SHAPE";
+constexpr const char* kAbsoluteModelHeader =
     "schema_version,constellation,signal,elevation_min_deg,elevation_max_deg,upper_edge_inclusive,status,count,"
     "p05_dbhz,p10_dbhz,p25_dbhz,p50_dbhz,p75_dbhz,p90_dbhz,p95_dbhz,mean_dbhz,stddev_dbhz,mad_dbhz,"
     "delta_count,delta_p50_dbhz,delta_p90_dbhz,delta_p99_dbhz,ar1_status,ar1";
+constexpr const char* kNormalizedModelHeader =
+    "schema_version,model_semantic,constellation,signal,elevation_min_deg,elevation_max_deg,upper_edge_inclusive,"
+    "status,contributing_source_count,delta_p50_db";
+
+enum class CsvSchema {
+    kAbsoluteV1,
+    kNormalizedV2,
+};
 
 void set_error(std::string* error_message, const std::string& message) {
     if (error_message != nullptr) {
@@ -247,7 +257,8 @@ bool bin_contains(const Cn0CalibratedBin& bin, double elevation_deg) {
     return elevation_deg >= bin.elevation_min_deg - kBinToleranceDeg && elevation_deg < bin.elevation_max_deg;
 }
 
-bool calibrated_nominal_dbhz(const Cn0Model& model, SignalId signal_id, double elevation_deg, double* nominal_dbhz) {
+bool calibrated_absolute_nominal_dbhz(const Cn0Model& model, SignalId signal_id, double elevation_deg,
+                                      double* nominal_dbhz) {
     if (nominal_dbhz == nullptr) {
         return false;
     }
@@ -336,15 +347,15 @@ bool file_identity(const char* file_path, Cn0ModelIdentity* identity, std::strin
     std::ostringstream hash_stream;
     hash_stream.imbue(std::locale::classic());
     hash_stream << std::hex << std::nouppercase << std::setw(16) << std::setfill('0') << hash;
-    identity->schema_version = kModelSchemaVersion;
     identity->file_name = std::filesystem::path(file_path).filename().generic_string();
     identity->hash = hash_stream.str();
     identity->size_bytes = size;
     return true;
 }
 
-bool validate_statistics_fields(const std::vector<std::string>& fields, std::uint64_t count, const std::string& status,
-                                std::size_t line_number, double* p50_dbhz, std::string* error_message) {
+bool validate_absolute_statistics_fields(const std::vector<std::string>& fields, std::uint64_t count,
+                                         const std::string& status, std::size_t line_number, double* p50_dbhz,
+                                         std::string* error_message) {
     double values[10]{};
     for (int index = 0; index < 10; ++index) {
         const std::string& field = fields[static_cast<std::size_t>(8 + index)];
@@ -448,11 +459,97 @@ bool validate_temporal_fields(const std::vector<std::string>& fields, std::size_
     return true;
 }
 
+bool validate_normalized_value(const std::vector<std::string>& fields, std::size_t line_number,
+                               std::uint64_t* support_count, double* delta_p50_db, bool* ready,
+                               std::string* error_message) {
+    if (!parse_u64(fields[8], support_count)) {
+        set_error(error_message,
+                  "normalized CN0 model has invalid contributing_source_count at line " + std::to_string(line_number));
+        return false;
+    }
+    const std::string& status = fields[7];
+    if (status != "EMPTY" && status != "SPARSE" && status != "READY") {
+        set_error(error_message,
+                  "normalized CN0 model has unsupported bin status at line " + std::to_string(line_number));
+        return false;
+    }
+    if (status == "EMPTY") {
+        if (*support_count != 0 || !fields[9].empty()) {
+            set_error(error_message,
+                      "normalized CN0 model EMPTY row has data at line " + std::to_string(line_number));
+            return false;
+        }
+        *delta_p50_db = std::numeric_limits<double>::quiet_NaN();
+        *ready = false;
+        return true;
+    }
+    if (*support_count == 0 || !parse_finite_double(fields[9], delta_p50_db)) {
+        set_error(error_message,
+                  "normalized CN0 model non-empty row lacks finite support/value at line " +
+                      std::to_string(line_number));
+        return false;
+    }
+    *ready = status == "READY";
+    return true;
+}
+
+bool parse_common_bin(const std::vector<std::string>& fields, std::size_t constellation_index, std::size_t signal_index,
+                      std::size_t elevation_min_index, std::size_t elevation_max_index, std::size_t inclusive_index,
+                      std::size_t line_number, Cn0CalibratedBin* bin, std::string* error_message) {
+    GnssConstellation constellation{};
+    if (!constellation_from_name(fields[constellation_index], &constellation)) {
+        set_error(error_message,
+                  "configured CN0 model has unsupported constellation at line " + std::to_string(line_number));
+        return false;
+    }
+    const SignalDefinition* definition = find_signal_definition_by_rinex(constellation, fields[signal_index].c_str());
+    if (definition == nullptr) {
+        set_error(error_message, "configured CN0 model signal is absent from central signal definitions at line " +
+                                     std::to_string(line_number));
+        return false;
+    }
+    bin->signal_id = definition->signal_id;
+    if (!parse_finite_double(fields[elevation_min_index], &bin->elevation_min_deg) ||
+        !parse_finite_double(fields[elevation_max_index], &bin->elevation_max_deg) ||
+        !parse_binary_flag(fields[inclusive_index], &bin->upper_edge_inclusive) || bin->elevation_min_deg < 0.0 ||
+        bin->elevation_max_deg > 90.0 || bin->elevation_max_deg <= bin->elevation_min_deg) {
+        set_error(error_message,
+                  "configured CN0 model has invalid elevation bin at line " + std::to_string(line_number));
+        return false;
+    }
+    bin->elevation_center_deg = 0.5 * (bin->elevation_min_deg + bin->elevation_max_deg);
+    return true;
+}
+
+bool append_validated_bin(Cn0Model* loaded, const Cn0CalibratedBin& bin, std::size_t line_number,
+                          std::string* error_message) {
+    const Cn0CalibratedBin* previous = previous_signal_bin(loaded->calibrated_bins, bin.signal_id);
+    if (previous != nullptr) {
+        if (bin.elevation_min_deg <= previous->elevation_min_deg + kBinToleranceDeg) {
+            set_error(error_message, "configured CN0 model bins are duplicate/non-monotonic at line " +
+                                         std::to_string(line_number));
+            return false;
+        }
+        if (bin.elevation_min_deg < previous->elevation_max_deg - kBinToleranceDeg) {
+            set_error(error_message, "configured CN0 model bins overlap at line " + std::to_string(line_number));
+            return false;
+        }
+        if (previous->upper_edge_inclusive) {
+            set_error(error_message, "configured CN0 model has a non-final inclusive upper edge at line " +
+                                         std::to_string(line_number - 1));
+            return false;
+        }
+    }
+    loaded->calibrated_bins.push_back(bin);
+    return true;
+}
+
 } // namespace
 
 Cn0Model make_builtin_cn0_model(std::uint64_t seed) {
     Cn0Model model{};
     model.source = Cn0ModelSource::kBuiltinFallback;
+    model.semantic = Cn0ModelSemantic::kBuiltinAbsoluteCn0;
     model.seed = seed;
     model.identity.schema_version = "builtin-cn0-v1";
     return model;
@@ -485,8 +582,19 @@ bool load_cn0_model_csv(const char* file_path, std::uint64_t seed, Cn0Model* mod
     if (!line.empty() && line.back() == '\r') {
         line.pop_back();
     }
-    if (line != kModelHeader) {
-        set_error(error_message, "configured CN0 model header/schema does not match gnss-cn0-model-v1");
+
+    CsvSchema schema{};
+    if (line == kAbsoluteModelHeader) {
+        schema = CsvSchema::kAbsoluteV1;
+        loaded.semantic = Cn0ModelSemantic::kAbsoluteStationCn0;
+        loaded.identity.schema_version = kAbsoluteModelSchemaVersion;
+    } else if (line == kNormalizedModelHeader) {
+        schema = CsvSchema::kNormalizedV2;
+        loaded.semantic = Cn0ModelSemantic::kNormalizedElevationShape;
+        loaded.identity.schema_version = kNormalizedModelSchemaVersion;
+    } else {
+        set_error(error_message,
+                  "configured CN0 model header/schema is neither gnss-cn0-model-v1 nor gnss-cn0-model-v2");
         return false;
     }
 
@@ -507,68 +615,42 @@ bool load_cn0_model_csv(const char* file_path, std::uint64_t seed, Cn0Model* mod
             return false;
         }
         const std::vector<std::string> fields = split_csv_line(line);
-        if (fields.size() != 24U) {
-            set_error(error_message,
-                      "configured CN0 model row must contain 24 columns at line " + std::to_string(line_number));
-            return false;
-        }
-        if (fields[0] != kModelSchemaVersion) {
-            set_error(error_message, "configured CN0 model row has incompatible schema version at line " +
-                                         std::to_string(line_number));
-            return false;
-        }
-
-        GnssConstellation constellation{};
-        if (!constellation_from_name(fields[1], &constellation)) {
-            set_error(error_message,
-                      "configured CN0 model has unsupported constellation at line " + std::to_string(line_number));
-            return false;
-        }
-        const SignalDefinition* definition = find_signal_definition_by_rinex(constellation, fields[2].c_str());
-        if (definition == nullptr) {
-            set_error(error_message, "configured CN0 model signal is absent from central signal definitions at line " +
-                                         std::to_string(line_number));
-            return false;
-        }
-
         Cn0CalibratedBin bin{};
-        bin.signal_id = definition->signal_id;
-        if (!parse_finite_double(fields[3], &bin.elevation_min_deg) ||
-            !parse_finite_double(fields[4], &bin.elevation_max_deg) ||
-            !parse_binary_flag(fields[5], &bin.upper_edge_inclusive) || bin.elevation_min_deg < 0.0 ||
-            bin.elevation_max_deg > 90.0 || bin.elevation_max_deg <= bin.elevation_min_deg) {
-            set_error(error_message,
-                      "configured CN0 model has invalid elevation bin at line " + std::to_string(line_number));
-            return false;
-        }
-        bin.elevation_center_deg = 0.5 * (bin.elevation_min_deg + bin.elevation_max_deg);
-
-        std::uint64_t count = 0;
-        if (!parse_u64(fields[7], &count) ||
-            !validate_statistics_fields(fields, count, fields[6], line_number, &bin.p50_dbhz, error_message) ||
-            !validate_temporal_fields(fields, line_number, error_message)) {
-            return false;
-        }
-        bin.ready = fields[6] == "READY";
-
-        const Cn0CalibratedBin* previous = previous_signal_bin(loaded.calibrated_bins, bin.signal_id);
-        if (previous != nullptr) {
-            if (bin.elevation_min_deg <= previous->elevation_min_deg + kBinToleranceDeg) {
-                set_error(error_message, "configured CN0 model bins are duplicate/non-monotonic at line " +
+        if (schema == CsvSchema::kAbsoluteV1) {
+            if (fields.size() != 24U || fields[0] != kAbsoluteModelSchemaVersion) {
+                set_error(error_message, "configured absolute CN0 model row is incompatible at line " +
                                              std::to_string(line_number));
                 return false;
             }
-            if (bin.elevation_min_deg < previous->elevation_max_deg - kBinToleranceDeg) {
-                set_error(error_message, "configured CN0 model bins overlap at line " + std::to_string(line_number));
+            if (!parse_common_bin(fields, 1U, 2U, 3U, 4U, 5U, line_number, &bin, error_message)) {
                 return false;
             }
-            if (previous->upper_edge_inclusive) {
-                set_error(error_message, "configured CN0 model has a non-final inclusive upper edge at line " +
-                                             std::to_string(line_number - 1));
+            std::uint64_t count = 0;
+            if (!parse_u64(fields[7], &count) ||
+                !validate_absolute_statistics_fields(fields, count, fields[6], line_number, &bin.p50_dbhz,
+                                                     error_message) ||
+                !validate_temporal_fields(fields, line_number, error_message)) {
                 return false;
             }
+            bin.support_count = count;
+            bin.delta_p50_db = std::numeric_limits<double>::quiet_NaN();
+            bin.ready = fields[6] == "READY";
+        } else {
+            if (fields.size() != 10U || fields[0] != kNormalizedModelSchemaVersion || fields[1] != kNormalizedSemantic) {
+                set_error(error_message, "configured normalized CN0 model row has incompatible schema/semantic at line " +
+                                             std::to_string(line_number));
+                return false;
+            }
+            if (!parse_common_bin(fields, 2U, 3U, 4U, 5U, 6U, line_number, &bin, error_message) ||
+                !validate_normalized_value(fields, line_number, &bin.support_count, &bin.delta_p50_db, &bin.ready,
+                                           error_message)) {
+                return false;
+            }
+            bin.p50_dbhz = std::numeric_limits<double>::quiet_NaN();
         }
-        loaded.calibrated_bins.push_back(bin);
+        if (!append_validated_bin(&loaded, bin, line_number, error_message)) {
+            return false;
+        }
     }
     if (!input.eof()) {
         set_error(error_message, "failed while reading configured CN0 model");
@@ -596,7 +678,10 @@ bool cn0_model_estimate_dbhz(const Cn0Model& model, SignalId signal_id, double e
             nominal_dbhz = builtin_nominal_dbhz(signal_id, elevation_deg);
             break;
         case Cn0ModelSource::kCalibratedCsv:
-            if (!calibrated_nominal_dbhz(model, signal_id, elevation_deg, &nominal_dbhz)) {
+            if (model.semantic != Cn0ModelSemantic::kAbsoluteStationCn0 ||
+                !calibrated_absolute_nominal_dbhz(model, signal_id, elevation_deg, &nominal_dbhz)) {
+                // NORMALIZED_ELEVATION_SHAPE is intentionally not interpreted as
+                // absolute dB-Hz until the receiver-baseline composition in #107.
                 return false;
             }
             break;
@@ -619,6 +704,18 @@ const char* cn0_model_source_name(Cn0ModelSource source) {
             return "BUILTIN_FALLBACK";
         case Cn0ModelSource::kCalibratedCsv:
             return "CALIBRATED_CSV";
+    }
+    return "UNKNOWN";
+}
+
+const char* cn0_model_semantic_name(Cn0ModelSemantic semantic) {
+    switch (semantic) {
+        case Cn0ModelSemantic::kBuiltinAbsoluteCn0:
+            return "BUILTIN_ABSOLUTE_CN0";
+        case Cn0ModelSemantic::kAbsoluteStationCn0:
+            return "ABSOLUTE_STATION_CN0";
+        case Cn0ModelSemantic::kNormalizedElevationShape:
+            return "NORMALIZED_ELEVATION_SHAPE";
     }
     return "UNKNOWN";
 }

--- a/src/model/cn0_model.cpp
+++ b/src/model/cn0_model.cpp
@@ -475,8 +475,7 @@ bool validate_normalized_value(const std::vector<std::string>& fields, std::size
     }
     if (status == "EMPTY") {
         if (*support_count != 0 || !fields[9].empty()) {
-            set_error(error_message,
-                      "normalized CN0 model EMPTY row has data at line " + std::to_string(line_number));
+            set_error(error_message, "normalized CN0 model EMPTY row has data at line " + std::to_string(line_number));
             return false;
         }
         *delta_p50_db = std::numeric_limits<double>::quiet_NaN();
@@ -484,9 +483,8 @@ bool validate_normalized_value(const std::vector<std::string>& fields, std::size
         return true;
     }
     if (*support_count == 0 || !parse_finite_double(fields[9], delta_p50_db)) {
-        set_error(error_message,
-                  "normalized CN0 model non-empty row lacks finite support/value at line " +
-                      std::to_string(line_number));
+        set_error(error_message, "normalized CN0 model non-empty row lacks finite support/value at line " +
+                                     std::to_string(line_number));
         return false;
     }
     *ready = status == "READY";
@@ -526,8 +524,8 @@ bool append_validated_bin(Cn0Model* loaded, const Cn0CalibratedBin& bin, std::si
     const Cn0CalibratedBin* previous = previous_signal_bin(loaded->calibrated_bins, bin.signal_id);
     if (previous != nullptr) {
         if (bin.elevation_min_deg <= previous->elevation_min_deg + kBinToleranceDeg) {
-            set_error(error_message, "configured CN0 model bins are duplicate/non-monotonic at line " +
-                                         std::to_string(line_number));
+            set_error(error_message,
+                      "configured CN0 model bins are duplicate/non-monotonic at line " + std::to_string(line_number));
             return false;
         }
         if (bin.elevation_min_deg < previous->elevation_max_deg - kBinToleranceDeg) {
@@ -618,8 +616,8 @@ bool load_cn0_model_csv(const char* file_path, std::uint64_t seed, Cn0Model* mod
         Cn0CalibratedBin bin{};
         if (schema == CsvSchema::kAbsoluteV1) {
             if (fields.size() != 24U || fields[0] != kAbsoluteModelSchemaVersion) {
-                set_error(error_message, "configured absolute CN0 model row is incompatible at line " +
-                                             std::to_string(line_number));
+                set_error(error_message,
+                          "configured absolute CN0 model row is incompatible at line " + std::to_string(line_number));
                 return false;
             }
             if (!parse_common_bin(fields, 1U, 2U, 3U, 4U, 5U, line_number, &bin, error_message)) {
@@ -636,9 +634,11 @@ bool load_cn0_model_csv(const char* file_path, std::uint64_t seed, Cn0Model* mod
             bin.delta_p50_db = std::numeric_limits<double>::quiet_NaN();
             bin.ready = fields[6] == "READY";
         } else {
-            if (fields.size() != 10U || fields[0] != kNormalizedModelSchemaVersion || fields[1] != kNormalizedSemantic) {
-                set_error(error_message, "configured normalized CN0 model row has incompatible schema/semantic at line " +
-                                             std::to_string(line_number));
+            if (fields.size() != 10U || fields[0] != kNormalizedModelSchemaVersion ||
+                fields[1] != kNormalizedSemantic) {
+                set_error(error_message,
+                          "configured normalized CN0 model row has incompatible schema/semantic at line " +
+                              std::to_string(line_number));
                 return false;
             }
             if (!parse_common_bin(fields, 2U, 3U, 4U, 5U, 6U, line_number, &bin, error_message) ||

--- a/src/model/cn0_model.h
+++ b/src/model/cn0_model.h
@@ -15,12 +15,21 @@ enum class Cn0ModelSource {
     kCalibratedCsv,
 };
 
+enum class Cn0ModelSemantic {
+    kBuiltinAbsoluteCn0,
+    kAbsoluteStationCn0,
+    kNormalizedElevationShape,
+};
+
 struct Cn0CalibratedBin {
     SignalId signal_id{SignalId::kGpsL1Ca};
     double elevation_min_deg{};
     double elevation_max_deg{};
     double elevation_center_deg{};
+    // Exactly one value is meaningful according to Cn0Model::semantic.
     double p50_dbhz{};
+    double delta_p50_db{};
+    std::uint64_t support_count{};
     bool upper_edge_inclusive{};
     bool ready{};
 };
@@ -34,6 +43,7 @@ struct Cn0ModelIdentity {
 
 struct Cn0Model {
     Cn0ModelSource source{Cn0ModelSource::kBuiltinFallback};
+    Cn0ModelSemantic semantic{Cn0ModelSemantic::kBuiltinAbsoluteCn0};
     std::uint64_t seed{};
     std::vector<Cn0CalibratedBin> calibrated_bins;
     Cn0ModelIdentity identity;
@@ -44,6 +54,7 @@ bool load_cn0_model_csv(const char* file_path, std::uint64_t seed, Cn0Model* mod
 bool cn0_model_estimate_dbhz(const Cn0Model& model, SignalId signal_id, double elevation_deg, const SimTime& time,
                              double* cn0_dbhz);
 const char* cn0_model_source_name(Cn0ModelSource source);
+const char* cn0_model_semantic_name(Cn0ModelSemantic semantic);
 
 } // namespace gnss_sim
 

--- a/tests/unit/test_cn0_model.cpp
+++ b/tests/unit/test_cn0_model.cpp
@@ -50,9 +50,8 @@ std::string model_row(double elevation_min_deg, double elevation_max_deg, bool i
 std::string normalized_model_row(double elevation_min_deg, double elevation_max_deg, bool inclusive, const char* status,
                                  std::uint64_t source_count, const char* delta_p50_db) {
     std::ostringstream output;
-    output << "gnss-cn0-model-v2,NORMALIZED_ELEVATION_SHAPE,GPS,1C," << elevation_min_deg << ','
-           << elevation_max_deg << ',' << (inclusive ? 1 : 0) << ',' << status << ',' << source_count << ','
-           << delta_p50_db;
+    output << "gnss-cn0-model-v2,NORMALIZED_ELEVATION_SHAPE,GPS,1C," << elevation_min_deg << ',' << elevation_max_deg
+           << ',' << (inclusive ? 1 : 0) << ',' << status << ',' << source_count << ',' << delta_p50_db;
     return output.str();
 }
 
@@ -201,8 +200,7 @@ TEST(Cn0Model, ExplicitMalformedModelsFailWithoutFallback) {
         std::string(kModelHeader) +
         "\ngnss-cn0-model-v1,GPS,1C,0,90,1,READY,100,39,39,39,40,41,41,41,40,1,1,1,,,,INSUFFICIENT_SUPPORT,\n";
     const std::string wrong_semantic =
-        std::string(kNormalizedModelHeader) +
-        "\ngnss-cn0-model-v2,ABSOLUTE_STATION_CN0,GPS,1C,0,90,1,READY,2,-1.0\n";
+        std::string(kNormalizedModelHeader) + "\ngnss-cn0-model-v2,ABSOLUTE_STATION_CN0,GPS,1C,0,90,1,READY,2,-1.0\n";
     const std::string cases[] = {std::string("bad-header\n") + valid_row + "\n", duplicate, nonfinite,
                                  missing_delta_statistics, wrong_semantic};
 

--- a/tests/unit/test_cn0_model.cpp
+++ b/tests/unit/test_cn0_model.cpp
@@ -15,6 +15,9 @@ constexpr const char* kModelHeader =
     "schema_version,constellation,signal,elevation_min_deg,elevation_max_deg,upper_edge_inclusive,status,count,"
     "p05_dbhz,p10_dbhz,p25_dbhz,p50_dbhz,p75_dbhz,p90_dbhz,p95_dbhz,mean_dbhz,stddev_dbhz,mad_dbhz,"
     "delta_count,delta_p50_dbhz,delta_p90_dbhz,delta_p99_dbhz,ar1_status,ar1";
+constexpr const char* kNormalizedModelHeader =
+    "schema_version,model_semantic,constellation,signal,elevation_min_deg,elevation_max_deg,upper_edge_inclusive,"
+    "status,contributing_source_count,delta_p50_db";
 
 std::string runtime_model_path() {
     return std::string(GNSS_SIM_TEST_DATA_DIR) + "/runtime_cn0_model.csv";
@@ -41,6 +44,15 @@ std::string model_row(double elevation_min_deg, double elevation_max_deg, bool i
            << ',' << status << ',' << count << ',' << (p50_dbhz - 1.0) << ',' << (p50_dbhz - 1.0) << ','
            << (p50_dbhz - 1.0) << ',' << p50_dbhz << ',' << (p50_dbhz + 1.0) << ',' << (p50_dbhz + 1.0) << ','
            << (p50_dbhz + 1.0) << ',' << p50_dbhz << ",1,1,0,,,,INSUFFICIENT_SUPPORT,";
+    return output.str();
+}
+
+std::string normalized_model_row(double elevation_min_deg, double elevation_max_deg, bool inclusive, const char* status,
+                                 std::uint64_t source_count, const char* delta_p50_db) {
+    std::ostringstream output;
+    output << "gnss-cn0-model-v2,NORMALIZED_ELEVATION_SHAPE,GPS,1C," << elevation_min_deg << ','
+           << elevation_max_deg << ',' << (inclusive ? 1 : 0) << ',' << status << ',' << source_count << ','
+           << delta_p50_db;
     return output.str();
 }
 
@@ -121,6 +133,8 @@ TEST(Cn0Model, CalibratedCentersEdgesAndBetweenCenterInterpolationAreGolden) {
     std::string error;
     ASSERT_TRUE(gnss_sim::load_cn0_model_csv(runtime_model_path().c_str(), 1234U, &model, &error)) << error;
     EXPECT_EQ(model.source, gnss_sim::Cn0ModelSource::kCalibratedCsv);
+    EXPECT_EQ(model.semantic, gnss_sim::Cn0ModelSemantic::kAbsoluteStationCn0);
+    EXPECT_STREQ(gnss_sim::cn0_model_semantic_name(model.semantic), "ABSOLUTE_STATION_CN0");
     EXPECT_EQ(model.identity.schema_version, "gnss-cn0-model-v1");
     EXPECT_EQ(model.identity.file_name, "runtime_cn0_model.csv");
     EXPECT_FALSE(model.identity.hash.empty());
@@ -136,6 +150,27 @@ TEST(Cn0Model, CalibratedCentersEdgesAndBetweenCenterInterpolationAreGolden) {
     EXPECT_NEAR(at_75 - at_45, 10.0, 1e-12);
     EXPECT_NEAR(estimate_model(model, gnss_sim::SignalId::kGpsL1Ca, 0.0, sow) - at_15, 0.0, 1e-12);
     EXPECT_NEAR(estimate_model(model, gnss_sim::SignalId::kGpsL1Ca, 90.0, sow) - at_75, 0.0, 1e-12);
+}
+
+TEST(Cn0Model, NormalizedSchemaIsRecognizedWithoutAbsoluteReinterpretation) {
+    const std::string content = std::string(kNormalizedModelHeader) + "\n" +
+                                normalized_model_row(0.0, 45.0, false, "READY", 3U, "-8.500000") + "\n" +
+                                normalized_model_row(45.0, 90.0, true, "READY", 3U, "-0.500000") + "\n";
+    const TemporaryModel file(content);
+    gnss_sim::Cn0Model model{};
+    std::string error;
+    ASSERT_TRUE(gnss_sim::load_cn0_model_csv(file.path().c_str(), 11U, &model, &error)) << error;
+    EXPECT_EQ(model.semantic, gnss_sim::Cn0ModelSemantic::kNormalizedElevationShape);
+    EXPECT_STREQ(gnss_sim::cn0_model_semantic_name(model.semantic), "NORMALIZED_ELEVATION_SHAPE");
+    EXPECT_EQ(model.identity.schema_version, "gnss-cn0-model-v2");
+    ASSERT_EQ(model.calibrated_bins.size(), 2U);
+    EXPECT_DOUBLE_EQ(model.calibrated_bins[0].delta_p50_db, -8.5);
+    EXPECT_EQ(model.calibrated_bins[0].support_count, 3U);
+
+    gnss_sim::SimTime time{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2300, 100.0, &time));
+    double cn0_dbhz = 0.0;
+    EXPECT_FALSE(gnss_sim::cn0_model_estimate_dbhz(model, gnss_sim::SignalId::kGpsL1Ca, 20.0, time, &cn0_dbhz));
 }
 
 TEST(Cn0Model, MissingSignalAndSparseGapUseExactBuiltinBaselinePolicy) {
@@ -165,8 +200,11 @@ TEST(Cn0Model, ExplicitMalformedModelsFailWithoutFallback) {
     const std::string missing_delta_statistics =
         std::string(kModelHeader) +
         "\ngnss-cn0-model-v1,GPS,1C,0,90,1,READY,100,39,39,39,40,41,41,41,40,1,1,1,,,,INSUFFICIENT_SUPPORT,\n";
+    const std::string wrong_semantic =
+        std::string(kNormalizedModelHeader) +
+        "\ngnss-cn0-model-v2,ABSOLUTE_STATION_CN0,GPS,1C,0,90,1,READY,2,-1.0\n";
     const std::string cases[] = {std::string("bad-header\n") + valid_row + "\n", duplicate, nonfinite,
-                                 missing_delta_statistics};
+                                 missing_delta_statistics, wrong_semantic};
 
     for (const std::string& content : cases) {
         const TemporaryModel file(content);

--- a/tests/unit/test_sim_config.cpp
+++ b/tests/unit/test_sim_config.cpp
@@ -50,6 +50,7 @@ TEST_F(SimConfigTest, FrozenDefaultsAreCentralized) {
     EXPECT_DOUBLE_EQ(config.receiver_clock_drift_mps, 0.0);
     EXPECT_EQ(config.atmosphere_mode, gnss_sim::AtmosphereMode::UNSPECIFIED);
     EXPECT_EQ(config.ttff.startup_mode, gnss_sim::StartupMode::HOT);
+    EXPECT_TRUE(config.cn0_high_dbhz.empty());
 }
 
 TEST_F(SimConfigTest, LoadsValidOverridesWithoutLeakingJsonTypes) {
@@ -62,6 +63,7 @@ TEST_F(SimConfigTest, LoadsValidOverridesWithoutLeakingJsonTypes) {
         "atmosphere_mode": "broadcast",
         "receiver": {"latitude_deg": 21, "longitude_deg": 121, "height_m": 50},
         "ttff": {"startup_mode": "COLD", "power_on_sec": 20, "power_off_sec": 5},
+        "cn0_high_dbhz": {"GPS L1 C/A": 47.25, "Galileo E5a": 49.0},
         "seed": 42
     })json");
 
@@ -75,7 +77,27 @@ TEST_F(SimConfigTest, LoadsValidOverridesWithoutLeakingJsonTypes) {
     EXPECT_DOUBLE_EQ(config.solution_elevation_mask_deg, 7.0);
     EXPECT_EQ(config.atmosphere_mode, gnss_sim::AtmosphereMode::BROADCAST);
     EXPECT_EQ(config.ttff.startup_mode, gnss_sim::StartupMode::COLD);
+    ASSERT_EQ(config.cn0_high_dbhz.size(), 2U);
+    EXPECT_EQ(config.cn0_high_dbhz[0].signal_name, "GPS L1 C/A");
+    EXPECT_DOUBLE_EQ(config.cn0_high_dbhz[0].cn0_dbhz, 47.25);
+    EXPECT_EQ(config.cn0_high_dbhz[1].signal_name, "Galileo E5a");
+    EXPECT_DOUBLE_EQ(config.cn0_high_dbhz[1].cn0_dbhz, 49.0);
     EXPECT_EQ(config.seed, 42U);
+}
+
+TEST_F(SimConfigTest, RejectsUnknownDuplicateAndNonNumericCn0Baselines) {
+    const char* cases[] = {
+        R"json({"cn0_high_dbhz":{"GPS L9":47.0}})json",
+        R"json({"cn0_high_dbhz":{"GPS L1 C/A":47.0,"GPS L1 C/A":48.0}})json",
+        R"json({"cn0_high_dbhz":{"GPS L1 C/A":"47.0"}})json",
+    };
+    for (const char* text : cases) {
+        write_test_config(text);
+        gnss_sim::SimConfig config{};
+        std::string error_message;
+        EXPECT_FALSE(gnss_sim::load_sim_config_json(TEST_CONFIG_PATH, &config, &error_message));
+        EXPECT_NE(error_message.find("cn0_high_dbhz"), std::string::npos) << error_message;
+    }
 }
 
 TEST_F(SimConfigTest, SupportsExplicitNoneWithoutFreezingProjectDefault) {


### PR DESCRIPTION
Implements #105
Parent: #104

Target branch: `integration/issues-103-104`.
This PR must **not** merge directly to `main`. The issue will be closed explicitly after this PR is validated and merged into the integration branch.

## Summary
- preserve `gnss-cn0-model-v1` as explicit `ABSOLUTE_STATION_CN0`
- introduce `gnss-cn0-model-v2` / `NORMALIZED_ELEVATION_SHAPE` without silently reinterpreting legacy files
- add receiver/antenna `cn0_high_dbhz` configuration keyed by central `SignalDefinition::name`
- keep receiver-specific baseline defaults empty so production CN0 levels must be calibrated/configured, not fabricated
- document schema/compatibility semantics

## Implementation Notes
- v1 keeps the existing 24-column absolute-station CSV contract unchanged
- v2 uses a compact 10-column normalized contract with `contributing_source_count` and `delta_p50_db`
- #105 deliberately does **not** compose normalized deltas into absolute dB-Hz; `cn0_model_estimate_dbhz()` rejects normalized semantics until #107 supplies the receiver baseline
- malformed/unknown schema, semantic, signal, duplicate baseline, and non-finite baseline inputs fail deterministically
- no RINEX OBS/NAV or ephemeris behavior is changed

## Validation
Focused unit coverage was added for legacy semantic preservation, v2 semantic recognition, no absolute reinterpretation, and receiver-baseline configuration validation. GitHub Actions is the authoritative build/test run for this connector-authored change.