### PR TITLE
Validate frozen-scene LOS_MULTIPATH reachability

### DIFF
--- a/docs/URBAN_LOS_MULTIPATH_REACHABILITY.md
+++ b/docs/URBAN_LOS_MULTIPATH_REACHABILITY.md
@@ -1,0 +1,77 @@
+# Frozen Four-Wall LOS_MULTIPATH Reachability
+
+This document records the Issue #130 reachability decision for the frozen V1 urban scene defined by Issue #103 and implemented by #115, #117, and #118.
+
+## Question
+
+The frozen scene is a square of four horizontally infinite facades around the centered receiver. Issue #117 established that a geometrically valid first-order specular reflection does not coexist with direct LOS in this scene. Issue #118 added the roof-edge Fresnel transition field.
+
+The remaining question is whether `LOS_MULTIPATH` is physically reachable without weakening reflection/occlusion rules and without adding a full direct field on top of a full diffracted field.
+
+## Deterministic sweep
+
+The permanent regression in `test_urban_rooftop_diffraction.cpp` sweeps:
+
+- azimuth: `0..355 deg` in `5 deg` steps: 72 azimuths;
+- elevation: local skyline `-5..+10 deg` in `0.25 deg` steps: 61 elevations per azimuth;
+- total: 4,392 deterministic geometry samples;
+- signal: GPS L1 C/A for the reachability proof;
+- finite source distance: 20,000 km, matching the existing propagation unit-test convention.
+
+Each sample calls the production geometry/propagation interfaces directly:
+
+1. `compute_urban_direct_path_geometry()` from #115;
+2. `compute_urban_first_order_reflections()` from #117;
+3. `compute_urban_rooftop_diffraction()` from #118.
+
+The synthetic finite source is only a unit-test geometry input. It does not create, modify, interpolate, or retarget NAV/EPH/ION records.
+
+## Diagnostic edge-transition reference
+
+For reachability evidence only, the sweep uses `v = -0.78` as the classical knife-edge boundary below which diffraction is commonly treated as negligible/unobstructed in the standard engineering approximation.
+
+This value is **not** frozen here as the production #121 tracking/state threshold. Its purpose is only to distinguish a physically meaningful clear-side roof-edge transition from an asymptotically negligible Fresnel correction.
+
+The diagnostic regions are therefore:
+
+- shadow: blocked direct geometry with `v > 0`;
+- LOS edge transition: direct LOS with `-0.78 < v < 0`;
+- far-clear LOS: direct LOS with `v <= -0.78`.
+
+## Regression decision
+
+The sweep requires all of the following to remain true:
+
+- zero samples with direct LOS and a retained #117 first-order specular reflection;
+- every sampled azimuth has at least one blocked/shadow sample;
+- every sampled azimuth has at least one direct-LOS sample in the clear-side roof-edge transition;
+- every sampled azimuth also reaches a far-clear LOS region where the edge effect becomes negligible.
+
+Therefore the frozen scene has a non-zero, physically defensible `LOS_MULTIPATH` region **only through the roof-edge-affected direct field**, not through simultaneous LOS + first-order specular reflection.
+
+## No direct/diffraction double counting
+
+The #118 Fresnel coefficient is the transfer factor of the roof-affected direct component. In the edge-transition region the observation model must use that field in place of an unmodified full-strength direct field.
+
+It must not synthesize
+
+`full direct + full diffracted`
+
+as two independent components. Doing so would double count the same transition field.
+
+A later coherent composition may combine the single roof-affected direct component with independent reflected paths when such reflected paths are geometrically valid. The frozen four-wall scene simply does not produce a direct-LOS + retained first-order reflection overlap.
+
+## V1 scene decision
+
+No geometry extension is required merely to make the Issue #103 `LOS_MULTIPATH` state reachable, because #103 explicitly allows an edge-affected LOS component and the clear-side Fresnel transition is non-zero over a finite region.
+
+Keep the frozen four-wall geometry unchanged for V1.
+
+However, this does **not** make `LOS + one specular reflection` or `LOS + multiple specular reflections` reachable in the frozen scene. If later acceptance criteria require those exact simultaneous path combinations, they need an explicit separate scene extension such as a finite-width/open street-canyon facade. Reflection occlusion must not be weakened to manufacture them.
+
+## Consequences for later issues
+
+- #121 should classify states without representing diffraction as a second full direct-like path.
+- #122 should synthesize the roof-affected direct field once, then combine only genuinely independent paths.
+- #124 should not require frozen-scene `LOS + specular reflection` scenarios that the geometry cannot produce. It may validate `LOS + roof-edge effect` for `LOS_MULTIPATH`, and validate retained reflection behavior in geometrically blocked/NLOS cases.
+- If product requirements still demand simultaneous LOS + specular multipath, create and review a separate finite/open-facade scene issue before #122/#124 are frozen.

--- a/tests/unit/test_urban_rooftop_diffraction.cpp
+++ b/tests/unit/test_urban_rooftop_diffraction.cpp
@@ -1,4 +1,6 @@
 #include "gnss/signal_definitions.h"
