### PR TITLE
Add central GNSS code-correlation metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,7 @@ if(BUILD_TESTING)
         tests/unit/test_rtklib_adapter.cpp
         tests/unit/test_satellite_engine.cpp
         tests/unit/test_scenario_engine.cpp
+        tests/unit/test_signal_correlation_metadata.cpp
         tests/unit/test_signal_definitions.cpp
         tests/unit/test_signal_tracking.cpp
         tests/unit/test_sim_config.cpp

--- a/docs/SIGNAL_CORRELATION_METADATA.md
+++ b/docs/SIGNAL_CORRELATION_METADATA.md
@@ -23,9 +23,9 @@ Each `SignalDefinition` carries:
 - `primary_subcarrier_rate_hz`: low-rate BOC subcarrier for composite BOC profiles;
 - `secondary_subcarrier_rate_hz`: high-rate BOC subcarrier for composite profiles;
 - `secondary_power_fraction`: power fraction of the secondary subcarrier contribution;
-- `secondary_phase`: in-phase, anti-phase, quadrature, or not applicable.
+- `secondary_phase`: in-phase, anti-phase, **positive quadrature (+90 deg)**, **negative quadrature (-90 deg)**, or not applicable.
 
-TMBOC uses a time-multiplex fraction rather than a fixed subcarrier phase, so `secondary_phase` is `kNotApplicable`.
+The sign of a quadrature relation is preserved because the later complex correlation function can have a signed imaginary component. TMBOC uses a time-multiplex fraction rather than a fixed subcarrier phase, so `secondary_phase` is `kNotApplicable`.
 
 ## Authoritative source baseline
 
@@ -65,9 +65,11 @@ QZSS L1C and L2C are explicitly unsupported in the V1 metadata. Current QZSS gen
 
 - BDS-SIS-ICD-B1I-3.0, February 2019: B1I, BPSK, 2.046 Mcps.
 - BDS-SIS-ICD-B3I-1.0, February 2018: B3I, 10.23 Mcps.
-- BDS-SIS-ICD-B1C-1.0, December 2017: B1C pilot code rate 1.023 Mcps and QMBOC(6,1,4/33). The BOC(1,1) and BOC(6,1) subcarriers are in quadrature with power ratio 29:4.
+- BDS-SIS-ICD-B1C-1.0, December 2017: B1C pilot code rate 1.023 Mcps and QMBOC(6,1,4/33). Under the ICD complex-envelope convention, the pilot subcarrier is represented as `sqrt(29/33) * BOC(1,1) - j * sqrt(4/33) * BOC(6,1)`. Therefore the central B1C pilot profile stores the BOC(6,1) term as **negative quadrature**, not an unsigned generic quadrature relation.
 - BDS-SIS-ICD-B2a-1.0, December 2017: B2a pilot/data ranging code rate 10.23 Mcps and BPSK(10).
 - BDS-SIS-ICD-B2b-1.0, July 2020: B2b-I ranging code rate 10.23 Mcps and BPSK(10).
+
+The generic QMBOC profile validator accepts either positive or negative quadrature structurally; the **specific B1C central entry** locks the negative sign required by the referenced ICD. This keeps the central type reusable without erasing the signal-specific phase convention.
 
 ### GLONASS
 
@@ -93,6 +95,7 @@ There is deliberately no fallback such as "unknown -> triangular BPSK".
 - the unsupported set is explicit and stable;
 - #119 minimum signals have the required representative profile and chip-rate metadata;
 - GPS L1C, Galileo E1-C, and BeiDou B1C retain their distinct TMBOC/CBOC/QMBOC identities;
+- BDS B1C retains the ICD-required negative-quadrature sign while the generic QMBOC validator can represent either signed quadrature orientation;
 - invalid/non-finite/inconsistent profiles are rejected;
 - existing signal lookup/carrier/NAV/bias/OEM7 behavior remains owned by the existing `SignalDefinition` regression suite.
 

