### PR TITLE
Implement deterministic rooftop Fresnel diffraction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,7 @@ add_library(gnss_sim_core STATIC
     src/model/receiver_truth.cpp
     src/model/signal_tracking.cpp
     src/model/urban_reflection_paths.cpp
+    src/model/urban_rooftop_diffraction.cpp
     src/model/urban_rf_model.cpp
     src/model/urban_scene_geometry.cpp
     src/output/novatel_nav_writer.cpp
@@ -258,6 +259,7 @@ if(BUILD_TESTING)
         tests/unit/test_solution_engine.cpp
         tests/unit/test_solution_signal_policy.cpp
         tests/unit/test_urban_reflection_paths.cpp
+        tests/unit/test_urban_rooftop_diffraction.cpp
         tests/unit/test_urban_rf_model.cpp
         tests/unit/test_urban_scene_geometry.cpp
     )

--- a/docs/URBAN_ROOFTOP_DIFFRACTION.md
+++ b/docs/URBAN_ROOFTOP_DIFFRACTION.md
@@ -1,0 +1,130 @@
+# Urban Rooftop Diffraction Model
+
+This document freezes the V1 single-rooftop diffraction contract implemented for Issue #118.
+
+## Scope
+
+The model represents the roof-affected direct component at the **actual first blocking wall** selected by `urban_scene_geometry`. It does not add an independent full-strength direct path plus an independent full-strength diffracted path. The Fresnel result is the transition field itself.
+
+V1 excludes double-edge diffraction, UTD, finite roof width, and a full electromagnetic solver.
+
+## Input geometry
+
+Satellite state, azimuth/elevation, and RTKLIB geometric range are taken from the already-converged `SatelliteGeometry`. No second satellite-state solution is performed and no NAV/EPH/ION record is generated, modified, interpolated, or retargeted.
+
+The local finite source is reconstructed using the same contract as first-order reflections:
+
+- receiver ENU: `R = (0, 0, antenna_height)`;
+- Euclidean satellite distance: `D0 = |S_ecef - R_ecef|`;
+- ENU direction from the existing azimuth/elevation;
+- satellite ENU: `S = R + D0 * u_enu`.
+
+The roof edge is the infinite line from the `UrbanWallPlane` of the direct path's `primary_wall`:
+
+`E(q) = E0 + q * t`,
+
+where `E0` is `roof_edge_anchor_enu_m` and `t` is the unit roof-edge direction.
+
+## Deterministic 3-D equivalent diffraction point
+
+For a point `X`, define its coordinate and perpendicular radius relative to the roof edge:
+
+`q_X = dot(X - E0, t)`
+
+`r_X = |(X - E0) - q_X t|`.
+
+The unique point that minimizes `|S-Q| + |Q-R|` along the infinite edge is
+
+`q_Q = (r_R q_S + r_S q_R) / (r_S + r_R)`
+
+`Q = E0 + q_Q t`.
+
+The two edge legs are
+
+`d_S = |S-Q|`, `d_R = |R-Q|`,
+
+and the explicit edge-path length is
+
+`L_edge = d_S + d_R`.
+
+## Stable excess path
+
+Directly subtracting two approximately 20,000 km path lengths is numerically weak near roof grazing. The implementation therefore uses an algebraically equivalent non-negative form.
+
+Let `u_S` and `u_R` be unit vectors from `Q` toward the satellite and receiver. Then
+
+`DeltaL = d_S d_R |u_S + u_R|^2 / (L_edge + D0)`.
+
+At exact grazing, `u_S = -u_R`, so `DeltaL = 0` without catastrophic cancellation.
+
+The RTKLIB/Sagnac-safe modeled path is then
+
+`L_model = SatelliteGeometry.geometric_range_m + DeltaL`.
+
+The RTKLIB corrected direct range is never subtracted from a Euclidean edge path.
+
+## Signed Fresnel clearance and parameter
+
+The clearance magnitude is the shortest distance between the infinite direct ray line and the infinite roof-edge line. Its sign follows the direct roof-clearance classification from `urban_scene_geometry`:
+
+- positive: edge intrudes into the direct path / shadow side;
+- zero: roof grazing;
+- negative: direct ray clears the roof.
+
+The equivalent knife-edge parameter uses the exact excess path and actual signal wavelength:
+
+`v = sign(clearance) * sqrt(2 DeltaL / lambda)`.
+
+This is equivalent to the usual paraxial knife-edge relation near the transition while remaining directly tied to the exact 3-D edge geometry.
+
+Carrier frequency and wavelength come only from the central `SignalDefinition` helpers, including GLONASS FDMA FCN handling.
+
+## Complex Fresnel coefficient
+
+The repository convention is
+
+- time dependence: `exp(+j omega t)`;
+- propagation: `exp(-j k L)`.
+
+With Fresnel integrals
+
+`C(v) = integral_0^v cos(pi t^2 / 2) dt`
+
+`S(v) = integral_0^v sin(pi t^2 / 2) dt`,
+
+the direct-referenced knife-edge coefficient is
+
+`F(v) = (1+j)/2 * [(1/2-C(v)) - j(1/2-S(v))]`.
+
+It satisfies the required anchors:
+
+- `v -> -infinity`: `F(v) -> 1`;
+- `v = 0`: `F(0) = 0.5`, which is `6.0206 dB` amplitude loss;
+- increasing positive `v`: increasing deep-shadow attenuation;
+- amplitude and phase vary continuously through `v = 0`.
+
+The implementation evaluates the Fresnel integrals deterministically with a convergent power series for small arguments and a continued-fraction representation for larger arguments.
+
+## Phase-reference contract and no double counting
+
+`fresnel_coefficient` is referenced to the unobstructed direct phase. Therefore later coherent composition may use it directly as the roof transfer factor relative to the direct field.
+
+For diagnostics and future path-rate work, the module also exposes
+
+`G_edge = exp(-j 2 pi DeltaL / lambda)`
+
+and an edge-referenced coefficient
+
+`F_edge = F(v) * conj(G_edge)`.
+
+The identity
+
+`F_edge * G_edge = F(v)`
+
+is regression-tested. This prevents the Fresnel phase from being counted a second time by blindly multiplying `F(v)` by another full `exp(-j k DeltaL)` term.
+
+## Integration boundary
+
+Issue #118 stops at propagation-layer outputs: roof edge, equivalent point/path, excess delay, signed clearance, `v`, complex coefficient, and phase references.
+
+It does **not** implement DLL bias, coherent CN0 composition, tracking state transitions, pseudorange/Doppler/ADR synthesis, or final RANGE output. Those remain owned by later #119-#123 work.

--- a/docs/URBAN_ROOFTOP_DIFFRACTION.md
+++ b/docs/URBAN_ROOFTOP_DIFFRACTION.md
@@ -65,17 +65,25 @@ The RTKLIB corrected direct range is never subtracted from a Euclidean edge path
 
 ## Signed Fresnel clearance and parameter
 
-The clearance magnitude is the shortest distance between the infinite direct ray line and the infinite roof-edge line. Its sign follows the direct roof-clearance classification from `urban_scene_geometry`:
+The clearance magnitude `h` is the shortest distance between the infinite direct ray line and the infinite roof-edge line. Its sign follows the direct roof-clearance classification from `urban_scene_geometry`:
 
 - positive: edge intrudes into the direct path / shadow side;
 - zero: roof grazing;
 - negative: direct ray clears the roof.
 
-The equivalent knife-edge parameter uses the exact excess path and actual signal wavelength:
+Using the two stationary edge-leg distances and the actual signal wavelength, the standard knife-edge Fresnel parameter is
 
-`v = sign(clearance) * sqrt(2 DeltaL / lambda)`.
+`v = h * sqrt(2 (d_S + d_R) / (lambda d_S d_R))`.
 
-This is equivalent to the usual paraxial knife-edge relation near the transition while remaining directly tied to the exact 3-D edge geometry.
+This normalization is consistent with the Fresnel integrals used below. In the paraxial limit,
+
+`DeltaL ~= h^2 (d_S + d_R) / (2 d_S d_R)`
+
+and therefore
+
+`v^2 ~= 4 DeltaL / lambda`.
+
+This relation is regression-tested so a factor-of-two normalization error cannot silently change diffraction attenuation.
 
 Carrier frequency and wavelength come only from the central `SignalDefinition` helpers, including GLONASS FDMA FCN handling.
 