+#include "gnss_sim/sim_config.h"
+#include "model/urban_reflection_paths.h"
 #include "model/urban_rooftop_diffraction.h"
 
 #include <cmath>
@@ -259,6 +261,110 @@ TEST(UrbanRooftopDiffraction, RepeatedEvaluationIsNumericallyIdentical) {
     EXPECT_DOUBLE_EQ(first.fresnel_v, second.fresnel_v);
     EXPECT_EQ(first.fresnel_coefficient, second.fresnel_coefficient);
     EXPECT_EQ(first.edge_reference_coefficient, second.edge_reference_coefficient);
+}
+
+TEST(UrbanRooftopDiffraction, FrozenFourWallReachabilitySweepFindsLosEdgeTransitionButNoLosSpecularOverlap) {
+    const gnss_sim::UrbanSceneGeometryConfig scene = gnss_sim::default_urban_scene_geometry_config();
+    const gnss_sim::SimConfig sim_config = gnss_sim::default_sim_config();
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+
+    // Diagnostic-only reference boundary. The classical knife-edge approximation
+    // treats v <= -0.78 as effectively unobstructed. This test uses that physical
+    // reference only to demonstrate a non-zero clear-side edge-transition region;
+    // it does not freeze a production tracking/state threshold for #121.
+    constexpr double kNegligibleKnifeEdgeV = -0.78;
+    constexpr int kAzimuthStepDeg = 5;
+    constexpr int kOffsetQuarterDegreeStart = -20; // -5 deg from the local skyline.
+    constexpr int kOffsetQuarterDegreeEnd = 40;    // +10 deg from the local skyline.
+    constexpr double kQuarterDegree = 0.25;
+    constexpr int kExpectedAzimuthSamples = 360 / kAzimuthStepDeg;
+    constexpr int kExpectedElevationSamples = kOffsetQuarterDegreeEnd - kOffsetQuarterDegreeStart + 1;
+
+    int total_samples = 0;
+    int line_of_sight_samples = 0;
+    int los_with_specular_reflection_samples = 0;
+    int azimuths_with_los_edge_transition = 0;
+    int azimuths_with_far_clear_los = 0;
+    int azimuths_with_shadow = 0;
+
+    for (int azimuth_deg = 0; azimuth_deg < 360; azimuth_deg += kAzimuthStepDeg) {
+        double skyline_rad = 0.0;
+        double horizontal_distance_m = 0.0;
+        std::string error_message;
+        ASSERT_TRUE(gnss_sim::compute_urban_skyline_elevation(scene, azimuth_deg * kDegreesToRadians, &skyline_rad,
+                                                              &horizontal_distance_m, &error_message))
+            << "az=" << azimuth_deg << ": " << error_message;
+        ASSERT_GT(horizontal_distance_m, 0.0);
+
+        bool has_los_edge_transition = false;
+        bool has_far_clear_los = false;
+        bool has_shadow = false;
+        const double skyline_deg = skyline_rad * kRadiansToDegrees;
+
+        for (int offset_quarter_degree = kOffsetQuarterDegreeStart; offset_quarter_degree <= kOffsetQuarterDegreeEnd;
+             ++offset_quarter_degree) {
+            const double elevation_deg = skyline_deg + kQuarterDegree * static_cast<double>(offset_quarter_degree);
+            gnss_sim::ReceiverTruth receiver{};
+            gnss_sim::SatelliteGeometry geometry{};
+            make_synthetic_geometry(static_cast<double>(azimuth_deg), elevation_deg, 0.0, &receiver, &geometry);
+
+            gnss_sim::UrbanDirectPathGeometry direct{};
+            error_message.clear();
+            ASSERT_TRUE(gnss_sim::compute_urban_direct_path_geometry(scene, geometry.azimuth_rad, geometry.elevation_rad,
+                                                                     &direct, &error_message))
+                << "az=" << azimuth_deg << " offset_q=" << offset_quarter_degree << ": " << error_message;
+            ASSERT_TRUE(direct.above_local_horizon);
+
+            gnss_sim::UrbanFirstOrderReflectionSet reflections{};
+            error_message.clear();
+            ASSERT_TRUE(gnss_sim::compute_urban_first_order_reflections(scene, sim_config.urban_rf, gps_l1, 0, receiver,
+                                                                        geometry, &reflections, &error_message))
+                << "az=" << azimuth_deg << " offset_q=" << offset_quarter_degree << ": " << error_message;
+
+            gnss_sim::UrbanRooftopDiffractionPath diffraction{};
+            gnss_sim::UrbanRooftopDiffractionStatus diffraction_status{};
+            error_message.clear();
+            ASSERT_TRUE(gnss_sim::compute_urban_rooftop_diffraction(scene, gps_l1, 0, receiver, geometry, &diffraction,
+                                                                    &diffraction_status, &error_message))
+                << "az=" << azimuth_deg << " offset_q=" << offset_quarter_degree << ": " << error_message;
+            ASSERT_EQ(diffraction_status, gnss_sim::UrbanRooftopDiffractionStatus::VALID);
+
+            ++total_samples;
+            if (direct.line_of_sight) {
+                ++line_of_sight_samples;
+                if (reflections.path_count > 0) {
+                    ++los_with_specular_reflection_samples;
+                }
+                EXPECT_EQ(reflections.path_count, 0)
+                    << "unexpected LOS+specular overlap at az=" << azimuth_deg << " el=" << elevation_deg;
+                EXPECT_LT(diffraction.fresnel_v, 0.0);
+
+                if (diffraction.fresnel_v > kNegligibleKnifeEdgeV) {
+                    has_los_edge_transition = true;
+                    EXPECT_GT(std::abs(diffraction.fresnel_coefficient - std::complex<double>(1.0, 0.0)), 1.0e-3);
+                } else {
+                    has_far_clear_los = true;
+                }
+            } else if (direct.blocked_by_wall && !direct.grazing_roof) {
+                has_shadow = true;
+                EXPECT_GT(diffraction.fresnel_v, 0.0);
+            }
+        }
+
+        EXPECT_TRUE(has_los_edge_transition) << "no LOS edge-transition sample at az=" << azimuth_deg;
+        EXPECT_TRUE(has_far_clear_los) << "no far-clear LOS sample at az=" << azimuth_deg;
+        EXPECT_TRUE(has_shadow) << "no blocked shadow sample at az=" << azimuth_deg;
+        azimuths_with_los_edge_transition += has_los_edge_transition ? 1 : 0;
+        azimuths_with_far_clear_los += has_far_clear_los ? 1 : 0;
+        azimuths_with_shadow += has_shadow ? 1 : 0;
+    }
+
+    EXPECT_EQ(total_samples, kExpectedAzimuthSamples * kExpectedElevationSamples);
+    EXPECT_GT(line_of_sight_samples, 0);
+    EXPECT_EQ(los_with_specular_reflection_samples, 0);
+    EXPECT_EQ(azimuths_with_los_edge_transition, kExpectedAzimuthSamples);
+    EXPECT_EQ(azimuths_with_far_clear_los, kExpectedAzimuthSamples);
+    EXPECT_EQ(azimuths_with_shadow, kExpectedAzimuthSamples);
 }
 
 } // namespace