--- a/docs/SIGNAL_CORRELATION_METADATA.md
+++ b/docs/SIGNAL_CORRELATION_METADATA.md
@@ -1,0 +1,108 @@
+# Central Signal Correlation Metadata
+
+Issue #133 adds the minimum code-domain metadata required by Issue #119 and its pure-correlation prerequisite #134. The metadata lives in the central `SignalDefinition` table so DLL code does not create a second signal mapping table.
+
+## Scope and interpretation
+
+`CodeCorrelationProfile` describes the **tracked RINEX signal component** used by the simulator. It is intentionally not a complete RF/IF/baseband signal description.
+
+For example:
+
+- Galileo E5a-Q / E5b-Q are represented as their independently tracked 10.23 Mcps sideband components, not as the full E5 AltBOC composite waveform.
+- BeiDou B1C `1P` represents the pilot component, whose ranging code is modulated by QMBOC(6,1,4/33).
+- GPS L1C `1L` represents the pilot component, whose spreading waveform uses TMBOC.
+
+The metadata exists only to let #134 evaluate idealized code correlation and to let #119 convert chip-domain delay to signal-specific DLL behavior. Carrier phase, RF polarization, material response, path amplitudes, diffraction, CN0, tracking, and observation synthesis remain in their existing/later layers.
+
+## Metadata fields
+
+Each `SignalDefinition` carries:
+
+- `model`: supported ideal correlation family or explicit `kUnsupported`;
+- `chip_rate_hz`: ranging-code chip rate for the tracked component;
+- `primary_subcarrier_rate_hz`: low-rate BOC subcarrier for composite BOC profiles;
+- `secondary_subcarrier_rate_hz`: high-rate BOC subcarrier for composite profiles;
+- `secondary_power_fraction`: power fraction of the secondary subcarrier contribution;
+- `secondary_phase`: in-phase, anti-phase, quadrature, or not applicable.
+
+TMBOC uses a time-multiplex fraction rather than a fixed subcarrier phase, so `secondary_phase` is `kNotApplicable`.
+
+## Authoritative source baseline
+
+The table is based on public system interface specifications rather than carrier-frequency inference or RINEX-name heuristics.
+
+### GPS
+
+- IS-GPS-200N, 1 Aug 2022, with currently published interface revision notices: L1 C/A and L2 P(Y)/L2C signal definitions.
+- IS-GPS-705J, 1 Aug 2022, with currently published interface revision notices: L5 signal definition.
+- IS-GPS-800J, 1 Aug 2022, with currently published interface revision notices: L1C signal definition. L1C-P uses TMBOC based on BOC(1,1) and BOC(6,1); the BOC(6,1) time/power fraction used for the idealized profile is 4/33.
+- Current public documents are indexed by GPS.gov under Interface Control Documents / Interface Specifications.
+
+Representative central profiles:
+
+- GPS L1 C/A: BPSK, 1.023 Mcps.
+- GPS L2 P: BPSK, 10.23 Mcps.
+- GPS L5 Q: BPSK, 10.23 Mcps.
+- GPS L1C pilot (`1L`): TMBOC(6,1,4/33), 1.023 Mcps code.
+
+GPS L2C `2S` remains explicitly unsupported in V1 correlation metadata. The RINEX component and the L2C CM/CL time-multiplexed waveform need a dedicated correlation convention in #134; assigning a generic triangle here would hide that decision.
+
+### QZSS
+
+- Cabinet Office, Japan, IS-QZSS-PNT-006, 11 Jul 2024, is the current PNT interface specification used as the QZSS signal baseline.
+- QZSS L1 C/A and L5 follow the compatible public PNT component definitions and are represented as 1.023 Mcps and 10.23 Mcps BPSK-style tracked components respectively.
+
+QZSS L1C and L2C are explicitly unsupported in the V1 metadata. Current QZSS generations/blocks do not give the existing central `SignalDefinition` enough satellite-block/component identity to freeze one unambiguous ideal correlation profile without adding more state. #133 does not guess.
+
+### Galileo
+
+- Galileo Open Service SIS ICD v2.2, November 2025, is the current in-force OS SIS reference.
+- E1-C is the pilot component of the E1 CBOC(6,1,1/11) signal. The pilot uses the minus/anti-phase CBOC combination, represented here as a 1/11 BOC(6,1) secondary power fraction relative to BOC(1,1).
+- E5a-Q and E5b-Q use 10.23 Mcps ranging codes. For V1 code correlation they are treated as independently tracked sideband components rather than a full-band AltBOC correlator.
+- E6-C uses a 5.115 Mcps BPSK-style tracked code component.
+
+### BeiDou
+
+- BDS-SIS-ICD-B1I-3.0, February 2019: B1I, BPSK, 2.046 Mcps.
+- BDS-SIS-ICD-B3I-1.0, February 2018: B3I, 10.23 Mcps.
+- BDS-SIS-ICD-B1C-1.0, December 2017: B1C pilot code rate 1.023 Mcps and QMBOC(6,1,4/33). The BOC(1,1) and BOC(6,1) subcarriers are in quadrature with power ratio 29:4.
+- BDS-SIS-ICD-B2a-1.0, December 2017: B2a pilot/data ranging code rate 10.23 Mcps and BPSK(10).
+- BDS-SIS-ICD-B2b-1.0, July 2020: B2b-I ranging code rate 10.23 Mcps and BPSK(10).
+
+### GLONASS
+
+The existing central signals represent the open FDMA G1/G2 components and the L3OC-Q component. Their public signal definitions use:
+
+- G1 open code: 0.511 Mcps BPSK-style code component;
+- G2 open code: 0.511 Mcps BPSK-style code component;
+- L3OC data/pilot components: 10.23 Mcps BPSK(10) components combined in quadrature at RF.
+
+These profiles are code-component metadata only; GLONASS carrier FDMA frequency/channel handling remains in the existing carrier-frequency model and is not duplicated here.
+
+## Unsupported means explicit, not fallback
+
+A `kUnsupported` profile must carry zero waveform parameters. `validate_code_correlation_profile()` rejects guessed parameters attached to an unsupported entry. Later correlation code must call `signal_has_supported_code_correlation()` (or otherwise check the profile) and fail explicitly for unsupported signals.
+
+There is deliberately no fallback such as "unknown -> triangular BPSK".
+
+## Validation contract
+
+`tests/unit/test_signal_correlation_metadata.cpp` permanently checks that:
+
+- every central signal has a structurally valid profile;
+- the unsupported set is explicit and stable;
+- #119 minimum signals have the required representative profile and chip-rate metadata;
+- GPS L1C, Galileo E1-C, and BeiDou B1C retain their distinct TMBOC/CBOC/QMBOC identities;
+- invalid/non-finite/inconsistent profiles are rejected;
+- existing signal lookup/carrier/NAV/bias/OEM7 behavior remains owned by the existing `SignalDefinition` regression suite.
+
+## Explicit exclusions
+
+Issue #133 does not implement:
+
+- the autocorrelation function itself (#134);
+- composite path correlation or coherent path summation (#119);
+- Early/Late discrimination or root solving (#119);
+- CN0/tracking/observables (#120-#122);
+- IF/baseband samples;
+- any NAV/EPH/ION generation, modification, interpolation, or retargeting.

--- a/docs/SIGNAL_CORRELATION_METADATA_SOURCES.md
+++ b/docs/SIGNAL_CORRELATION_METADATA_SOURCES.md
@@ -7,11 +7,11 @@ This companion source index records the public specifications used for Issue #13
 - Galileo: Galileo Open Service SIS ICD v2.2 (November 2025), current in-force Open Service reference published by the European GNSS Service Centre.
 - BeiDou B1I: BDS-SIS-ICD-B1I-3.0 (February 2019).
 - BeiDou B3I: BDS-SIS-ICD-B3I-1.0 (February 2018).
-- BeiDou B1C: BDS-SIS-ICD-B1C-1.0 (December 2017).
+- BeiDou B1C: BDS-SIS-ICD-B1C-1.0 (December 2017). The pilot QMBOC complex-envelope convention uses the BOC(6,1) term with `-j` relative to BOC(1,1), so the central profile preserves **negative quadrature** rather than unsigned quadrature.
 - BeiDou B2a: BDS-SIS-ICD-B2a-1.0 (December 2017).
 - BeiDou B2b: BDS-SIS-ICD-B2b-1.0 (July 2020).
 - GLONASS: public GLONASS open-signal interface definitions for legacy L1/L2 OF and L3OC; the central metadata records only the already-supported tracked code components and does not change FDMA carrier handling.
 
-Verified profile anchors used by the permanent tests include GPS L1C pilot TMBOC, GPS L5 10.23 Mcps, Galileo E1-C CBOC(-), Galileo E5a/E5b 10.23 Mcps sideband components, BeiDou B1C pilot QMBOC(6,1,4/33), and BeiDou B2a/B2b BPSK(10).
+Verified profile anchors used by the permanent tests include GPS L1C pilot TMBOC, GPS L5 10.23 Mcps, Galileo E1-C CBOC(-), Galileo E5a/E5b 10.23 Mcps sideband components, BeiDou B1C pilot QMBOC(6,1,4/33) with the ICD-required negative-quadrature sign, and BeiDou B2a/B2b BPSK(10).
 
 If a later implementation needs a signal whose current central entry is `kUnsupported`, that issue must identify the exact tracked component and authoritative waveform convention first. It must not replace `kUnsupported` with a generic BPSK triangle merely to make the signal pass through the DLL.

--- a/docs/SIGNAL_CORRELATION_METADATA_SOURCES.md
+++ b/docs/SIGNAL_CORRELATION_METADATA_SOURCES.md
@@ -1,0 +1,17 @@
+# Signal correlation metadata source index
+
+This companion source index records the public specifications used for Issue #133. It is intentionally separated from implementation code so later Issue #134 reviews can verify correlation equations against the same source baseline.
+
+- GPS: GPS.gov current Interface Control Documents / Interface Specifications index; IS-GPS-200N, IS-GPS-705J, IS-GPS-800J and their published revision notices.
+- QZSS: Cabinet Office, Japan, IS-QZSS-PNT-006 (11 July 2024).
+- Galileo: Galileo Open Service SIS ICD v2.2 (November 2025), current in-force Open Service reference published by the European GNSS Service Centre.
+- BeiDou B1I: BDS-SIS-ICD-B1I-3.0 (February 2019).
+- BeiDou B3I: BDS-SIS-ICD-B3I-1.0 (February 2018).
+- BeiDou B1C: BDS-SIS-ICD-B1C-1.0 (December 2017).
+- BeiDou B2a: BDS-SIS-ICD-B2a-1.0 (December 2017).
+- BeiDou B2b: BDS-SIS-ICD-B2b-1.0 (July 2020).
+- GLONASS: public GLONASS open-signal interface definitions for legacy L1/L2 OF and L3OC; the central metadata records only the already-supported tracked code components and does not change FDMA carrier handling.
+
+Verified profile anchors used by the permanent tests include GPS L1C pilot TMBOC, GPS L5 10.23 Mcps, Galileo E1-C CBOC(-), Galileo E5a/E5b 10.23 Mcps sideband components, BeiDou B1C pilot QMBOC(6,1,4/33), and BeiDou B2a/B2b BPSK(10).
+
+If a later implementation needs a signal whose current central entry is `kUnsupported`, that issue must identify the exact tracked component and authoritative waveform convention first. It must not replace `kUnsupported` with a generic BPSK triangle merely to make the signal pass through the DLL.

--- a/src/gnss/signal_definitions.cpp
+++ b/src/gnss/signal_definitions.cpp
@@ -41,10 +41,11 @@ constexpr CodeCorrelationProfile cboc_correlation(double chip_rate_hz, double pr
 
 constexpr CodeCorrelationProfile qmboc_correlation(double chip_rate_hz, double primary_subcarrier_rate_hz,
                                                    double secondary_subcarrier_rate_hz,
-                                                   double secondary_power_fraction) {
+                                                   double secondary_power_fraction,
+                                                   CompositeSubcarrierPhase secondary_phase) {
     return {CodeCorrelationModel::kQmboc, chip_rate_hz,
             primary_subcarrier_rate_hz,   secondary_subcarrier_rate_hz,
-            secondary_power_fraction,     CompositeSubcarrierPhase::kQuadrature};
+            secondary_power_fraction,     secondary_phase};
 }
 
 void set_error(std::string* error_message, const char* message) {
@@ -119,7 +120,7 @@ constexpr SignalDefinition kSignalDefinitions[] = {
      NavMessageFamily::kBeidouD1D2, CodeBiasModel::kBeidouB3I, 2, bpsk_correlation(10.23e6)},
     {GnssConstellation::kBeidou, SignalId::kBeidouB1C, "BeiDou B1C", "1P", CarrierFrequencyModel::kFixed, 1575.42e6,
      NavMessageFamily::kBeidouBcnav1, CodeBiasModel::kBeidouB1C, 7,
-     qmboc_correlation(1.023e6, 1.023e6, 6.138e6, 4.0 / 33.0)},
+     qmboc_correlation(1.023e6, 1.023e6, 6.138e6, 4.0 / 33.0, CompositeSubcarrierPhase::kNegativeQuadrature)},
     {GnssConstellation::kBeidou, SignalId::kBeidouB2A, "BeiDou B2a", "5P", CarrierFrequencyModel::kFixed, 1176.45e6,
      NavMessageFamily::kBeidouBcnav2, CodeBiasModel::kBeidouB2A, 9, bpsk_correlation(10.23e6)},
     {GnssConstellation::kBeidou, SignalId::kBeidouB2B, "BeiDou B2b", "7D", CarrierFrequencyModel::kFixed, 1207.14e6,
@@ -218,7 +219,9 @@ bool validate_code_correlation_profile(const CodeCorrelationProfile& profile, st
             return true;
 
         case CodeCorrelationModel::kQmboc:
-            if (!composite_rates_valid(profile) || profile.secondary_phase != CompositeSubcarrierPhase::kQuadrature) {
+            if (!composite_rates_valid(profile) ||
+                (profile.secondary_phase != CompositeSubcarrierPhase::kPositiveQuadrature &&
+                 profile.secondary_phase != CompositeSubcarrierPhase::kNegativeQuadrature)) {
                 set_error(error_message, "QMBOC correlation profile parameters are inconsistent");
                 return false;
             }

--- a/src/gnss/signal_definitions.cpp
+++ b/src/gnss/signal_definitions.cpp
@@ -16,58 +16,116 @@ constexpr double kGlonassG2StepHz = 0.4375e6;
 constexpr int kGlonassMinFcn = -7;
 constexpr int kGlonassMaxFcn = 6;
 
+constexpr CodeCorrelationProfile unsupported_correlation() {
+    return {CodeCorrelationModel::kUnsupported, 0.0, 0.0, 0.0, 0.0,
+            CompositeSubcarrierPhase::kNotApplicable};
+}
+
+constexpr CodeCorrelationProfile bpsk_correlation(double chip_rate_hz) {
+    return {CodeCorrelationModel::kBpsk, chip_rate_hz, 0.0, 0.0, 0.0,
+            CompositeSubcarrierPhase::kNotApplicable};
+}
+
+constexpr CodeCorrelationProfile tmboc_correlation(double chip_rate_hz, double primary_subcarrier_rate_hz,
+                                                    double secondary_subcarrier_rate_hz,
+                                                    double secondary_power_fraction) {
+    return {CodeCorrelationModel::kTmboc, chip_rate_hz, primary_subcarrier_rate_hz, secondary_subcarrier_rate_hz,
+            secondary_power_fraction, CompositeSubcarrierPhase::kNotApplicable};
+}
+
+constexpr CodeCorrelationProfile cboc_correlation(double chip_rate_hz, double primary_subcarrier_rate_hz,
+                                                   double secondary_subcarrier_rate_hz,
+                                                   double secondary_power_fraction,
+                                                   CompositeSubcarrierPhase secondary_phase) {
+    return {CodeCorrelationModel::kCboc, chip_rate_hz, primary_subcarrier_rate_hz, secondary_subcarrier_rate_hz,
+            secondary_power_fraction, secondary_phase};
+}
+
+constexpr CodeCorrelationProfile qmboc_correlation(double chip_rate_hz, double primary_subcarrier_rate_hz,
+                                                    double secondary_subcarrier_rate_hz,
+                                                    double secondary_power_fraction) {
+    return {CodeCorrelationModel::kQmboc, chip_rate_hz, primary_subcarrier_rate_hz, secondary_subcarrier_rate_hz,
+            secondary_power_fraction, CompositeSubcarrierPhase::kQuadrature};
+}
+
+void set_error(std::string* error_message, const char* message) {
+    if (error_message != nullptr) {
+        *error_message = message;
+    }
+}
+
+bool finite_nonnegative(double value) {
+    return std::isfinite(value) && value >= 0.0;
+}
+
+bool composite_rates_valid(const CodeCorrelationProfile& profile) {
+    return std::isfinite(profile.chip_rate_hz) && profile.chip_rate_hz > 0.0 &&
+           std::isfinite(profile.primary_subcarrier_rate_hz) && profile.primary_subcarrier_rate_hz > 0.0 &&
+           std::isfinite(profile.secondary_subcarrier_rate_hz) &&
+           profile.secondary_subcarrier_rate_hz > profile.primary_subcarrier_rate_hz &&
+           std::isfinite(profile.secondary_power_fraction) && profile.secondary_power_fraction > 0.0 &&
+           profile.secondary_power_fraction < 1.0;
+}
+
 // OEM7 signal types match the RANGE RINEX mapping table in the pinned RTKLIB
 // fork. RINEX codes resolve through RTKLIB, including its modern-BDS extension.
+//
+// Code-correlation profiles are the tracked RINEX component, not a full RF
+// composite waveform. Ambiguous profiles are explicitly unsupported rather than
+// silently mapped to a generic BPSK triangle. See docs/SIGNAL_CORRELATION_METADATA.md.
 constexpr SignalDefinition kSignalDefinitions[] = {
     {GnssConstellation::kGps, SignalId::kGpsL1Ca, "GPS L1 C/A", "1C", CarrierFrequencyModel::kFixed, 1575.42e6,
-     NavMessageFamily::kGpsLnav, CodeBiasModel::kGpsL1Ca, 0},
+     NavMessageFamily::kGpsLnav, CodeBiasModel::kGpsL1Ca, 0, bpsk_correlation(1.023e6)},
     {GnssConstellation::kGps, SignalId::kGpsL1C, "GPS L1C", "1L", CarrierFrequencyModel::kFixed, 1575.42e6,
-     NavMessageFamily::kGpsCnav2, CodeBiasModel::kGpsL1C, 16},
+     NavMessageFamily::kGpsCnav2, CodeBiasModel::kGpsL1C, 16,
+     tmboc_correlation(1.023e6, 1.023e6, 6.138e6, 4.0 / 33.0)},
     {GnssConstellation::kGps, SignalId::kGpsL2P, "GPS L2P", "2P", CarrierFrequencyModel::kFixed, 1227.60e6,
-     NavMessageFamily::kGpsLnav, CodeBiasModel::kGpsL2P, 5},
+     NavMessageFamily::kGpsLnav, CodeBiasModel::kGpsL2P, 5, bpsk_correlation(10.23e6)},
     {GnssConstellation::kGps, SignalId::kGpsL2C, "GPS L2C", "2S", CarrierFrequencyModel::kFixed, 1227.60e6,
-     NavMessageFamily::kGpsCnav, CodeBiasModel::kGpsL2C, 17},
+     NavMessageFamily::kGpsCnav, CodeBiasModel::kGpsL2C, 17, unsupported_correlation()},
     {GnssConstellation::kGps, SignalId::kGpsL5Q, "GPS L5Q", "5Q", CarrierFrequencyModel::kFixed, 1176.45e6,
-     NavMessageFamily::kGpsCnav, CodeBiasModel::kGpsL5Q, 14},
+     NavMessageFamily::kGpsCnav, CodeBiasModel::kGpsL5Q, 14, bpsk_correlation(10.23e6)},
 
     {GnssConstellation::kQzss, SignalId::kQzssL1Ca, "QZSS L1 C/A", "1C", CarrierFrequencyModel::kFixed, 1575.42e6,
-     NavMessageFamily::kQzssLnav, CodeBiasModel::kQzssL1Ca, 0},
+     NavMessageFamily::kQzssLnav, CodeBiasModel::kQzssL1Ca, 0, bpsk_correlation(1.023e6)},
     {GnssConstellation::kQzss, SignalId::kQzssL1C, "QZSS L1C", "1L", CarrierFrequencyModel::kFixed, 1575.42e6,
-     NavMessageFamily::kQzssCnav2, CodeBiasModel::kQzssL1C, 16},
+     NavMessageFamily::kQzssCnav2, CodeBiasModel::kQzssL1C, 16, unsupported_correlation()},
     {GnssConstellation::kQzss, SignalId::kQzssL2C, "QZSS L2C", "2S", CarrierFrequencyModel::kFixed, 1227.60e6,
-     NavMessageFamily::kQzssCnav, CodeBiasModel::kQzssL2C, 17},
+     NavMessageFamily::kQzssCnav, CodeBiasModel::kQzssL2C, 17, unsupported_correlation()},
     {GnssConstellation::kQzss, SignalId::kQzssL5Q, "QZSS L5Q", "5Q", CarrierFrequencyModel::kFixed, 1176.45e6,
-     NavMessageFamily::kQzssCnav, CodeBiasModel::kQzssL5Q, 14},
+     NavMessageFamily::kQzssCnav, CodeBiasModel::kQzssL5Q, 14, bpsk_correlation(10.23e6)},
 
     {GnssConstellation::kGlonass, SignalId::kGlonassG1, "GLONASS G1", "1C", CarrierFrequencyModel::kGlonassFdmaG1,
-     kGlonassG1BaseHz, NavMessageFamily::kGlonassFdma, CodeBiasModel::kGlonassG1, 0},
+     kGlonassG1BaseHz, NavMessageFamily::kGlonassFdma, CodeBiasModel::kGlonassG1, 0, bpsk_correlation(0.511e6)},
     {GnssConstellation::kGlonass, SignalId::kGlonassG2, "GLONASS G2", "2C", CarrierFrequencyModel::kGlonassFdmaG2,
-     kGlonassG2BaseHz, NavMessageFamily::kGlonassFdma, CodeBiasModel::kGlonassG2, 1},
+     kGlonassG2BaseHz, NavMessageFamily::kGlonassFdma, CodeBiasModel::kGlonassG2, 1, bpsk_correlation(0.511e6)},
     {GnssConstellation::kGlonass, SignalId::kGlonassG3, "GLONASS G3", "3Q", CarrierFrequencyModel::kFixed, 1202.025e6,
-     NavMessageFamily::kGlonassL3Oc, CodeBiasModel::kGlonassG3, 6},
+     NavMessageFamily::kGlonassL3Oc, CodeBiasModel::kGlonassG3, 6, bpsk_correlation(10.23e6)},
 
     {GnssConstellation::kGalileo, SignalId::kGalileoE1, "Galileo E1", "1C", CarrierFrequencyModel::kFixed, 1575.42e6,
-     NavMessageFamily::kGalileoInav, CodeBiasModel::kGalileoE1, 2},
+     NavMessageFamily::kGalileoInav, CodeBiasModel::kGalileoE1, 2,
+     cboc_correlation(1.023e6, 1.023e6, 6.138e6, 1.0 / 11.0, CompositeSubcarrierPhase::kAntiPhase)},
     {GnssConstellation::kGalileo, SignalId::kGalileoE5A, "Galileo E5a", "5Q", CarrierFrequencyModel::kFixed, 1176.45e6,
-     NavMessageFamily::kGalileoFnav, CodeBiasModel::kGalileoE5A, 12},
+     NavMessageFamily::kGalileoFnav, CodeBiasModel::kGalileoE5A, 12, bpsk_correlation(10.23e6)},
     {GnssConstellation::kGalileo, SignalId::kGalileoE5B, "Galileo E5b", "7Q", CarrierFrequencyModel::kFixed, 1207.14e6,
-     NavMessageFamily::kGalileoInav, CodeBiasModel::kGalileoE5B, 17},
+     NavMessageFamily::kGalileoInav, CodeBiasModel::kGalileoE5B, 17, bpsk_correlation(10.23e6)},
     // Galileo HAS is transmitted on the E6-B data component, but the HAS Initial
     // Service code-bias observable is E6-C (RINEX C6C). OEM7 RANGE signal type
     // 7 is E6C; type 6 would be E6B/C6B and must not consume a C6C OSB.
     {GnssConstellation::kGalileo, SignalId::kGalileoE6, "Galileo E6", "6C", CarrierFrequencyModel::kFixed, 1278.75e6,
-     NavMessageFamily::kGalileoCnav, CodeBiasModel::kGalileoE6, 7},
+     NavMessageFamily::kGalileoCnav, CodeBiasModel::kGalileoE6, 7, bpsk_correlation(5.115e6)},
 
     {GnssConstellation::kBeidou, SignalId::kBeidouB1I, "BeiDou B1I", "2I", CarrierFrequencyModel::kFixed, 1561.098e6,
-     NavMessageFamily::kBeidouD1D2, CodeBiasModel::kBeidouB1I, 0},
+     NavMessageFamily::kBeidouD1D2, CodeBiasModel::kBeidouB1I, 0, bpsk_correlation(2.046e6)},
     {GnssConstellation::kBeidou, SignalId::kBeidouB3I, "BeiDou B3I", "6I", CarrierFrequencyModel::kFixed, 1268.52e6,
-     NavMessageFamily::kBeidouD1D2, CodeBiasModel::kBeidouB3I, 2},
+     NavMessageFamily::kBeidouD1D2, CodeBiasModel::kBeidouB3I, 2, bpsk_correlation(10.23e6)},
     {GnssConstellation::kBeidou, SignalId::kBeidouB1C, "BeiDou B1C", "1P", CarrierFrequencyModel::kFixed, 1575.42e6,
-     NavMessageFamily::kBeidouBcnav1, CodeBiasModel::kBeidouB1C, 7},
+     NavMessageFamily::kBeidouBcnav1, CodeBiasModel::kBeidouB1C, 7,
+     qmboc_correlation(1.023e6, 1.023e6, 6.138e6, 4.0 / 33.0)},
     {GnssConstellation::kBeidou, SignalId::kBeidouB2A, "BeiDou B2a", "5P", CarrierFrequencyModel::kFixed, 1176.45e6,
-     NavMessageFamily::kBeidouBcnav2, CodeBiasModel::kBeidouB2A, 9},
+     NavMessageFamily::kBeidouBcnav2, CodeBiasModel::kBeidouB2A, 9, bpsk_correlation(10.23e6)},
     {GnssConstellation::kBeidou, SignalId::kBeidouB2B, "BeiDou B2b", "7D", CarrierFrequencyModel::kFixed, 1207.14e6,
-     NavMessageFamily::kBeidouBcnav3, CodeBiasModel::kBeidouB2B, 11},
+     NavMessageFamily::kBeidouBcnav3, CodeBiasModel::kBeidouB2B, 11, bpsk_correlation(10.23e6)},
 };
 
 constexpr std::size_t kSignalDefinitionCount = sizeof(kSignalDefinitions) / sizeof(kSignalDefinitions[0]);