--- a/src/model/urban_rooftop_diffraction.cpp
+++ b/src/model/urban_rooftop_diffraction.cpp
@@ -364,17 +364,17 @@ bool compute_urban_rooftop_diffraction(const UrbanSceneGeometryConfig& scene_con
         return false;
     }
 
-    const double fresnel_magnitude = std::sqrt(2.0 * result.excess_path_length_m / wavelength_m);
-    if (!std::isfinite(fresnel_magnitude)) {
-        set_error(error_message, "urban rooftop Fresnel parameter magnitude is non-finite");
+    const double fresnel_scale =
+        std::sqrt(2.0 * result.edge_path_euclidean_range_m /
+                  (wavelength_m * result.source_edge_distance_m * result.receiver_edge_distance_m));
+    if (!finite_positive(fresnel_scale)) {
+        set_error(error_message, "urban rooftop Fresnel parameter scale is invalid");
         return false;
     }
-    if (result.signed_clearance_m > 0.0) {
-        result.fresnel_v = fresnel_magnitude;
-    } else if (result.signed_clearance_m < 0.0) {
-        result.fresnel_v = -fresnel_magnitude;
-    } else {
-        result.fresnel_v = 0.0;
+    result.fresnel_v = result.signed_clearance_m * fresnel_scale;
+    if (!std::isfinite(result.fresnel_v)) {
+        set_error(error_message, "urban rooftop Fresnel parameter is non-finite");
+        return false;
     }
 
     if (!compute_complex_knife_edge_coefficient(result.fresnel_v, &result.fresnel_coefficient, error_message)) {

--- a/src/model/urban_rooftop_diffraction.cpp
+++ b/src/model/urban_rooftop_diffraction.cpp
@@ -1,0 +1,410 @@
+#include "model/urban_rooftop_diffraction.h"
+
+#include "model/urban_reflection_paths.h"
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+
+namespace gnss_sim {
+namespace {
+
+constexpr double kPi = 3.141592653589793238462643383279502884;
+constexpr double kSpeedOfLightMps = 299792458.0;
+constexpr double kDirectionTolerance = 1.0e-12;
+constexpr double kExcessToleranceM = 1.0e-9;
+constexpr double kFresnelSeriesLimit = 1.5;
+constexpr int kFresnelMaxIterations = 100;
+constexpr double kFresnelEpsilon = 1.0e-14;
+constexpr double kFresnelMin = 1.0e-300;
+
+void set_error(std::string* error_message, const char* message) {
+    if (error_message != nullptr) {
+        *error_message = message;
+    }
+}
+
+bool finite_positive(double value) {
+    return std::isfinite(value) && value > 0.0;
+}
+
+bool finite_point(const EnuPoint& point) {
+    return std::isfinite(point.east_m) && std::isfinite(point.north_m) && std::isfinite(point.up_m);
+}
+
+bool finite_complex(const std::complex<double>& value) {
+    return std::isfinite(value.real()) && std::isfinite(value.imag());
+}
+
+void point_difference(const EnuPoint& left, const EnuPoint& right, double difference[3]) {
+    difference[0] = left.east_m - right.east_m;
+    difference[1] = left.north_m - right.north_m;
+    difference[2] = left.up_m - right.up_m;
+}
+
+double dot3(const double left[3], const double right[3]) {
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2];
+}
+
+void cross3(const double left[3], const double right[3], double result[3]) {
+    result[0] = left[1] * right[2] - left[2] * right[1];
+    result[1] = left[2] * right[0] - left[0] * right[2];
+    result[2] = left[0] * right[1] - left[1] * right[0];
+}
+
+double norm3(const double value[3]) {
+    return std::sqrt(dot3(value, value));
+}
+
+EnuPoint add_scaled(const EnuPoint& point, const double direction[3], double scale) {
+    return {point.east_m + direction[0] * scale, point.north_m + direction[1] * scale,
+            point.up_m + direction[2] * scale};
+}
+
+bool unit_direction(const EnuPoint& from, const EnuPoint& to, double direction[3], double* distance_m) {
+    if (direction == nullptr || distance_m == nullptr) {
+        return false;
+    }
+    double difference[3]{};
+    point_difference(to, from, difference);
+    const double distance = norm3(difference);
+    if (!finite_positive(distance)) {
+        return false;
+    }
+    for (int index = 0; index < 3; ++index) {
+        direction[index] = difference[index] / distance;
+    }
+    *distance_m = distance;
+    return true;
+}
+
+bool fresnel_integrals(double argument, double* cosine_integral, double* sine_integral) {
+    if (cosine_integral == nullptr || sine_integral == nullptr || !std::isfinite(argument)) {
+        return false;
+    }
+
+    const double absolute_argument = std::fabs(argument);
+    double sine_value = 0.0;
+    double cosine_value = 0.0;
+
+    if (absolute_argument < std::sqrt(kFresnelMin)) {
+        cosine_value = absolute_argument;
+    } else if (absolute_argument <= kFresnelSeriesLimit) {
+        double sum = 0.0;
+        double sine_sum = 0.0;
+        double cosine_sum = absolute_argument;
+        double sign = 1.0;
+        const double factor = 0.5 * kPi * absolute_argument * absolute_argument;
+        bool odd_term = true;
+        double term = absolute_argument;
+        int denominator = 3;
+
+        for (int iteration = 1; iteration <= kFresnelMaxIterations; ++iteration) {
+            term *= factor / static_cast<double>(iteration);
+            sum += sign * term / static_cast<double>(denominator);
+            const double convergence = std::max(1.0, std::fabs(sum)) * kFresnelEpsilon;
+            if (odd_term) {
+                sign = -sign;
+                sine_sum = sum;
+                sum = cosine_sum;
+            } else {
+                cosine_sum = sum;
+                sum = sine_sum;
+            }
+            if (std::fabs(term) <= convergence) {
+                break;
+            }
+            odd_term = !odd_term;
+            denominator += 2;
+        }
+        sine_value = sine_sum;
+        cosine_value = cosine_sum;
+    } else {
+        const double pi_x_squared = kPi * absolute_argument * absolute_argument;
+        std::complex<double> b(1.0, -pi_x_squared);
+        std::complex<double> c(1.0 / kFresnelMin, 0.0);
+        std::complex<double> d = 1.0 / b;
+        std::complex<double> h = d;
+        int odd_index = -1;
+
+        for (int iteration = 2; iteration <= kFresnelMaxIterations; ++iteration) {
+            odd_index += 2;
+            const double a = -static_cast<double>(odd_index * (odd_index + 1));
+            b += std::complex<double>(4.0, 0.0);
+            d = 1.0 / (a * d + b);
+            c = b + a / c;
+            const std::complex<double> delta = c * d;
+            h *= delta;
+            if (std::fabs(delta.real() - 1.0) + std::fabs(delta.imag()) <= kFresnelEpsilon) {
+                break;
+            }
+        }
+
+        h *= std::complex<double>(absolute_argument, -absolute_argument);
+        const std::complex<double> phase = std::exp(std::complex<double>(0.0, 0.5 * pi_x_squared));
+        const std::complex<double> integrals =
+            std::complex<double>(0.5, 0.5) * (std::complex<double>(1.0, 0.0) - phase * h);
+        cosine_value = integrals.real();
+        sine_value = integrals.imag();
+    }
+
+    if (argument < 0.0) {
+        cosine_value = -cosine_value;
+        sine_value = -sine_value;
+    }
+    if (!std::isfinite(cosine_value) || !std::isfinite(sine_value)) {
+        return false;
+    }
+    *cosine_integral = cosine_value;
+    *sine_integral = sine_value;
+    return true;
+}
+
+bool edge_coordinate_and_radius(const EnuPoint& point, const EnuPoint& edge_anchor, const double edge_direction[3],
+                                double* edge_coordinate_m, double* perpendicular_radius_m) {
+    if (edge_coordinate_m == nullptr || perpendicular_radius_m == nullptr) {
+        return false;
+    }
+    double relative[3]{};
+    point_difference(point, edge_anchor, relative);
+    const double coordinate = dot3(relative, edge_direction);
+    double perpendicular[3]{};
+    for (int index = 0; index < 3; ++index) {
+        perpendicular[index] = relative[index] - coordinate * edge_direction[index];
+    }
+    const double radius = norm3(perpendicular);
+    if (!std::isfinite(coordinate) || !finite_positive(radius)) {
+        return false;
+    }
+    *edge_coordinate_m = coordinate;
+    *perpendicular_radius_m = radius;
+    return true;
+}
+
+bool compute_signed_edge_clearance(const EnuPoint& receiver_enu_m, const EnuPoint& satellite_enu_m,
+                                   const UrbanWallPlane& wall, const UrbanDirectPathGeometry& direct_geometry,
+                                   double* signed_clearance_m) {
+    if (signed_clearance_m == nullptr) {
+        return false;
+    }
+
+    double direct_direction[3]{};
+    double direct_distance_m = 0.0;
+    if (!unit_direction(receiver_enu_m, satellite_enu_m, direct_direction, &direct_distance_m)) {
+        return false;
+    }
+    (void)direct_distance_m;
+
+    double normal_to_lines[3]{};
+    cross3(direct_direction, wall.roof_edge_direction_enu, normal_to_lines);
+    const double normal_length = norm3(normal_to_lines);
+    if (!finite_positive(normal_length) || normal_length <= kDirectionTolerance) {
+        return false;
+    }
+
+    double edge_offset[3]{};
+    point_difference(wall.roof_edge_anchor_enu_m, receiver_enu_m, edge_offset);
+    const double clearance_abs = std::fabs(dot3(edge_offset, normal_to_lines)) / normal_length;
+    if (!std::isfinite(clearance_abs)) {
+        return false;
+    }
+
+    if (direct_geometry.grazing_roof || clearance_abs <= kDirectionTolerance) {
+        *signed_clearance_m = 0.0;
+    } else if (direct_geometry.roof_clearance_m < 0.0) {
+        *signed_clearance_m = clearance_abs;
+    } else {
+        *signed_clearance_m = -clearance_abs;
+    }
+    return true;
+}
+
+} // namespace
+
+bool compute_complex_knife_edge_coefficient(double fresnel_v, std::complex<double>* coefficient,
+                                            std::string* error_message) {
+    if (coefficient == nullptr || !std::isfinite(fresnel_v)) {
+        set_error(error_message, "knife-edge Fresnel coefficient request is invalid");
+        return false;
+    }
+
+    double cosine_integral = 0.0;
+    double sine_integral = 0.0;
+    if (!fresnel_integrals(fresnel_v, &cosine_integral, &sine_integral)) {
+        set_error(error_message, "knife-edge Fresnel integral evaluation failed");
+        return false;
+    }
+
+    const std::complex<double> tail(0.5 - cosine_integral, -(0.5 - sine_integral));
+    const std::complex<double> result = 0.5 * std::complex<double>(1.0, 1.0) * tail;
+    if (!finite_complex(result)) {
+        set_error(error_message, "knife-edge Fresnel coefficient is non-finite");
+        return false;
+    }
+    *coefficient = result;
+    return true;
+}
+
+bool compute_urban_rooftop_diffraction(const UrbanSceneGeometryConfig& scene_config,
+                                       const SignalDefinition& signal, int glonass_fcn,
+                                       const ReceiverTruth& receiver, const SatelliteGeometry& satellite_geometry,
+                                       UrbanRooftopDiffractionPath* diffraction,
+                                       UrbanRooftopDiffractionStatus* status, std::string* error_message) {
+    if (diffraction == nullptr || status == nullptr || !validate_urban_scene_geometry_config(scene_config, error_message) ||
+        !finite_positive(satellite_geometry.geometric_range_m)) {
+        set_error(error_message, "urban rooftop diffraction request is invalid");
+        return false;
+    }
+
+    double carrier_frequency_hz = 0.0;
+    double wavelength_m = 0.0;
+    if (!signal_carrier_frequency_hz(signal, glonass_fcn, &carrier_frequency_hz) ||
+        !signal_wavelength_m(signal, glonass_fcn, &wavelength_m)) {
+        set_error(error_message, "urban rooftop diffraction signal frequency/wavelength resolution failed");
+        return false;
+    }
+
+    UrbanRooftopDiffractionPath result{};
+    if (!reconstruct_urban_satellite_enu(scene_config, receiver, satellite_geometry, &result.receiver_enu_m,
+                                         &result.satellite_enu_m, &result.direct_euclidean_range_m, error_message)) {
+        return false;
+    }
+    result.direct_model_range_m = satellite_geometry.geometric_range_m;
+    result.carrier_frequency_hz = carrier_frequency_hz;
+    result.wavelength_m = wavelength_m;
+
+    UrbanDirectPathGeometry direct_geometry{};
+    if (!compute_urban_direct_path_geometry(scene_config, satellite_geometry.azimuth_rad,
+                                            satellite_geometry.elevation_rad, &direct_geometry, error_message)) {
+        return false;
+    }
+    if (!direct_geometry.above_local_horizon) {
+        *diffraction = result;
+        *status = UrbanRooftopDiffractionStatus::BELOW_LOCAL_HORIZON;
+        return true;
+    }
+    if (direct_geometry.primary_wall == UrbanWallId::NONE || direct_geometry.first_wall_count <= 0) {
+        *diffraction = result;
+        *status = UrbanRooftopDiffractionStatus::NO_BLOCKING_ROOF_EDGE;
+        return true;
+    }
+
+    UrbanWallPlane wall{};
+    if (!urban_wall_plane(scene_config, direct_geometry.primary_wall, &wall, error_message)) {
+        return false;
+    }
+    const double edge_direction_norm = norm3(wall.roof_edge_direction_enu);
+    if (!std::isfinite(edge_direction_norm) || std::fabs(edge_direction_norm - 1.0) > kDirectionTolerance) {
+        set_error(error_message, "urban rooftop edge direction is not unit length");
+        return false;
+    }
+
+    double source_coordinate_m = 0.0;
+    double receiver_coordinate_m = 0.0;
+    double source_radius_m = 0.0;
+    double receiver_radius_m = 0.0;
+    if (!edge_coordinate_and_radius(result.satellite_enu_m, wall.roof_edge_anchor_enu_m,
+                                    wall.roof_edge_direction_enu, &source_coordinate_m, &source_radius_m) ||
+        !edge_coordinate_and_radius(result.receiver_enu_m, wall.roof_edge_anchor_enu_m,
+                                    wall.roof_edge_direction_enu, &receiver_coordinate_m, &receiver_radius_m)) {
+        set_error(error_message, "urban rooftop equivalent-edge geometry is degenerate");
+        return false;
+    }
+
+    const double radius_sum_m = source_radius_m + receiver_radius_m;
+    if (!finite_positive(radius_sum_m)) {
+        set_error(error_message, "urban rooftop equivalent-edge radius sum is invalid");
+        return false;
+    }
+    const double diffraction_coordinate_m =
+        (receiver_radius_m * source_coordinate_m + source_radius_m * receiver_coordinate_m) / radius_sum_m;
+    result.diffraction_point_enu_m =
+        add_scaled(wall.roof_edge_anchor_enu_m, wall.roof_edge_direction_enu, diffraction_coordinate_m);
+    if (!finite_point(result.diffraction_point_enu_m)) {
+        set_error(error_message, "urban rooftop equivalent diffraction point is non-finite");
+        return false;
+    }
+
+    double source_direction[3]{};
+    double receiver_direction[3]{};
+    if (!unit_direction(result.diffraction_point_enu_m, result.satellite_enu_m, source_direction,
+                        &result.source_edge_distance_m) ||
+        !unit_direction(result.diffraction_point_enu_m, result.receiver_enu_m, receiver_direction,
+                        &result.receiver_edge_distance_m)) {
+        set_error(error_message, "urban rooftop edge-leg geometry is invalid");
+        return false;
+    }
+
+    result.edge_path_euclidean_range_m = result.source_edge_distance_m + result.receiver_edge_distance_m;
+    double direction_sum_squared = 0.0;
+    for (int index = 0; index < 3; ++index) {
+        const double sum = source_direction[index] + receiver_direction[index];
+        direction_sum_squared += sum * sum;
+    }
+    const double excess_denominator_m = result.edge_path_euclidean_range_m + result.direct_euclidean_range_m;
+    if (!finite_positive(excess_denominator_m) || !std::isfinite(direction_sum_squared) ||
+        direction_sum_squared < 0.0) {
+        set_error(error_message, "urban rooftop stable excess-path geometry is invalid");
+        return false;
+    }
+    result.excess_path_length_m = result.source_edge_distance_m * result.receiver_edge_distance_m *
+                                  direction_sum_squared / excess_denominator_m;
+    if (!std::isfinite(result.excess_path_length_m) || result.excess_path_length_m < -kExcessToleranceM) {
+        set_error(error_message, "urban rooftop excess-path calculation is invalid");
+        return false;
+    }
+    result.excess_path_length_m = std::max(0.0, result.excess_path_length_m);
+    result.model_path_range_m = result.direct_model_range_m + result.excess_path_length_m;
+    result.excess_delay_sec = result.excess_path_length_m / kSpeedOfLightMps;
+
+    if (!compute_signed_edge_clearance(result.receiver_enu_m, result.satellite_enu_m, wall, direct_geometry,
+                                       &result.signed_clearance_m)) {
+        set_error(error_message, "urban rooftop signed Fresnel clearance calculation failed");
+        return false;
+    }
+
+    const double fresnel_magnitude = std::sqrt(2.0 * result.excess_path_length_m / wavelength_m);
+    if (!std::isfinite(fresnel_magnitude)) {
+        set_error(error_message, "urban rooftop Fresnel parameter magnitude is non-finite");
+        return false;
+    }
+    if (result.signed_clearance_m > 0.0) {
+        result.fresnel_v = fresnel_magnitude;
+    } else if (result.signed_clearance_m < 0.0) {
+        result.fresnel_v = -fresnel_magnitude;
+    } else {
+        result.fresnel_v = 0.0;
+    }
+
+    if (!compute_complex_knife_edge_coefficient(result.fresnel_v, &result.fresnel_coefficient, error_message)) {
+        return false;
+    }
+    result.excess_carrier_phase_rad = -2.0 * kPi * result.excess_path_length_m / wavelength_m;
+    result.edge_geometric_phase_factor = std::polar(1.0, result.excess_carrier_phase_rad);
+    result.edge_reference_coefficient = result.fresnel_coefficient * std::conj(result.edge_geometric_phase_factor);
+    if (!std::isfinite(result.model_path_range_m) || !std::isfinite(result.excess_delay_sec) ||
+        !std::isfinite(result.excess_carrier_phase_rad) || !finite_complex(result.edge_geometric_phase_factor) ||
+        !finite_complex(result.edge_reference_coefficient)) {
+        set_error(error_message, "urban rooftop diffraction phase/delay result is non-finite");
+        return false;
+    }
+
+    result.wall_id = direct_geometry.primary_wall;
+    *diffraction = result;
+    *status = UrbanRooftopDiffractionStatus::VALID;
+    return true;
+}
+
+const char* urban_rooftop_diffraction_status_name(UrbanRooftopDiffractionStatus status) {
+    switch (status) {
+        case UrbanRooftopDiffractionStatus::VALID:
+            return "VALID";
+        case UrbanRooftopDiffractionStatus::BELOW_LOCAL_HORIZON:
+            return "BELOW_LOCAL_HORIZON";
+        case UrbanRooftopDiffractionStatus::NO_BLOCKING_ROOF_EDGE:
+            return "NO_BLOCKING_ROOF_EDGE";
+    }
+    return "UNKNOWN";
+}
+
+} // namespace gnss_sim

--- a/src/model/urban_rooftop_diffraction.cpp
+++ b/src/model/urban_rooftop_diffraction.cpp
@@ -245,12 +245,13 @@ bool compute_complex_knife_edge_coefficient(double fresnel_v, std::complex<doubl
     return true;
 }
 
-bool compute_urban_rooftop_diffraction(const UrbanSceneGeometryConfig& scene_config,
-                                       const SignalDefinition& signal, int glonass_fcn,
-                                       const ReceiverTruth& receiver, const SatelliteGeometry& satellite_geometry,
-                                       UrbanRooftopDiffractionPath* diffraction,
-                                       UrbanRooftopDiffractionStatus* status, std::string* error_message) {
-    if (diffraction == nullptr || status == nullptr || !validate_urban_scene_geometry_config(scene_config, error_message) ||
+bool compute_urban_rooftop_diffraction(const UrbanSceneGeometryConfig& scene_config, const SignalDefinition& signal,
+                                       int glonass_fcn, const ReceiverTruth& receiver,
+                                       const SatelliteGeometry& satellite_geometry,
+                                       UrbanRooftopDiffractionPath* diffraction, UrbanRooftopDiffractionStatus* status,
+                                       std::string* error_message) {
+    if (diffraction == nullptr || status == nullptr ||
+        !validate_urban_scene_geometry_config(scene_config, error_message) ||
         !finite_positive(satellite_geometry.geometric_range_m)) {
         set_error(error_message, "urban rooftop diffraction request is invalid");
         return false;
@@ -303,10 +304,10 @@ bool compute_urban_rooftop_diffraction(const UrbanSceneGeometryConfig& scene_con
     double receiver_coordinate_m = 0.0;
     double source_radius_m = 0.0;
     double receiver_radius_m = 0.0;
-    if (!edge_coordinate_and_radius(result.satellite_enu_m, wall.roof_edge_anchor_enu_m,
-                                    wall.roof_edge_direction_enu, &source_coordinate_m, &source_radius_m) ||
-        !edge_coordinate_and_radius(result.receiver_enu_m, wall.roof_edge_anchor_enu_m,
-                                    wall.roof_edge_direction_enu, &receiver_coordinate_m, &receiver_radius_m)) {
+    if (!edge_coordinate_and_radius(result.satellite_enu_m, wall.roof_edge_anchor_enu_m, wall.roof_edge_direction_enu,
+                                    &source_coordinate_m, &source_radius_m) ||
+        !edge_coordinate_and_radius(result.receiver_enu_m, wall.roof_edge_anchor_enu_m, wall.roof_edge_direction_enu,
+                                    &receiver_coordinate_m, &receiver_radius_m)) {
         set_error(error_message, "urban rooftop equivalent-edge geometry is degenerate");
         return false;
     }
@@ -347,8 +348,8 @@ bool compute_urban_rooftop_diffraction(const UrbanSceneGeometryConfig& scene_con
         set_error(error_message, "urban rooftop stable excess-path geometry is invalid");
         return false;
     }
-    result.excess_path_length_m = result.source_edge_distance_m * result.receiver_edge_distance_m *
-                                  direction_sum_squared / excess_denominator_m;
+    result.excess_path_length_m =
+        result.source_edge_distance_m * result.receiver_edge_distance_m * direction_sum_squared / excess_denominator_m;
     if (!std::isfinite(result.excess_path_length_m) || result.excess_path_length_m < -kExcessToleranceM) {
         set_error(error_message, "urban rooftop excess-path calculation is invalid");
         return false;

--- a/src/model/urban_rooftop_diffraction.h
+++ b/src/model/urban_rooftop_diffraction.h
@@ -51,11 +51,11 @@ bool compute_complex_knife_edge_coefficient(double fresnel_v, std::complex<doubl
 // Compute the roof-affected direct component for the actual first blocking
 // wall selected by #115 geometry. A non-applicable edge is reported through
 // status and is not a model failure.
-bool compute_urban_rooftop_diffraction(const UrbanSceneGeometryConfig& scene_config,
-                                       const SignalDefinition& signal, int glonass_fcn,
-                                       const ReceiverTruth& receiver, const SatelliteGeometry& satellite_geometry,
-                                       UrbanRooftopDiffractionPath* diffraction,
-                                       UrbanRooftopDiffractionStatus* status, std::string* error_message);
+bool compute_urban_rooftop_diffraction(const UrbanSceneGeometryConfig& scene_config, const SignalDefinition& signal,
+                                       int glonass_fcn, const ReceiverTruth& receiver,
+                                       const SatelliteGeometry& satellite_geometry,
+                                       UrbanRooftopDiffractionPath* diffraction, UrbanRooftopDiffractionStatus* status,
+                                       std::string* error_message);
 
 const char* urban_rooftop_diffraction_status_name(UrbanRooftopDiffractionStatus status);
 

--- a/src/model/urban_rooftop_diffraction.h
+++ b/src/model/urban_rooftop_diffraction.h
@@ -1,0 +1,64 @@
+#ifndef GNSS_SIM_SRC_MODEL_URBAN_ROOFTOP_DIFFRACTION_H_
+#define GNSS_SIM_SRC_MODEL_URBAN_ROOFTOP_DIFFRACTION_H_
+
+#include "gnss/satellite_engine.h"
+#include "gnss/signal_definitions.h"
+#include "model/receiver_truth.h"
+#include "model/urban_scene_geometry.h"
+
+#include <complex>
+#include <string>
+
+namespace gnss_sim {
+
+enum class UrbanRooftopDiffractionStatus {
+    VALID = 0,
+    BELOW_LOCAL_HORIZON,
+    NO_BLOCKING_ROOF_EDGE,
+};
+
+struct UrbanRooftopDiffractionPath {
+    UrbanWallId wall_id;
+    EnuPoint satellite_enu_m;
+    EnuPoint receiver_enu_m;
+    EnuPoint diffraction_point_enu_m;
+    double direct_euclidean_range_m;
+    double edge_path_euclidean_range_m;
+    double direct_model_range_m;
+    double model_path_range_m;
+    double excess_path_length_m;
+    double excess_delay_sec;
+    double source_edge_distance_m;
+    double receiver_edge_distance_m;
+    double signed_clearance_m;
+    double fresnel_v;
+    double carrier_frequency_hz;
+    double wavelength_m;
+    double excess_carrier_phase_rad;
+    std::complex<double> edge_geometric_phase_factor;
+    std::complex<double> fresnel_coefficient;
+    std::complex<double> edge_reference_coefficient;
+};
+
+// Complex scalar knife-edge field coefficient referenced to the unobstructed
+// direct field. With the repository exp(+j*w*t), exp(-j*k*L) convention:
+//   v -> -infinity : coefficient -> 1
+//   v = 0           : coefficient = 0.5  (~6.02 dB loss)
+//   v -> +infinity : coefficient -> 0
+bool compute_complex_knife_edge_coefficient(double fresnel_v, std::complex<double>* coefficient,
+                                            std::string* error_message);
+
+// Compute the roof-affected direct component for the actual first blocking
+// wall selected by #115 geometry. A non-applicable edge is reported through
+// status and is not a model failure.
+bool compute_urban_rooftop_diffraction(const UrbanSceneGeometryConfig& scene_config,
+                                       const SignalDefinition& signal, int glonass_fcn,
+                                       const ReceiverTruth& receiver, const SatelliteGeometry& satellite_geometry,
+                                       UrbanRooftopDiffractionPath* diffraction,
+                                       UrbanRooftopDiffractionStatus* status, std::string* error_message);
+
+const char* urban_rooftop_diffraction_status_name(UrbanRooftopDiffractionStatus status);
+
+} // namespace gnss_sim
+
+#endif // GNSS_SIM_SRC_MODEL_URBAN_ROOFTOP_DIFFRACTION_H_

--- a/tests/unit/test_urban_rooftop_diffraction.cpp
+++ b/tests/unit/test_urban_rooftop_diffraction.cpp
@@ -40,16 +40,16 @@ double cardinal_skyline_deg(const gnss_sim::UrbanSceneGeometryConfig& scene) {
     double skyline_rad = 0.0;
     double horizontal_distance_m = 0.0;
     std::string error_message;
-    EXPECT_TRUE(gnss_sim::compute_urban_skyline_elevation(scene, 0.0, &skyline_rad, &horizontal_distance_m,
-                                                          &error_message))
+    EXPECT_TRUE(
+        gnss_sim::compute_urban_skyline_elevation(scene, 0.0, &skyline_rad, &horizontal_distance_m, &error_message))
         << error_message;
     EXPECT_NEAR(horizontal_distance_m, scene.wall_distance_m, 1.0e-12);
     return skyline_rad * kRadiansToDegrees;
 }
 
 gnss_sim::UrbanRooftopDiffractionPath evaluate(double elevation_deg, const gnss_sim::SignalDefinition& definition,
-                                                int glonass_fcn, double sagnac_offset_m,
-                                                gnss_sim::UrbanRooftopDiffractionStatus* status) {
+                                               int glonass_fcn, double sagnac_offset_m,
+                                               gnss_sim::UrbanRooftopDiffractionStatus* status) {
     const gnss_sim::UrbanSceneGeometryConfig scene = gnss_sim::default_urban_scene_geometry_config();
     gnss_sim::ReceiverTruth receiver{};
     gnss_sim::SatelliteGeometry geometry{};
@@ -57,8 +57,8 @@ gnss_sim::UrbanRooftopDiffractionPath evaluate(double elevation_deg, const gnss_
 
     gnss_sim::UrbanRooftopDiffractionPath result{};
     std::string error_message;
-    EXPECT_TRUE(gnss_sim::compute_urban_rooftop_diffraction(scene, definition, glonass_fcn, receiver, geometry,
-                                                            &result, status, &error_message))
+    EXPECT_TRUE(gnss_sim::compute_urban_rooftop_diffraction(scene, definition, glonass_fcn, receiver, geometry, &result,
+                                                            status, &error_message))
         << error_message;
     return result;
 }

--- a/tests/unit/test_urban_rooftop_diffraction.cpp
+++ b/tests/unit/test_urban_rooftop_diffraction.cpp
@@ -206,7 +206,7 @@ TEST(UrbanRooftopDiffraction, ExcessPathUsesEuclideanGeometryThenAddsRtklibBasel
     ASSERT_EQ(shifted_status, gnss_sim::UrbanRooftopDiffractionStatus::VALID);
     EXPECT_DOUBLE_EQ(zero.excess_path_length_m, shifted.excess_path_length_m);
     EXPECT_DOUBLE_EQ(zero.fresnel_v, shifted.fresnel_v);
-    EXPECT_DOUBLE_EQ(zero.fresnel_coefficient, shifted.fresnel_coefficient);
+    EXPECT_EQ(zero.fresnel_coefficient, shifted.fresnel_coefficient);
     EXPECT_NEAR(shifted.model_path_range_m - zero.model_path_range_m, 25.0, 1.0e-9);
 }
 
@@ -236,8 +236,8 @@ TEST(UrbanRooftopDiffraction, RepeatedEvaluationIsNumericallyIdentical) {
     EXPECT_DOUBLE_EQ(first.diffraction_point_enu_m.up_m, second.diffraction_point_enu_m.up_m);
     EXPECT_DOUBLE_EQ(first.signed_clearance_m, second.signed_clearance_m);
     EXPECT_DOUBLE_EQ(first.fresnel_v, second.fresnel_v);
-    EXPECT_DOUBLE_EQ(first.fresnel_coefficient, second.fresnel_coefficient);
-    EXPECT_DOUBLE_EQ(first.edge_reference_coefficient, second.edge_reference_coefficient);
+    EXPECT_EQ(first.fresnel_coefficient, second.fresnel_coefficient);
+    EXPECT_EQ(first.edge_reference_coefficient, second.edge_reference_coefficient);
 }
 
 } // namespace

--- a/tests/unit/test_urban_rooftop_diffraction.cpp
+++ b/tests/unit/test_urban_rooftop_diffraction.cpp
@@ -82,6 +82,8 @@ TEST(UrbanRooftopDiffraction, ComplexFresnelAnchorsMatchKnifeEdgeLimits) {
     EXPECT_NEAR(-20.0 * std::log10(std::abs(grazing)), 6.020599913279624, 1.0e-12);
     EXPECT_GT(std::abs(positive_half), std::abs(positive_one));
     EXPECT_GT(std::abs(positive_one), std::abs(positive_two));
+    EXPECT_NEAR(positive_one.real(), -0.10907627388358884, 1.0e-12);
+    EXPECT_NEAR(positive_one.imag(), -0.17081712649323413, 1.0e-12);
     EXPECT_NEAR(std::abs(clear_far), 1.0, 0.03);
 }
 

--- a/tests/unit/test_urban_rooftop_diffraction.cpp
+++ b/tests/unit/test_urban_rooftop_diffraction.cpp
@@ -1,0 +1,243 @@
+#include "gnss/signal_definitions.h"
+#include "model/urban_rooftop_diffraction.h"
+
+#include <cmath>
+#include <complex>
+#include <gtest/gtest.h>
+#include <string>
+
+namespace {
+
+constexpr double kPi = 3.141592653589793238462643383279502884;
+constexpr double kDegreesToRadians = kPi / 180.0;
+constexpr double kRadiansToDegrees = 180.0 / kPi;
+constexpr double kSyntheticSatelliteDistanceM = 20000000.0;
+
+void make_synthetic_geometry(double azimuth_deg, double elevation_deg, double sagnac_offset_m,
+                             gnss_sim::ReceiverTruth* receiver, gnss_sim::SatelliteGeometry* geometry) {
+    ASSERT_NE(receiver, nullptr);
+    ASSERT_NE(geometry, nullptr);
+    *receiver = {};
+    *geometry = {};
+    receiver->position_ecef_m[0] = 0.0;
+    receiver->position_ecef_m[1] = 0.0;
+    receiver->position_ecef_m[2] = 0.0;
+    geometry->satellite_state.position_ecef_m[0] = kSyntheticSatelliteDistanceM;
+    geometry->satellite_state.position_ecef_m[1] = 0.0;
+    geometry->satellite_state.position_ecef_m[2] = 0.0;
+    geometry->azimuth_rad = azimuth_deg * kDegreesToRadians;
+    geometry->elevation_rad = elevation_deg * kDegreesToRadians;
+    geometry->geometric_range_m = kSyntheticSatelliteDistanceM + sagnac_offset_m;
+}
+
+const gnss_sim::SignalDefinition& signal(gnss_sim::SignalId signal_id) {
+    const gnss_sim::SignalDefinition* definition = gnss_sim::find_signal_definition(signal_id);
+    EXPECT_NE(definition, nullptr);
+    return *definition;
+}
+
+double cardinal_skyline_deg(const gnss_sim::UrbanSceneGeometryConfig& scene) {
+    double skyline_rad = 0.0;
+    double horizontal_distance_m = 0.0;
+    std::string error_message;
+    EXPECT_TRUE(gnss_sim::compute_urban_skyline_elevation(scene, 0.0, &skyline_rad, &horizontal_distance_m,
+                                                          &error_message))
+        << error_message;
+    EXPECT_NEAR(horizontal_distance_m, scene.wall_distance_m, 1.0e-12);
+    return skyline_rad * kRadiansToDegrees;
+}
+
+gnss_sim::UrbanRooftopDiffractionPath evaluate(double elevation_deg, const gnss_sim::SignalDefinition& definition,
+                                                int glonass_fcn, double sagnac_offset_m,
+                                                gnss_sim::UrbanRooftopDiffractionStatus* status) {
+    const gnss_sim::UrbanSceneGeometryConfig scene = gnss_sim::default_urban_scene_geometry_config();
+    gnss_sim::ReceiverTruth receiver{};
+    gnss_sim::SatelliteGeometry geometry{};
+    make_synthetic_geometry(0.0, elevation_deg, sagnac_offset_m, &receiver, &geometry);
+
+    gnss_sim::UrbanRooftopDiffractionPath result{};
+    std::string error_message;
+    EXPECT_TRUE(gnss_sim::compute_urban_rooftop_diffraction(scene, definition, glonass_fcn, receiver, geometry,
+                                                            &result, status, &error_message))
+        << error_message;
+    return result;
+}
+
+TEST(UrbanRooftopDiffraction, ComplexFresnelAnchorsMatchKnifeEdgeLimits) {
+    std::string error_message;
+    std::complex<double> grazing{};
+    std::complex<double> positive_half{};
+    std::complex<double> positive_one{};
+    std::complex<double> positive_two{};
+    std::complex<double> clear_far{};
+
+    ASSERT_TRUE(gnss_sim::compute_complex_knife_edge_coefficient(0.0, &grazing, &error_message)) << error_message;
+    ASSERT_TRUE(gnss_sim::compute_complex_knife_edge_coefficient(0.5, &positive_half, &error_message));
+    ASSERT_TRUE(gnss_sim::compute_complex_knife_edge_coefficient(1.0, &positive_one, &error_message));
+    ASSERT_TRUE(gnss_sim::compute_complex_knife_edge_coefficient(2.0, &positive_two, &error_message));
+    ASSERT_TRUE(gnss_sim::compute_complex_knife_edge_coefficient(-10.0, &clear_far, &error_message));
+
+    EXPECT_NEAR(grazing.real(), 0.5, 1.0e-14);
+    EXPECT_NEAR(grazing.imag(), 0.0, 1.0e-14);
+    EXPECT_NEAR(-20.0 * std::log10(std::abs(grazing)), 6.020599913279624, 1.0e-12);
+    EXPECT_GT(std::abs(positive_half), std::abs(positive_one));
+    EXPECT_GT(std::abs(positive_one), std::abs(positive_two));
+    EXPECT_NEAR(std::abs(clear_far), 1.0, 0.03);
+}
+
+TEST(UrbanRooftopDiffraction, ComplexCoefficientIsContinuousAcrossGrazing) {
+    std::string error_message;
+    std::complex<double> negative{};
+    std::complex<double> positive{};
+    ASSERT_TRUE(gnss_sim::compute_complex_knife_edge_coefficient(-1.0e-4, &negative, &error_message));
+    ASSERT_TRUE(gnss_sim::compute_complex_knife_edge_coefficient(1.0e-4, &positive, &error_message));
+    EXPECT_LT(std::abs(negative - positive), 3.0e-4);
+}
+
+TEST(UrbanRooftopDiffraction, ExactCardinalSkylineUsesActualNorthRoofEdge) {
+    const gnss_sim::UrbanSceneGeometryConfig scene = gnss_sim::default_urban_scene_geometry_config();
+    const double skyline_deg = cardinal_skyline_deg(scene);
+    gnss_sim::UrbanRooftopDiffractionStatus status{};
+    const gnss_sim::UrbanRooftopDiffractionPath path =
+        evaluate(skyline_deg, signal(gnss_sim::SignalId::kGpsL1Ca), 0, 25.0, &status);
+
+    ASSERT_EQ(status, gnss_sim::UrbanRooftopDiffractionStatus::VALID);
+    EXPECT_EQ(path.wall_id, gnss_sim::UrbanWallId::NORTH);
+    EXPECT_NEAR(path.diffraction_point_enu_m.east_m, 0.0, 1.0e-8);
+    EXPECT_NEAR(path.diffraction_point_enu_m.north_m, scene.wall_distance_m, 1.0e-8);
+    EXPECT_NEAR(path.diffraction_point_enu_m.up_m, scene.wall_height_m, 1.0e-8);
+    EXPECT_NEAR(path.signed_clearance_m, 0.0, 1.0e-8);
+    EXPECT_NEAR(path.fresnel_v, 0.0, 1.0e-8);
+    EXPECT_NEAR(std::abs(path.fresnel_coefficient), 0.5, 1.0e-8);
+    EXPECT_NEAR(path.model_path_range_m - path.direct_model_range_m, path.excess_path_length_m, 1.0e-12);
+    EXPECT_NEAR(path.direct_model_range_m - path.direct_euclidean_range_m, 25.0, 1.0e-6);
+
+    const std::complex<double> reconstructed = path.edge_reference_coefficient * path.edge_geometric_phase_factor;
+    EXPECT_NEAR(reconstructed.real(), path.fresnel_coefficient.real(), 1.0e-12);
+    EXPECT_NEAR(reconstructed.imag(), path.fresnel_coefficient.imag(), 1.0e-12);
+}
+
+TEST(UrbanRooftopDiffraction, ShadowAndClearSidesUseOppositeSignedFresnelV) {
+    const gnss_sim::UrbanSceneGeometryConfig scene = gnss_sim::default_urban_scene_geometry_config();
+    const double skyline_deg = cardinal_skyline_deg(scene);
+    gnss_sim::UrbanRooftopDiffractionStatus shadow_status{};
+    gnss_sim::UrbanRooftopDiffractionStatus clear_status{};
+
+    const gnss_sim::UrbanRooftopDiffractionPath shadow =
+        evaluate(skyline_deg - 1.0, signal(gnss_sim::SignalId::kGpsL1Ca), 0, 0.0, &shadow_status);
+    const gnss_sim::UrbanRooftopDiffractionPath clear =
+        evaluate(skyline_deg + 1.0, signal(gnss_sim::SignalId::kGpsL1Ca), 0, 0.0, &clear_status);
+
+    ASSERT_EQ(shadow_status, gnss_sim::UrbanRooftopDiffractionStatus::VALID);
+    ASSERT_EQ(clear_status, gnss_sim::UrbanRooftopDiffractionStatus::VALID);
+    EXPECT_GT(shadow.signed_clearance_m, 0.0);
+    EXPECT_GT(shadow.fresnel_v, 0.0);
+    EXPECT_LT(std::abs(shadow.fresnel_coefficient), 0.5);
+    EXPECT_LT(clear.signed_clearance_m, 0.0);
+    EXPECT_LT(clear.fresnel_v, 0.0);
+    EXPECT_GT(std::abs(clear.fresnel_coefficient), 0.5);
+}
+
+TEST(UrbanRooftopDiffraction, GeometryAndComplexFieldRemainContinuousNearSkyline) {
+    const gnss_sim::UrbanSceneGeometryConfig scene = gnss_sim::default_urban_scene_geometry_config();
+    const double skyline_deg = cardinal_skyline_deg(scene);
+    gnss_sim::UrbanRooftopDiffractionStatus below_status{};
+    gnss_sim::UrbanRooftopDiffractionStatus above_status{};
+
+    const gnss_sim::UrbanRooftopDiffractionPath below =
+        evaluate(skyline_deg - 0.01, signal(gnss_sim::SignalId::kGpsL1Ca), 0, 0.0, &below_status);
+    const gnss_sim::UrbanRooftopDiffractionPath above =
+        evaluate(skyline_deg + 0.01, signal(gnss_sim::SignalId::kGpsL1Ca), 0, 0.0, &above_status);
+
+    ASSERT_EQ(below_status, gnss_sim::UrbanRooftopDiffractionStatus::VALID);
+    ASSERT_EQ(above_status, gnss_sim::UrbanRooftopDiffractionStatus::VALID);
+    EXPECT_NEAR(below.excess_path_length_m, above.excess_path_length_m, 1.0e-9);
+    EXPECT_LT(std::abs(below.fresnel_coefficient - above.fresnel_coefficient), 3.0e-3);
+}
+
+TEST(UrbanRooftopDiffraction, UsesCentralSignalWavelengthForFresnelParameter) {
+    const gnss_sim::UrbanSceneGeometryConfig scene = gnss_sim::default_urban_scene_geometry_config();
+    const double elevation_deg = cardinal_skyline_deg(scene) - 1.0;
+    gnss_sim::UrbanRooftopDiffractionStatus l1_status{};
+    gnss_sim::UrbanRooftopDiffractionStatus l5_status{};
+
+    const gnss_sim::UrbanRooftopDiffractionPath l1 =
+        evaluate(elevation_deg, signal(gnss_sim::SignalId::kGpsL1Ca), 0, 0.0, &l1_status);
+    const gnss_sim::UrbanRooftopDiffractionPath l5 =
+        evaluate(elevation_deg, signal(gnss_sim::SignalId::kGpsL5Q), 0, 0.0, &l5_status);
+
+    ASSERT_EQ(l1_status, gnss_sim::UrbanRooftopDiffractionStatus::VALID);
+    ASSERT_EQ(l5_status, gnss_sim::UrbanRooftopDiffractionStatus::VALID);
+    EXPECT_DOUBLE_EQ(l1.excess_path_length_m, l5.excess_path_length_m);
+    EXPECT_LT(l1.wavelength_m, l5.wavelength_m);
+    EXPECT_GT(l1.fresnel_v, l5.fresnel_v);
+}
+
+TEST(UrbanRooftopDiffraction, GlonassFdmaChannelChangesWavelengthAndResponse) {
+    const gnss_sim::UrbanSceneGeometryConfig scene = gnss_sim::default_urban_scene_geometry_config();
+    const double elevation_deg = cardinal_skyline_deg(scene) - 2.0;
+    const gnss_sim::SignalDefinition& glonass = signal(gnss_sim::SignalId::kGlonassG1);
+    gnss_sim::UrbanRooftopDiffractionStatus low_status{};
+    gnss_sim::UrbanRooftopDiffractionStatus high_status{};
+
+    const gnss_sim::UrbanRooftopDiffractionPath low = evaluate(elevation_deg, glonass, -7, 0.0, &low_status);
+    const gnss_sim::UrbanRooftopDiffractionPath high = evaluate(elevation_deg, glonass, 6, 0.0, &high_status);
+
+    ASSERT_EQ(low_status, gnss_sim::UrbanRooftopDiffractionStatus::VALID);
+    ASSERT_EQ(high_status, gnss_sim::UrbanRooftopDiffractionStatus::VALID);
+    EXPECT_NE(low.carrier_frequency_hz, high.carrier_frequency_hz);
+    EXPECT_NE(low.wavelength_m, high.wavelength_m);
+    EXPECT_NE(low.fresnel_v, high.fresnel_v);
+    EXPECT_NE(low.fresnel_coefficient, high.fresnel_coefficient);
+}
+
+TEST(UrbanRooftopDiffraction, ExcessPathUsesEuclideanGeometryThenAddsRtklibBaseline) {
+    const gnss_sim::UrbanSceneGeometryConfig scene = gnss_sim::default_urban_scene_geometry_config();
+    const double elevation_deg = cardinal_skyline_deg(scene) - 2.0;
+    gnss_sim::UrbanRooftopDiffractionStatus zero_status{};
+    gnss_sim::UrbanRooftopDiffractionStatus shifted_status{};
+
+    const gnss_sim::UrbanRooftopDiffractionPath zero =
+        evaluate(elevation_deg, signal(gnss_sim::SignalId::kGpsL1Ca), 0, 0.0, &zero_status);
+    const gnss_sim::UrbanRooftopDiffractionPath shifted =
+        evaluate(elevation_deg, signal(gnss_sim::SignalId::kGpsL1Ca), 0, 25.0, &shifted_status);
+
+    ASSERT_EQ(zero_status, gnss_sim::UrbanRooftopDiffractionStatus::VALID);
+    ASSERT_EQ(shifted_status, gnss_sim::UrbanRooftopDiffractionStatus::VALID);
+    EXPECT_DOUBLE_EQ(zero.excess_path_length_m, shifted.excess_path_length_m);
+    EXPECT_DOUBLE_EQ(zero.fresnel_v, shifted.fresnel_v);
+    EXPECT_DOUBLE_EQ(zero.fresnel_coefficient, shifted.fresnel_coefficient);
+    EXPECT_NEAR(shifted.model_path_range_m - zero.model_path_range_m, 25.0, 1.0e-9);
+}
+
+TEST(UrbanRooftopDiffraction, BelowLocalHorizonIsExplicitlyNonApplicable) {
+    gnss_sim::UrbanRooftopDiffractionStatus status{};
+    const gnss_sim::UrbanRooftopDiffractionPath path =
+        evaluate(-1.0, signal(gnss_sim::SignalId::kGpsL1Ca), 0, 0.0, &status);
+    EXPECT_EQ(status, gnss_sim::UrbanRooftopDiffractionStatus::BELOW_LOCAL_HORIZON);
+    EXPECT_EQ(path.wall_id, gnss_sim::UrbanWallId::NONE);
+}
+
+TEST(UrbanRooftopDiffraction, RepeatedEvaluationIsNumericallyIdentical) {
+    const gnss_sim::UrbanSceneGeometryConfig scene = gnss_sim::default_urban_scene_geometry_config();
+    const double elevation_deg = cardinal_skyline_deg(scene) - 0.5;
+    gnss_sim::UrbanRooftopDiffractionStatus first_status{};
+    gnss_sim::UrbanRooftopDiffractionStatus second_status{};
+
+    const gnss_sim::UrbanRooftopDiffractionPath first =
+        evaluate(elevation_deg, signal(gnss_sim::SignalId::kGpsL1Ca), 0, 17.0, &first_status);
+    const gnss_sim::UrbanRooftopDiffractionPath second =
+        evaluate(elevation_deg, signal(gnss_sim::SignalId::kGpsL1Ca), 0, 17.0, &second_status);
+
+    ASSERT_EQ(first_status, second_status);
+    ASSERT_EQ(first_status, gnss_sim::UrbanRooftopDiffractionStatus::VALID);
+    EXPECT_DOUBLE_EQ(first.diffraction_point_enu_m.east_m, second.diffraction_point_enu_m.east_m);
+    EXPECT_DOUBLE_EQ(first.diffraction_point_enu_m.north_m, second.diffraction_point_enu_m.north_m);
+    EXPECT_DOUBLE_EQ(first.diffraction_point_enu_m.up_m, second.diffraction_point_enu_m.up_m);
+    EXPECT_DOUBLE_EQ(first.signed_clearance_m, second.signed_clearance_m);
+    EXPECT_DOUBLE_EQ(first.fresnel_v, second.fresnel_v);
+    EXPECT_DOUBLE_EQ(first.fresnel_coefficient, second.fresnel_coefficient);
+    EXPECT_DOUBLE_EQ(first.edge_reference_coefficient, second.edge_reference_coefficient);
+}
+
+} // namespace

--- a/tests/unit/test_urban_rooftop_diffraction.cpp
+++ b/tests/unit/test_urban_rooftop_diffraction.cpp
@@ -138,6 +138,25 @@ TEST(UrbanRooftopDiffraction, ShadowAndClearSidesUseOppositeSignedFresnelV) {
     EXPECT_GT(std::abs(clear.fresnel_coefficient), 0.5);
 }
 
+TEST(UrbanRooftopDiffraction, StandardFresnelParameterUsesSignedClearanceAndEdgeLegs) {
+    const gnss_sim::UrbanSceneGeometryConfig scene = gnss_sim::default_urban_scene_geometry_config();
+    const double elevation_deg = cardinal_skyline_deg(scene) - 1.0;
+    gnss_sim::UrbanRooftopDiffractionStatus status{};
+    const gnss_sim::UrbanRooftopDiffractionPath path =
+        evaluate(elevation_deg, signal(gnss_sim::SignalId::kGpsL1Ca), 0, 0.0, &status);
+
+    ASSERT_EQ(status, gnss_sim::UrbanRooftopDiffractionStatus::VALID);
+    const double expected_v =
+        path.signed_clearance_m *
+        std::sqrt(2.0 * path.edge_path_euclidean_range_m /
+                  (path.wavelength_m * path.source_edge_distance_m * path.receiver_edge_distance_m));
+    EXPECT_NEAR(path.fresnel_v, expected_v, 1.0e-12);
+    EXPECT_NEAR(path.fresnel_v, 0.20497, 1.0e-4);
+
+    const double paraxial_v_squared = 4.0 * path.excess_path_length_m / path.wavelength_m;
+    EXPECT_NEAR(path.fresnel_v * path.fresnel_v, paraxial_v_squared, 1.0e-4 * paraxial_v_squared);
+}
+
 TEST(UrbanRooftopDiffraction, GeometryAndComplexFieldRemainContinuousNearSkyline) {
     const gnss_sim::UrbanSceneGeometryConfig scene = gnss_sim::default_urban_scene_geometry_config();
     const double skyline_deg = cardinal_skyline_deg(scene);


### PR DESCRIPTION
Closes #118

## Summary

Implements the frozen V1 deterministic single-rooftop Fresnel knife-edge diffraction model for the urban four-wall scene.

## Implementation Notes

- Reuses the existing #115 direct-path geometry and the **actual `primary_wall` roof edge**; no alternate/fabricated obstruction geometry is introduced.
- Reuses #117 `reconstruct_urban_satellite_enu()` so the model consumes the already-converged `SatelliteGeometry` and does **not** run a second satellite-state/propagation-time solve.
- Determines a unique 3-D equivalent diffraction point on the infinite roof edge by minimizing the source-edge-receiver path analytically:
  - `q_X = dot(X-E0, t)`
  - `r_X = |(X-E0)-q_X t|`
  - `q_Q = (r_R q_S + r_S q_R)/(r_S+r_R)`.
- Computes the exact Euclidean edge path and uses a numerically stable excess-path expression near grazing rather than subtracting two ~20,000 km ranges:
  - `DeltaL = d_S d_R |u_S+u_R|^2 / (L_edge + D0)`.
- Preserves the #117 Sagnac-safe range contract:
  - `model_path = SatelliteGeometry::geometric_range_m + DeltaL`.
  - RTKLIB-corrected range is never subtracted from a Euclidean edge path.
- Signed roof clearance `h` is positive in shadow, zero at grazing, negative on the clear side.
- Resolves carrier frequency and wavelength only from the central `SignalDefinition`, including GLONASS FDMA FCN.
- Uses the standard knife-edge Fresnel normalization:
  - `v = h * sqrt(2(d_S+d_R)/(lambda d_S d_R))`.
  - In the paraxial limit, `v^2 ~= 4 DeltaL/lambda`; this relation is regression-tested to prevent normalization-factor errors.
- Implements a deterministic **complex** Fresnel coefficient under the repository convention `exp(+jωt)` / `exp(-jkL)`:
  - `F(v) = (1+j)/2 * [(1/2-C(v)) - j(1/2-S(v))]`
  - `F(0)=0.5` (~6.0206 dB), `v -> -inf` approaches unobstructed, positive `v` increasingly attenuates.
- Avoids direct/diffraction phase double counting. `fresnel_coefficient` is direct-path referenced; for edge-path diagnostics the implementation exposes:
  - `G_edge = exp(-jk DeltaL)`
  - `F_edge = F(v) * conj(G_edge)`
  - therefore `F_edge * G_edge = F(v)`.
- Exposes wall, equivalent edge point, edge legs/path, excess path/delay, signed clearance, `v`, wavelength/frequency, complex Fresnel coefficient, and phase-reference diagnostics for later #119-#123 integration.
- Does **not** implement DLL, CN0 composition, tracking, pseudorange/Doppler/ADR synthesis, or final RANGE behavior in this PR.
- Adds permanent model documentation in `docs/URBAN_ROOFTOP_DIFFRACTION.md`.

## Regression Coverage

- `v = 0` -> 6.0206 dB anchor.
- Increasing positive `v` -> increasing attenuation.
- Large negative `v` -> unobstructed limit.
- Complex coefficient continuity across grazing.
- Actual cardinal roof edge / exact skyline geometry.
- Shadow and clear sides produce opposite signed `v`.
- Standard `v` normalization from signed clearance and edge-leg distances, plus `v^2 ~= 4 DeltaL/lambda` near-grazing check.
- Near-skyline geometry and complex field continuity.
- GPS L1/L5 wavelength dependence.
- GLONASS FDMA FCN dependence.
- Sagnac-safe excess-path behavior under a synthetic RTKLIB-range offset.
- Below-horizon explicit non-applicable state.
- Bitwise-repeat deterministic evaluation.

## Validation so far

The first CI run compiled and passed the complete Ubuntu and Windows test suites, including the RANGEA and self-contained serialized-NAV regressions. Its only failure was clang-format; that exact generated format diff was applied. During pre-merge self-review, a Fresnel-parameter normalization error in the initial implementation (`sqrt(2 DeltaL/lambda)`) was found and corrected to the standard clearance/distance formula above before merge. The corrected head must pass CI again.

## Safety / Data Provenance

This PR does **not** generate, modify, interpolate, retarget, or fabricate NAV/EPH/ION data and does not tune the propagation model to obtain a desired PVT error. Satellite geometry continues to originate from the existing authentic-NAV production path.

## Next gate

After #118 is validated and merged, proceed to #130 to sweep azimuth/elevation around the skyline and determine whether `LOS_MULTIPATH` is physically reachable in the frozen four-wall scene before continuing to #119.