--- a/tests/unit/test_urban_rooftop_diffraction.cpp
+++ b/tests/unit/test_urban_rooftop_diffraction.cpp
@@ -310,8 +310,8 @@ TEST(UrbanRooftopDiffraction, FrozenFourWallReachabilitySweepFindsLosEdgeTransit
 
             gnss_sim::UrbanDirectPathGeometry direct{};
             error_message.clear();
-            ASSERT_TRUE(gnss_sim::compute_urban_direct_path_geometry(scene, geometry.azimuth_rad, geometry.elevation_rad,
-                                                                     &direct, &error_message))
+            ASSERT_TRUE(gnss_sim::compute_urban_direct_path_geometry(scene, geometry.azimuth_rad,
+                                                                     geometry.elevation_rad, &direct, &error_message))
                 << "az=" << azimuth_deg << " offset_q=" << offset_quarter_degree << ": " << error_message;
             ASSERT_TRUE(direct.above_local_horizon);
 


### PR DESCRIPTION
Closes #130

## Summary

Adds deterministic reachability evidence for the frozen four-wall urban scene after #117 reflections and #118 rooftop diffraction are both available.

## Validation method

- Sweeps 72 azimuths (`0..355 deg`, `5 deg` step).
- For each azimuth, sweeps 61 elevations from local skyline `-5..+10 deg` in `0.25 deg` steps.
- Total: 4,392 deterministic samples.
- Every sample calls the production #115 direct-geometry, #117 first-order-reflection, and #118 rooftop-diffraction interfaces.
- No production propagation/measurement/state code is changed.

## Reachability contract under test

- Direct LOS + retained #117 first-order specular reflection must remain **zero** across the sweep.
- Every sampled azimuth must contain blocked/shadow samples with positive `v`.
- Every sampled azimuth must contain a clear-side LOS roof-edge transition sample.
- Every sampled azimuth must also reach far-clear LOS.

For the diagnostic reachability boundary only, the test uses the classical knife-edge `v = -0.78` negligible-diffraction reference. This is explicitly **not** frozen as a production #121 state threshold.

## Decision encoded by the regression

The frozen scene can reach #103 `LOS_MULTIPATH` through the **roof-edge-affected direct field** over a finite clear-side transition region. It still cannot produce simultaneous direct LOS + retained first-order specular reflection.

No geometry extension is required merely for the V1 `LOS_MULTIPATH` state because #103 explicitly allows edge-affected LOS. However, later validation must not claim that the frozen scene can produce `LOS + one/multiple specular reflections`. If that exact path combination remains a product requirement, it needs a separate explicit finite/open-facade scene extension rather than weakened occlusion.

## Double-counting constraint

#118 diffraction remains a transfer factor applied to the direct component; the model must not synthesize a full direct field plus a full diffracted field as two independent paths.

## Data provenance

The sweep uses synthetic finite-source geometry only inside unit tests and does not create, modify, interpolate, or retarget NAV/EPH/ION. No target state percentage or PVT error is injected.