@@ -116,6 +174,68 @@ const SignalDefinition* find_signal_definition_by_oem7(GnssConstellation constel
         }
     }
     return nullptr;
+}
+
+bool validate_code_correlation_profile(const CodeCorrelationProfile& profile, std::string* error_message) {
+    if (!finite_nonnegative(profile.chip_rate_hz) || !finite_nonnegative(profile.primary_subcarrier_rate_hz) ||
+        !finite_nonnegative(profile.secondary_subcarrier_rate_hz) ||
+        !finite_nonnegative(profile.secondary_power_fraction)) {
+        set_error(error_message, "signal code-correlation profile contains a non-finite or negative numeric value");
+        return false;
+    }
+
+    switch (profile.model) {
+        case CodeCorrelationModel::kUnsupported:
+            if (profile.chip_rate_hz != 0.0 || profile.primary_subcarrier_rate_hz != 0.0 ||
+                profile.secondary_subcarrier_rate_hz != 0.0 || profile.secondary_power_fraction != 0.0 ||
+                profile.secondary_phase != CompositeSubcarrierPhase::kNotApplicable) {
+                set_error(error_message, "unsupported correlation profile must not carry guessed waveform parameters");
+                return false;
+            }
+            return true;
+
+        case CodeCorrelationModel::kBpsk:
+            if (profile.chip_rate_hz <= 0.0 || profile.primary_subcarrier_rate_hz != 0.0 ||
+                profile.secondary_subcarrier_rate_hz != 0.0 || profile.secondary_power_fraction != 0.0 ||
+                profile.secondary_phase != CompositeSubcarrierPhase::kNotApplicable) {
+                set_error(error_message, "BPSK correlation profile parameters are inconsistent");
+                return false;
+            }
+            return true;
+
+        case CodeCorrelationModel::kTmboc:
+            if (!composite_rates_valid(profile) ||
+                profile.secondary_phase != CompositeSubcarrierPhase::kNotApplicable) {
+                set_error(error_message, "TMBOC correlation profile parameters are inconsistent");
+                return false;
+            }
+            return true;
+
+        case CodeCorrelationModel::kCboc:
+            if (!composite_rates_valid(profile) ||
+                (profile.secondary_phase != CompositeSubcarrierPhase::kInPhase &&
+                 profile.secondary_phase != CompositeSubcarrierPhase::kAntiPhase)) {
+                set_error(error_message, "CBOC correlation profile parameters are inconsistent");
+                return false;
+            }
+            return true;
+
+        case CodeCorrelationModel::kQmboc:
+            if (!composite_rates_valid(profile) ||
+                profile.secondary_phase != CompositeSubcarrierPhase::kQuadrature) {
+                set_error(error_message, "QMBOC correlation profile parameters are inconsistent");
+                return false;
+            }
+            return true;
+    }
+
+    set_error(error_message, "unknown signal code-correlation profile model");
+    return false;
+}
+
+bool signal_has_supported_code_correlation(const SignalDefinition& definition) {
+    return definition.code_correlation.model != CodeCorrelationModel::kUnsupported &&
+           validate_code_correlation_profile(definition.code_correlation, nullptr);
 }
 
 bool signal_carrier_frequency_hz(const SignalDefinition& definition, int glonass_fcn, double* frequency_hz) {

--- a/src/gnss/signal_definitions.cpp
+++ b/src/gnss/signal_definitions.cpp
@@ -40,11 +40,9 @@ constexpr CodeCorrelationProfile cboc_correlation(double chip_rate_hz, double pr
 }
 
 constexpr CodeCorrelationProfile qmboc_correlation(double chip_rate_hz, double primary_subcarrier_rate_hz,
-                                                   double secondary_subcarrier_rate_hz,
-                                                   double secondary_power_fraction,
+                                                   double secondary_subcarrier_rate_hz, double secondary_power_fraction,
                                                    CompositeSubcarrierPhase secondary_phase) {
-    return {CodeCorrelationModel::kQmboc, chip_rate_hz,
-            primary_subcarrier_rate_hz,   secondary_subcarrier_rate_hz,
+    return {CodeCorrelationModel::kQmboc, chip_rate_hz,   primary_subcarrier_rate_hz, secondary_subcarrier_rate_hz,
             secondary_power_fraction,     secondary_phase};
 }
 

--- a/src/gnss/signal_definitions.cpp
+++ b/src/gnss/signal_definitions.cpp
@@ -17,35 +17,34 @@ constexpr int kGlonassMinFcn = -7;
 constexpr int kGlonassMaxFcn = 6;
 
 constexpr CodeCorrelationProfile unsupported_correlation() {
-    return {CodeCorrelationModel::kUnsupported, 0.0, 0.0, 0.0, 0.0,
-            CompositeSubcarrierPhase::kNotApplicable};
+    return {CodeCorrelationModel::kUnsupported, 0.0, 0.0, 0.0, 0.0, CompositeSubcarrierPhase::kNotApplicable};
 }
 
 constexpr CodeCorrelationProfile bpsk_correlation(double chip_rate_hz) {
-    return {CodeCorrelationModel::kBpsk, chip_rate_hz, 0.0, 0.0, 0.0,
-            CompositeSubcarrierPhase::kNotApplicable};
+    return {CodeCorrelationModel::kBpsk, chip_rate_hz, 0.0, 0.0, 0.0, CompositeSubcarrierPhase::kNotApplicable};
 }
 
 constexpr CodeCorrelationProfile tmboc_correlation(double chip_rate_hz, double primary_subcarrier_rate_hz,
-                                                    double secondary_subcarrier_rate_hz,
-                                                    double secondary_power_fraction) {
-    return {CodeCorrelationModel::kTmboc, chip_rate_hz, primary_subcarrier_rate_hz, secondary_subcarrier_rate_hz,
-            secondary_power_fraction, CompositeSubcarrierPhase::kNotApplicable};
+                                                   double secondary_subcarrier_rate_hz,
+                                                   double secondary_power_fraction) {
+    return {CodeCorrelationModel::kTmboc, chip_rate_hz,
+            primary_subcarrier_rate_hz,   secondary_subcarrier_rate_hz,
+            secondary_power_fraction,     CompositeSubcarrierPhase::kNotApplicable};
 }
 
 constexpr CodeCorrelationProfile cboc_correlation(double chip_rate_hz, double primary_subcarrier_rate_hz,
-                                                   double secondary_subcarrier_rate_hz,
-                                                   double secondary_power_fraction,
-                                                   CompositeSubcarrierPhase secondary_phase) {
-    return {CodeCorrelationModel::kCboc, chip_rate_hz, primary_subcarrier_rate_hz, secondary_subcarrier_rate_hz,
-            secondary_power_fraction, secondary_phase};
+                                                  double secondary_subcarrier_rate_hz, double secondary_power_fraction,
+                                                  CompositeSubcarrierPhase secondary_phase) {
+    return {CodeCorrelationModel::kCboc, chip_rate_hz,   primary_subcarrier_rate_hz, secondary_subcarrier_rate_hz,
+            secondary_power_fraction,    secondary_phase};
 }
 
 constexpr CodeCorrelationProfile qmboc_correlation(double chip_rate_hz, double primary_subcarrier_rate_hz,
-                                                    double secondary_subcarrier_rate_hz,
-                                                    double secondary_power_fraction) {
-    return {CodeCorrelationModel::kQmboc, chip_rate_hz, primary_subcarrier_rate_hz, secondary_subcarrier_rate_hz,
-            secondary_power_fraction, CompositeSubcarrierPhase::kQuadrature};
+                                                   double secondary_subcarrier_rate_hz,
+                                                   double secondary_power_fraction) {
+    return {CodeCorrelationModel::kQmboc, chip_rate_hz,
+            primary_subcarrier_rate_hz,   secondary_subcarrier_rate_hz,
+            secondary_power_fraction,     CompositeSubcarrierPhase::kQuadrature};
 }
 
 void set_error(std::string* error_message, const char* message) {
@@ -77,8 +76,7 @@ constexpr SignalDefinition kSignalDefinitions[] = {
     {GnssConstellation::kGps, SignalId::kGpsL1Ca, "GPS L1 C/A", "1C", CarrierFrequencyModel::kFixed, 1575.42e6,
      NavMessageFamily::kGpsLnav, CodeBiasModel::kGpsL1Ca, 0, bpsk_correlation(1.023e6)},
     {GnssConstellation::kGps, SignalId::kGpsL1C, "GPS L1C", "1L", CarrierFrequencyModel::kFixed, 1575.42e6,
-     NavMessageFamily::kGpsCnav2, CodeBiasModel::kGpsL1C, 16,
-     tmboc_correlation(1.023e6, 1.023e6, 6.138e6, 4.0 / 33.0)},
+     NavMessageFamily::kGpsCnav2, CodeBiasModel::kGpsL1C, 16, tmboc_correlation(1.023e6, 1.023e6, 6.138e6, 4.0 / 33.0)},
     {GnssConstellation::kGps, SignalId::kGpsL2P, "GPS L2P", "2P", CarrierFrequencyModel::kFixed, 1227.60e6,
      NavMessageFamily::kGpsLnav, CodeBiasModel::kGpsL2P, 5, bpsk_correlation(10.23e6)},
     {GnssConstellation::kGps, SignalId::kGpsL2C, "GPS L2C", "2S", CarrierFrequencyModel::kFixed, 1227.60e6,
@@ -212,17 +210,15 @@ bool validate_code_correlation_profile(const CodeCorrelationProfile& profile, st
             return true;
 
         case CodeCorrelationModel::kCboc:
-            if (!composite_rates_valid(profile) ||
-                (profile.secondary_phase != CompositeSubcarrierPhase::kInPhase &&
-                 profile.secondary_phase != CompositeSubcarrierPhase::kAntiPhase)) {
+            if (!composite_rates_valid(profile) || (profile.secondary_phase != CompositeSubcarrierPhase::kInPhase &&
+                                                    profile.secondary_phase != CompositeSubcarrierPhase::kAntiPhase)) {
                 set_error(error_message, "CBOC correlation profile parameters are inconsistent");
                 return false;
             }
             return true;
 
         case CodeCorrelationModel::kQmboc:
-            if (!composite_rates_valid(profile) ||
-                profile.secondary_phase != CompositeSubcarrierPhase::kQuadrature) {
+            if (!composite_rates_valid(profile) || profile.secondary_phase != CompositeSubcarrierPhase::kQuadrature) {
                 set_error(error_message, "QMBOC correlation profile parameters are inconsistent");
                 return false;
             }

--- a/src/gnss/signal_definitions.h
+++ b/src/gnss/signal_definitions.h
@@ -102,12 +102,14 @@ enum class CodeCorrelationModel {
 
 // Relationship of a secondary subcarrier to the primary subcarrier for
 // composite correlation models. TMBOC time multiplexing does not use a fixed
-// phase relation and therefore uses kNotApplicable.
+// phase relation and therefore uses kNotApplicable. Quadrature sign is kept
+// explicitly because complex code correlation depends on +90 versus -90 deg.
 enum class CompositeSubcarrierPhase {
     kNotApplicable = 0,
     kInPhase,
     kAntiPhase,
-    kQuadrature,
+    kPositiveQuadrature,
+    kNegativeQuadrature,
 };
 
 struct CodeCorrelationProfile {

--- a/src/gnss/signal_definitions.h
+++ b/src/gnss/signal_definitions.h
@@ -2,6 +2,7 @@
 #define GNSS_SIM_SRC_GNSS_SIGNAL_DEFINITIONS_H_
 
 #include <cstddef>
+#include <string>
 
 namespace gnss_sim {
 
@@ -89,6 +90,35 @@ enum class CodeBiasModel {
     kBeidouB2B,
 };
 
+// Ideal code-domain correlation family used by the V1 DLL model. This is
+// intentionally narrower than a full IF/baseband signal description.
+enum class CodeCorrelationModel {
+    kUnsupported = 0,
+    kBpsk,
+    kTmboc,
+    kCboc,
+    kQmboc,
+};
+
+// Relationship of a secondary subcarrier to the primary subcarrier for
+// composite correlation models. TMBOC time multiplexing does not use a fixed
+// phase relation and therefore uses kNotApplicable.
+enum class CompositeSubcarrierPhase {
+    kNotApplicable = 0,
+    kInPhase,
+    kAntiPhase,
+    kQuadrature,
+};
+
+struct CodeCorrelationProfile {
+    CodeCorrelationModel model;
+    double chip_rate_hz;
+    double primary_subcarrier_rate_hz;
+    double secondary_subcarrier_rate_hz;
+    double secondary_power_fraction;
+    CompositeSubcarrierPhase secondary_phase;
+};
+
 struct SignalDefinition {
     GnssConstellation constellation;
     SignalId signal_id;
@@ -99,12 +129,16 @@ struct SignalDefinition {
     NavMessageFamily nav_message_family;
     CodeBiasModel code_bias_model;
     int novatel_oem7_signal_type;
+    CodeCorrelationProfile code_correlation;
 };
 
 const SignalDefinition* signal_definitions(std::size_t* count);
 const SignalDefinition* find_signal_definition(SignalId signal_id);
 const SignalDefinition* find_signal_definition_by_rinex(GnssConstellation constellation, const char* rinex_signal_code);
 const SignalDefinition* find_signal_definition_by_oem7(GnssConstellation constellation, int novatel_oem7_signal_type);
+
+bool validate_code_correlation_profile(const CodeCorrelationProfile& profile, std::string* error_message);
+bool signal_has_supported_code_correlation(const SignalDefinition& definition);
 
 bool signal_carrier_frequency_hz(const SignalDefinition& definition, int glonass_fcn, double* frequency_hz);
 bool signal_wavelength_m(const SignalDefinition& definition, int glonass_fcn, double* wavelength_m);

--- a/tests/unit/test_signal_correlation_metadata.cpp
+++ b/tests/unit/test_signal_correlation_metadata.cpp
@@ -78,7 +78,8 @@ TEST(SignalCorrelationMetadata, MinimumIssue119SignalsHaveAuthoritativeProfiles)
     EXPECT_DOUBLE_EQ(bds_b1c.code_correlation.primary_subcarrier_rate_hz, 1.023e6);
     EXPECT_DOUBLE_EQ(bds_b1c.code_correlation.secondary_subcarrier_rate_hz, 6.138e6);
     EXPECT_DOUBLE_EQ(bds_b1c.code_correlation.secondary_power_fraction, 4.0 / 33.0);
-    EXPECT_EQ(bds_b1c.code_correlation.secondary_phase, gnss_sim::CompositeSubcarrierPhase::kQuadrature);
+    EXPECT_EQ(bds_b1c.code_correlation.secondary_phase,
+              gnss_sim::CompositeSubcarrierPhase::kNegativeQuadrature);
     EXPECT_EQ(bds_b2a.code_correlation.model, gnss_sim::CodeCorrelationModel::kBpsk);
     EXPECT_DOUBLE_EQ(bds_b2a.code_correlation.chip_rate_hz, 10.23e6);
 }
@@ -128,13 +129,18 @@ TEST(SignalCorrelationMetadata, InvalidProfilesAreRejectedWithoutSilentRepair) {
 
     gnss_sim::CodeCorrelationProfile cboc_wrong_phase{
         gnss_sim::CodeCorrelationModel::kCboc,          1.023e6, 1.023e6, 6.138e6, 1.0 / 11.0,
-        gnss_sim::CompositeSubcarrierPhase::kQuadrature};
+        gnss_sim::CompositeSubcarrierPhase::kPositiveQuadrature};
     EXPECT_FALSE(gnss_sim::validate_code_correlation_profile(cboc_wrong_phase, &error_message));
 
     gnss_sim::CodeCorrelationProfile qmboc_wrong_phase{
         gnss_sim::CodeCorrelationModel::kQmboc,        1.023e6, 1.023e6, 6.138e6, 4.0 / 33.0,
         gnss_sim::CompositeSubcarrierPhase::kAntiPhase};
     EXPECT_FALSE(gnss_sim::validate_code_correlation_profile(qmboc_wrong_phase, &error_message));
+
+    gnss_sim::CodeCorrelationProfile qmboc_positive{
+        gnss_sim::CodeCorrelationModel::kQmboc, 1.023e6, 1.023e6, 6.138e6, 4.0 / 33.0,
+        gnss_sim::CompositeSubcarrierPhase::kPositiveQuadrature};
+    EXPECT_TRUE(gnss_sim::validate_code_correlation_profile(qmboc_positive, &error_message));
 
     gnss_sim::CodeCorrelationProfile nonfinite{gnss_sim::CodeCorrelationModel::kBpsk,
                                                std::numeric_limits<double>::quiet_NaN(),

--- a/tests/unit/test_signal_correlation_metadata.cpp
+++ b/tests/unit/test_signal_correlation_metadata.cpp
@@ -78,8 +78,7 @@ TEST(SignalCorrelationMetadata, MinimumIssue119SignalsHaveAuthoritativeProfiles)
     EXPECT_DOUBLE_EQ(bds_b1c.code_correlation.primary_subcarrier_rate_hz, 1.023e6);
     EXPECT_DOUBLE_EQ(bds_b1c.code_correlation.secondary_subcarrier_rate_hz, 6.138e6);
     EXPECT_DOUBLE_EQ(bds_b1c.code_correlation.secondary_power_fraction, 4.0 / 33.0);
-    EXPECT_EQ(bds_b1c.code_correlation.secondary_phase,
-              gnss_sim::CompositeSubcarrierPhase::kNegativeQuadrature);
+    EXPECT_EQ(bds_b1c.code_correlation.secondary_phase, gnss_sim::CompositeSubcarrierPhase::kNegativeQuadrature);
     EXPECT_EQ(bds_b2a.code_correlation.model, gnss_sim::CodeCorrelationModel::kBpsk);
     EXPECT_DOUBLE_EQ(bds_b2a.code_correlation.chip_rate_hz, 10.23e6);
 }
@@ -127,9 +126,12 @@ TEST(SignalCorrelationMetadata, InvalidProfilesAreRejectedWithoutSilentRepair) {
         gnss_sim::CodeCorrelationModel::kBpsk, 0.0, 0.0, 0.0, 0.0, gnss_sim::CompositeSubcarrierPhase::kNotApplicable};
     EXPECT_FALSE(gnss_sim::validate_code_correlation_profile(bpsk_without_rate, &error_message));
 
-    gnss_sim::CodeCorrelationProfile cboc_wrong_phase{
-        gnss_sim::CodeCorrelationModel::kCboc,          1.023e6, 1.023e6, 6.138e6, 1.0 / 11.0,
-        gnss_sim::CompositeSubcarrierPhase::kPositiveQuadrature};
+    gnss_sim::CodeCorrelationProfile cboc_wrong_phase{gnss_sim::CodeCorrelationModel::kCboc,
+                                                      1.023e6,
+                                                      1.023e6,
+                                                      6.138e6,
+                                                      1.0 / 11.0,
+                                                      gnss_sim::CompositeSubcarrierPhase::kPositiveQuadrature};
     EXPECT_FALSE(gnss_sim::validate_code_correlation_profile(cboc_wrong_phase, &error_message));
 
     gnss_sim::CodeCorrelationProfile qmboc_wrong_phase{
@@ -137,9 +139,12 @@ TEST(SignalCorrelationMetadata, InvalidProfilesAreRejectedWithoutSilentRepair) {
         gnss_sim::CompositeSubcarrierPhase::kAntiPhase};
     EXPECT_FALSE(gnss_sim::validate_code_correlation_profile(qmboc_wrong_phase, &error_message));
 
-    gnss_sim::CodeCorrelationProfile qmboc_positive{
-        gnss_sim::CodeCorrelationModel::kQmboc, 1.023e6, 1.023e6, 6.138e6, 4.0 / 33.0,
-        gnss_sim::CompositeSubcarrierPhase::kPositiveQuadrature};
+    gnss_sim::CodeCorrelationProfile qmboc_positive{gnss_sim::CodeCorrelationModel::kQmboc,
+                                                    1.023e6,
+                                                    1.023e6,
+                                                    6.138e6,
+                                                    4.0 / 33.0,
+                                                    gnss_sim::CompositeSubcarrierPhase::kPositiveQuadrature};
     EXPECT_TRUE(gnss_sim::validate_code_correlation_profile(qmboc_positive, &error_message));
 
     gnss_sim::CodeCorrelationProfile nonfinite{gnss_sim::CodeCorrelationModel::kBpsk,

--- a/tests/unit/test_signal_correlation_metadata.cpp
+++ b/tests/unit/test_signal_correlation_metadata.cpp
@@ -106,8 +106,8 @@ TEST(SignalCorrelationMetadata, RepresentativeBpskRatesStaySignalSpecific) {
 }
 
 TEST(SignalCorrelationMetadata, AmbiguousCompositeSignalsFailExplicitlyInsteadOfFallingBack) {
-    for (gnss_sim::SignalId signal_id : {gnss_sim::SignalId::kGpsL2C, gnss_sim::SignalId::kQzssL1C,
-                                         gnss_sim::SignalId::kQzssL2C}) {
+    for (gnss_sim::SignalId signal_id :
+         {gnss_sim::SignalId::kGpsL2C, gnss_sim::SignalId::kQzssL1C, gnss_sim::SignalId::kQzssL2C}) {
         const gnss_sim::SignalDefinition& definition = signal(signal_id);
         EXPECT_EQ(definition.code_correlation.model, gnss_sim::CodeCorrelationModel::kUnsupported);
         EXPECT_FALSE(gnss_sim::signal_has_supported_code_correlation(definition));
@@ -118,28 +118,30 @@ TEST(SignalCorrelationMetadata, InvalidProfilesAreRejectedWithoutSilentRepair) {
     std::string error_message;
 
     gnss_sim::CodeCorrelationProfile unsupported_with_guess{
-        gnss_sim::CodeCorrelationModel::kUnsupported, 1.023e6, 0.0, 0.0, 0.0,
+        gnss_sim::CodeCorrelationModel::kUnsupported,      1.023e6, 0.0, 0.0, 0.0,
         gnss_sim::CompositeSubcarrierPhase::kNotApplicable};
     EXPECT_FALSE(gnss_sim::validate_code_correlation_profile(unsupported_with_guess, &error_message));
 
     gnss_sim::CodeCorrelationProfile bpsk_without_rate{
-        gnss_sim::CodeCorrelationModel::kBpsk, 0.0, 0.0, 0.0, 0.0,
-        gnss_sim::CompositeSubcarrierPhase::kNotApplicable};
+        gnss_sim::CodeCorrelationModel::kBpsk, 0.0, 0.0, 0.0, 0.0, gnss_sim::CompositeSubcarrierPhase::kNotApplicable};
     EXPECT_FALSE(gnss_sim::validate_code_correlation_profile(bpsk_without_rate, &error_message));
 
     gnss_sim::CodeCorrelationProfile cboc_wrong_phase{
-        gnss_sim::CodeCorrelationModel::kCboc, 1.023e6, 1.023e6, 6.138e6, 1.0 / 11.0,
+        gnss_sim::CodeCorrelationModel::kCboc,          1.023e6, 1.023e6, 6.138e6, 1.0 / 11.0,
         gnss_sim::CompositeSubcarrierPhase::kQuadrature};
     EXPECT_FALSE(gnss_sim::validate_code_correlation_profile(cboc_wrong_phase, &error_message));
 
     gnss_sim::CodeCorrelationProfile qmboc_wrong_phase{
-        gnss_sim::CodeCorrelationModel::kQmboc, 1.023e6, 1.023e6, 6.138e6, 4.0 / 33.0,
+        gnss_sim::CodeCorrelationModel::kQmboc,        1.023e6, 1.023e6, 6.138e6, 4.0 / 33.0,
         gnss_sim::CompositeSubcarrierPhase::kAntiPhase};
     EXPECT_FALSE(gnss_sim::validate_code_correlation_profile(qmboc_wrong_phase, &error_message));
 
-    gnss_sim::CodeCorrelationProfile nonfinite{
-        gnss_sim::CodeCorrelationModel::kBpsk, std::numeric_limits<double>::quiet_NaN(), 0.0, 0.0, 0.0,
-        gnss_sim::CompositeSubcarrierPhase::kNotApplicable};
+    gnss_sim::CodeCorrelationProfile nonfinite{gnss_sim::CodeCorrelationModel::kBpsk,
+                                               std::numeric_limits<double>::quiet_NaN(),
+                                               0.0,
+                                               0.0,
+                                               0.0,
+                                               gnss_sim::CompositeSubcarrierPhase::kNotApplicable};
     EXPECT_FALSE(gnss_sim::validate_code_correlation_profile(nonfinite, &error_message));
 }
 

--- a/tests/unit/test_signal_correlation_metadata.cpp
+++ b/tests/unit/test_signal_correlation_metadata.cpp
@@ -1,0 +1,146 @@
+#include "gnss/signal_definitions.h"
+
+#include <cmath>
+#include <cstddef>
+#include <gtest/gtest.h>
+#include <limits>
+#include <set>
+#include <string>
+
+namespace {
+
+const gnss_sim::SignalDefinition& signal(gnss_sim::SignalId signal_id) {
+    const gnss_sim::SignalDefinition* definition = gnss_sim::find_signal_definition(signal_id);
+    EXPECT_NE(definition, nullptr);
+    return *definition;
+}
+
+TEST(SignalCorrelationMetadata, EveryCentralDefinitionHasAnExplicitValidProfile) {
+    std::size_t count = 0;
+    const gnss_sim::SignalDefinition* definitions = gnss_sim::signal_definitions(&count);
+    ASSERT_NE(definitions, nullptr);
+    ASSERT_GT(count, 0U);
+
+    const std::set<gnss_sim::SignalId> expected_unsupported = {
+        gnss_sim::SignalId::kGpsL2C,
+        gnss_sim::SignalId::kQzssL1C,
+        gnss_sim::SignalId::kQzssL2C,
+    };
+
+    std::size_t unsupported_count = 0;
+    for (std::size_t index = 0; index < count; ++index) {
+        const gnss_sim::SignalDefinition& definition = definitions[index];
+        std::string error_message;
+        EXPECT_TRUE(gnss_sim::validate_code_correlation_profile(definition.code_correlation, &error_message))
+            << definition.name << ": " << error_message;
+
+        const bool expected_supported = expected_unsupported.count(definition.signal_id) == 0;
+        EXPECT_EQ(gnss_sim::signal_has_supported_code_correlation(definition), expected_supported) << definition.name;
+        if (!expected_supported) {
+            ++unsupported_count;
+            EXPECT_EQ(definition.code_correlation.model, gnss_sim::CodeCorrelationModel::kUnsupported);
+            EXPECT_DOUBLE_EQ(definition.code_correlation.chip_rate_hz, 0.0);
+        }
+    }
+    EXPECT_EQ(unsupported_count, expected_unsupported.size());
+}
+
+TEST(SignalCorrelationMetadata, MinimumIssue119SignalsHaveAuthoritativeProfiles) {
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    const gnss_sim::SignalDefinition& gps_l5 = signal(gnss_sim::SignalId::kGpsL5Q);
+    const gnss_sim::SignalDefinition& gal_e1 = signal(gnss_sim::SignalId::kGalileoE1);
+    const gnss_sim::SignalDefinition& gal_e5a = signal(gnss_sim::SignalId::kGalileoE5A);
+    const gnss_sim::SignalDefinition& gal_e5b = signal(gnss_sim::SignalId::kGalileoE5B);
+    const gnss_sim::SignalDefinition& bds_b1i = signal(gnss_sim::SignalId::kBeidouB1I);
+    const gnss_sim::SignalDefinition& bds_b1c = signal(gnss_sim::SignalId::kBeidouB1C);
+    const gnss_sim::SignalDefinition& bds_b2a = signal(gnss_sim::SignalId::kBeidouB2A);
+
+    EXPECT_EQ(gps_l1.code_correlation.model, gnss_sim::CodeCorrelationModel::kBpsk);
+    EXPECT_DOUBLE_EQ(gps_l1.code_correlation.chip_rate_hz, 1.023e6);
+    EXPECT_EQ(gps_l5.code_correlation.model, gnss_sim::CodeCorrelationModel::kBpsk);
+    EXPECT_DOUBLE_EQ(gps_l5.code_correlation.chip_rate_hz, 10.23e6);
+
+    EXPECT_EQ(gal_e1.code_correlation.model, gnss_sim::CodeCorrelationModel::kCboc);
+    EXPECT_DOUBLE_EQ(gal_e1.code_correlation.chip_rate_hz, 1.023e6);
+    EXPECT_DOUBLE_EQ(gal_e1.code_correlation.primary_subcarrier_rate_hz, 1.023e6);
+    EXPECT_DOUBLE_EQ(gal_e1.code_correlation.secondary_subcarrier_rate_hz, 6.138e6);
+    EXPECT_DOUBLE_EQ(gal_e1.code_correlation.secondary_power_fraction, 1.0 / 11.0);
+    EXPECT_EQ(gal_e1.code_correlation.secondary_phase, gnss_sim::CompositeSubcarrierPhase::kAntiPhase);
+    EXPECT_EQ(gal_e5a.code_correlation.model, gnss_sim::CodeCorrelationModel::kBpsk);
+    EXPECT_EQ(gal_e5b.code_correlation.model, gnss_sim::CodeCorrelationModel::kBpsk);
+    EXPECT_DOUBLE_EQ(gal_e5a.code_correlation.chip_rate_hz, 10.23e6);
+    EXPECT_DOUBLE_EQ(gal_e5b.code_correlation.chip_rate_hz, 10.23e6);
+
+    EXPECT_EQ(bds_b1i.code_correlation.model, gnss_sim::CodeCorrelationModel::kBpsk);
+    EXPECT_DOUBLE_EQ(bds_b1i.code_correlation.chip_rate_hz, 2.046e6);
+    EXPECT_EQ(bds_b1c.code_correlation.model, gnss_sim::CodeCorrelationModel::kQmboc);
+    EXPECT_DOUBLE_EQ(bds_b1c.code_correlation.chip_rate_hz, 1.023e6);
+    EXPECT_DOUBLE_EQ(bds_b1c.code_correlation.primary_subcarrier_rate_hz, 1.023e6);
+    EXPECT_DOUBLE_EQ(bds_b1c.code_correlation.secondary_subcarrier_rate_hz, 6.138e6);
+    EXPECT_DOUBLE_EQ(bds_b1c.code_correlation.secondary_power_fraction, 4.0 / 33.0);
+    EXPECT_EQ(bds_b1c.code_correlation.secondary_phase, gnss_sim::CompositeSubcarrierPhase::kQuadrature);
+    EXPECT_EQ(bds_b2a.code_correlation.model, gnss_sim::CodeCorrelationModel::kBpsk);
+    EXPECT_DOUBLE_EQ(bds_b2a.code_correlation.chip_rate_hz, 10.23e6);
+}
+
+TEST(SignalCorrelationMetadata, GpsL1CPilotUsesTmbocProfile) {
+    const gnss_sim::CodeCorrelationProfile& profile = signal(gnss_sim::SignalId::kGpsL1C).code_correlation;
+    EXPECT_EQ(profile.model, gnss_sim::CodeCorrelationModel::kTmboc);
+    EXPECT_DOUBLE_EQ(profile.chip_rate_hz, 1.023e6);
+    EXPECT_DOUBLE_EQ(profile.primary_subcarrier_rate_hz, 1.023e6);
+    EXPECT_DOUBLE_EQ(profile.secondary_subcarrier_rate_hz, 6.138e6);
+    EXPECT_DOUBLE_EQ(profile.secondary_power_fraction, 4.0 / 33.0);
+    EXPECT_EQ(profile.secondary_phase, gnss_sim::CompositeSubcarrierPhase::kNotApplicable);
+}
+
+TEST(SignalCorrelationMetadata, RepresentativeBpskRatesStaySignalSpecific) {
+    EXPECT_DOUBLE_EQ(signal(gnss_sim::SignalId::kGpsL2P).code_correlation.chip_rate_hz, 10.23e6);
+    EXPECT_DOUBLE_EQ(signal(gnss_sim::SignalId::kQzssL1Ca).code_correlation.chip_rate_hz, 1.023e6);
+    EXPECT_DOUBLE_EQ(signal(gnss_sim::SignalId::kQzssL5Q).code_correlation.chip_rate_hz, 10.23e6);
+    EXPECT_DOUBLE_EQ(signal(gnss_sim::SignalId::kGlonassG1).code_correlation.chip_rate_hz, 0.511e6);
+    EXPECT_DOUBLE_EQ(signal(gnss_sim::SignalId::kGlonassG2).code_correlation.chip_rate_hz, 0.511e6);
+    EXPECT_DOUBLE_EQ(signal(gnss_sim::SignalId::kGlonassG3).code_correlation.chip_rate_hz, 10.23e6);
+    EXPECT_DOUBLE_EQ(signal(gnss_sim::SignalId::kGalileoE6).code_correlation.chip_rate_hz, 5.115e6);
+    EXPECT_DOUBLE_EQ(signal(gnss_sim::SignalId::kBeidouB3I).code_correlation.chip_rate_hz, 10.23e6);
+    EXPECT_DOUBLE_EQ(signal(gnss_sim::SignalId::kBeidouB2B).code_correlation.chip_rate_hz, 10.23e6);
+}
+
+TEST(SignalCorrelationMetadata, AmbiguousCompositeSignalsFailExplicitlyInsteadOfFallingBack) {
+    for (gnss_sim::SignalId signal_id : {gnss_sim::SignalId::kGpsL2C, gnss_sim::SignalId::kQzssL1C,
+                                         gnss_sim::SignalId::kQzssL2C}) {
+        const gnss_sim::SignalDefinition& definition = signal(signal_id);
+        EXPECT_EQ(definition.code_correlation.model, gnss_sim::CodeCorrelationModel::kUnsupported);
+        EXPECT_FALSE(gnss_sim::signal_has_supported_code_correlation(definition));
+    }
+}
+
+TEST(SignalCorrelationMetadata, InvalidProfilesAreRejectedWithoutSilentRepair) {
+    std::string error_message;
+
+    gnss_sim::CodeCorrelationProfile unsupported_with_guess{
+        gnss_sim::CodeCorrelationModel::kUnsupported, 1.023e6, 0.0, 0.0, 0.0,
+        gnss_sim::CompositeSubcarrierPhase::kNotApplicable};
+    EXPECT_FALSE(gnss_sim::validate_code_correlation_profile(unsupported_with_guess, &error_message));
+
+    gnss_sim::CodeCorrelationProfile bpsk_without_rate{
+        gnss_sim::CodeCorrelationModel::kBpsk, 0.0, 0.0, 0.0, 0.0,
+        gnss_sim::CompositeSubcarrierPhase::kNotApplicable};
+    EXPECT_FALSE(gnss_sim::validate_code_correlation_profile(bpsk_without_rate, &error_message));
+
+    gnss_sim::CodeCorrelationProfile cboc_wrong_phase{
+        gnss_sim::CodeCorrelationModel::kCboc, 1.023e6, 1.023e6, 6.138e6, 1.0 / 11.0,
+        gnss_sim::CompositeSubcarrierPhase::kQuadrature};
+    EXPECT_FALSE(gnss_sim::validate_code_correlation_profile(cboc_wrong_phase, &error_message));
+
+    gnss_sim::CodeCorrelationProfile qmboc_wrong_phase{
+        gnss_sim::CodeCorrelationModel::kQmboc, 1.023e6, 1.023e6, 6.138e6, 4.0 / 33.0,
+        gnss_sim::CompositeSubcarrierPhase::kAntiPhase};
+    EXPECT_FALSE(gnss_sim::validate_code_correlation_profile(qmboc_wrong_phase, &error_message));
+
+    gnss_sim::CodeCorrelationProfile nonfinite{
+        gnss_sim::CodeCorrelationModel::kBpsk, std::numeric_limits<double>::quiet_NaN(), 0.0, 0.0, 0.0,
+        gnss_sim::CompositeSubcarrierPhase::kNotApplicable};
+    EXPECT_FALSE(gnss_sim::validate_code_correlation_profile(nonfinite, &error_message));
+}
+
+} // namespace


### PR DESCRIPTION
Closes #133

## Summary

Adds the minimum central per-signal code/modulation metadata required by #134/#119 without implementing correlation math or DLL behavior.

## Implementation Notes

- Extends the existing central `SignalDefinition`; no DLL-local parallel signal table is introduced.
- Adds `CodeCorrelationModel` profiles for BPSK, TMBOC, CBOC, QMBOC, plus explicit `kUnsupported`.
- Adds code chip rate, primary/secondary subcarrier rates, secondary contribution fraction, and phase relation needed by later ideal correlation math.
- Composite phase metadata preserves **signed quadrature** (`+90°` vs `-90°`) because later complex correlation depends on that sign.
- Models the tracked RINEX component, not a complete RF/IF/baseband composite waveform.
- GPS L1C `1L` is the pilot/TMBOC component.
- Galileo E1 `1C` is the pilot CBOC(-) component.
- Galileo E5a/E5b Q are represented as independently tracked 10.23-Mcps sideband components for V1 correlation, not a full-band AltBOC correlator.
- BeiDou B1C `1P` is the pilot QMBOC(6,1,4/33) component. Its ICD complex-envelope convention uses the BOC(6,1) term with **`-j`**, so the central entry stores `kNegativeQuadrature`.
- The generic QMBOC validator accepts structurally valid positive or negative quadrature; the BDS B1C entry locks the signal-specific negative sign.
- GPS L2C `2S`, QZSS L1C, and QZSS L2C remain explicitly unsupported rather than receiving a guessed generic triangular profile.
- `validate_code_correlation_profile()` rejects inconsistent/non-finite metadata and rejects guessed parameters attached to `kUnsupported`.
- Existing carrier-frequency, wavelength, NAV-family, code-bias, RINEX, OEM7 and SPP-priority semantics are unchanged.

## Sources

Permanent source/convention notes are in `docs/SIGNAL_CORRELATION_METADATA.md` and `docs/SIGNAL_CORRELATION_METADATA_SOURCES.md`, using public GPS IS documents, QZSS PNT IS, Galileo OS SIS ICD, BeiDou SIS ICDs, and public GLONASS signal definitions.

## Tests

Adds `test_signal_correlation_metadata.cpp` and wires it into the existing unit-test target. It verifies:
- every central signal has a structurally valid explicit profile;
- unsupported signals do not silently fall back;
- #119 minimum signals retain authoritative rates/profile identities;
- GPS L1C TMBOC, Galileo E1 CBOC, and BDS B1C QMBOC stay distinct;
- BDS B1C keeps negative quadrature while generic QMBOC can represent either signed orientation;
- malformed/non-finite profiles fail validation.

## Scope exclusions

No autocorrelation function, multipath correlator, Early/Late discriminator, root solver, tracking, CN0, observation synthesis, IF/baseband generation, or NAV/EPH/ION changes are included.

## Data provenance / safety

This PR does not generate, modify, interpolate, retarget, or fabricate NAV/EPH/ION and does not tune any parameter for target PVT behavior.

## Next

After this PR is validated and merged, implement #134 pure ideal signal-specific correlation functions, then return to #119 for composite path correlation + noncoherent E/L discrimination + stable-root solving.