### PR TITLE
Implement pure signal-specific ideal code correlation functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ add_library(gnss_sim_core STATIC
     src/model/atmosphere_model.cpp
     src/model/bestpos_rtk_model.cpp
     src/model/cn0_model.cpp
+    src/model/code_correlation.cpp
     src/model/measurement_error_model.cpp
     src/model/measurement_model.cpp
     src/model/receiver_truth.cpp
@@ -236,6 +237,7 @@ if(BUILD_TESTING)
         tests/unit/test_cn0_model.cpp
         tests/unit/test_cn0_normalized_builder.cpp
         tests/unit/test_cn0_statistics.cpp
+        tests/unit/test_code_correlation.cpp
         tests/unit/test_deterministic_rng.cpp
         tests/unit/test_galileo_has_adapter.cpp
         tests/unit/test_low_elevation_signal_geometry.cpp

--- a/docs/IDEAL_CODE_CORRELATION.md
+++ b/docs/IDEAL_CODE_CORRELATION.md
@@ -1,0 +1,121 @@
+# Ideal Signal-Specific Code Correlation
+
+Issue #134 implements the pure code-domain correlation layer required before Issue #119 adds multipath path composition and a noncoherent Early/Late discriminator.
+
+This layer consumes only the central `CodeCorrelationProfile` metadata completed by Issue #133. It does not switch on signal names and does not contain a second signal table.
+
+## V1 ideal-code convention
+
+The V1 model treats different spreading-code chips as uncorrelated for the purpose of the ideal local correlation shape. Therefore only overlap inside the same normalized code-chip interval contributes, and
+
+`R(tau) = 0` for `|tau| >= 1 chip`.
+
+Within one chip, the spreading chip is multiplied by the signal-specific subcarrier waveform. The implementation evaluates its autocorrelation exactly from piecewise-constant waveform intervals rather than by time sampling.
+
+The returned correlation is normalized so that `R(0) = 1`.
+
+## BPSK
+
+For a BPSK-style rectangular spreading chip,
+
+`R(tau) = 1 - |tau|`, for `|tau| < 1`,
+
+and zero otherwise.
+
+The normalized chip-domain shape is the same for GPS L1 C/A and GPS L5, but the physical delay scale is not: the chip duration is `1 / chip_rate`, and the chip length is `c / chip_rate`. Thus a 10.23 Mcps signal has one tenth the meter-scale main-lobe width of a 1.023 Mcps signal.
+
+## Sine-BOC primitive
+
+Composite profiles use the standard sine-BOC square subcarrier primitive. For BOC(n,1), one code chip contains `2n` constant half-subcarrier intervals with alternating `+1/-1` signs.
+
+The implementation converts the metadata subcarrier-rate / chip-rate ratio to an integer `n`. Non-integer or unsupported ratios fail explicitly; they are not approximated or silently rounded into another waveform.
+
+For a piecewise-constant chip waveform `w(t)`, positive-delay autocorrelation is evaluated by exact interval overlap:
+
+`R(tau) = integral w(t) conj(w(t - tau)) dt / E`,
+
+where `E = integral |w(t)|^2 dt` over one normalized chip. Negative delays use the Hermitian identity
+
+`R(-tau) = conj(R(tau))`.
+
+## TMBOC
+
+GPS L1C pilot metadata uses TMBOC(6,1,4/33). TMBOC is time-multiplexed across code chips, so V1 uses the ideal ensemble/time-average correlation
+
+`R_TMBOC = (29/33) R_BOC(1,1) + (4/33) R_BOC(6,1)`.
+
+There is no coherent BOC(1,1)-to-BOC(6,1) cross term in this ideal TMBOC average because the two subcarriers occupy different multiplexed chip positions.
+
+Representative permanent anchors are:
+
+- `R(1/12 chip) = 0.5479797979797979`;
+- `R(1/4 chip) = 0.12878787878787884`;
+- `R(1/2 chip) = -0.37878787878787884`.
+
+These anchors make it impossible for L1C to silently collapse to a BPSK triangle.
+
+## CBOC
+
+Galileo E1-C pilot metadata uses CBOC(6,1,1/11) with the minus/anti-phase combination. The normalized one-chip waveform is formed as
+
+`w = sqrt(10/11) BOC(1,1) - sqrt(1/11) BOC(6,1)`.
+
+Because the two subcarriers are coherently summed in the same chip, their cross terms are retained by the exact interval-overlap integral.
+
+Representative permanent anchors are:
+
+- `R(1/12 chip) = 0.5505715506035093`;
+- `R(1/4 chip) = 0.11117761120957005`;
+- `R(1/2 chip) = -0.409090909090909`.
+
+## QMBOC
+
+BeiDou B1C pilot metadata uses QMBOC(6,1,4/33). Under the B1C ICD complex-envelope convention the one-chip subcarrier is
+
+`w = sqrt(29/33) BOC(1,1) - j sqrt(4/33) BOC(6,1)`.
+
+Issue #133 therefore preserves the secondary term as **negative quadrature**. The generic pure-correlation evaluator consumes that signed phase when constructing the chip waveform.
+
+For ideal autocorrelation of the same complex pilot waveform, the orthogonal cross terms cancel and the resulting current B1C anchors equal the 29/33 : 4/33 power-weighted BOC autocorrelation:
+
+- `R(1/12 chip) = 0.5479797979797979`;
+- `R(1/4 chip) = 0.12878787878787884`;
+- `R(1/2 chip) = -0.37878787878787884`.
+
+The implementation still returns `std::complex<double>` and preserves Hermitian semantics so the signed waveform convention is not lost at the API boundary.
+
+## Galileo E5 sidebands
+
+The central #133 convention models Galileo E5a-Q and E5b-Q as the independently tracked 10.23 Mcps sideband components, not as a full-band E5 AltBOC receiver. Their V1 local code correlation is therefore the BPSK-style 10.23 Mcps component correlation.
+
+## Supported delay APIs
+
+Two narrow public evaluations are provided:
+
+- `ideal_code_correlation_chips(profile, delay_chips, ...)` for pure normalized profile tests;
+- `ideal_signal_code_correlation(definition, delay_seconds, ...)` for later propagation/DLL integration.
+
+`signal_code_chip_duration_s()` and `signal_code_chip_length_m()` expose the physical scale from the same central chip-rate metadata.
+
+## Explicit failure behavior
+
+- `kUnsupported` central profiles fail rather than falling back to BPSK.
+- malformed #133 metadata fails validation;
+- composite subcarrier rates that are not representable as supported integer BOC(n,1) multiples fail explicitly;
+- non-finite delays fail;
+- no waveform parameter is inferred from carrier frequency, RINEX code, or signal name.
+
+## Scope boundary
+
+Issue #134 does **not** implement:
+
+- reflected/diffracted/direct path summation;
+- propagation complex amplitudes or carrier phases;
+- Early/Late spacing or discriminator output;
+- S-curve root search/stability classification;
+- acquisition/tracking root policy;
+- CN0, lock, pseudorange, Doppler, carrier/ADR, or final observation synthesis;
+- IF/baseband samples;
+- NAV/EPH/ION changes.
+
+Those remain in #119 and later issues. In particular, the #130 rule still applies: rooftop diffraction modifies the direct component and must not later be inserted as a second full-strength direct-like path.

--- a/src/model/code_correlation.cpp
+++ b/src/model/code_correlation.cpp
@@ -187,8 +187,7 @@ bool tmboc_autocorrelation(const CodeCorrelationProfile& profile, double delay_c
         !boc_autocorrelation(secondary_multiple, delay_chips, &secondary)) {
         return false;
     }
-    *correlation = (1.0 - profile.secondary_power_fraction) * primary +
-                   profile.secondary_power_fraction * secondary;
+    *correlation = (1.0 - profile.secondary_power_fraction) * primary + profile.secondary_power_fraction * secondary;
     return true;
 }
 
@@ -273,8 +272,7 @@ bool signal_code_chip_duration_s(const SignalDefinition& definition, double* chi
     return true;
 }
 
-bool signal_code_chip_length_m(const SignalDefinition& definition, double* chip_length_m,
-                               std::string* error_message) {
+bool signal_code_chip_length_m(const SignalDefinition& definition, double* chip_length_m, std::string* error_message) {
     if (chip_length_m == nullptr) {
         set_error(error_message, "code chip-length output pointer is null");
         return false;

--- a/src/model/code_correlation.cpp
+++ b/src/model/code_correlation.cpp
@@ -1,0 +1,291 @@
+#include "model/code_correlation.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace gnss_sim {
+namespace {
+
+constexpr double kSpeedOfLightMps = 299792458.0;
+constexpr int kMaxBocMultiple = 64;
+constexpr int kMaxCorrelationSegments = 2 * kMaxBocMultiple;
+constexpr double kIntegerRatioTolerance = 1.0e-10;
+
+void set_error(std::string* error_message, const char* message) {
+    if (error_message != nullptr) {
+        *error_message = message;
+    }
+}
+
+int gcd_int(int lhs, int rhs) {
+    while (rhs != 0) {
+        const int remainder = lhs % rhs;
+        lhs = rhs;
+        rhs = remainder;
+    }
+    return lhs;
+}
+
+bool boc_multiple(double subcarrier_rate_hz, double chip_rate_hz, int* multiple) {
+    if (multiple == nullptr || !std::isfinite(subcarrier_rate_hz) || !std::isfinite(chip_rate_hz) ||
+        subcarrier_rate_hz <= 0.0 || chip_rate_hz <= 0.0) {
+        return false;
+    }
+    const double ratio = subcarrier_rate_hz / chip_rate_hz;
+    const double rounded = std::round(ratio);
+    if (rounded < 1.0 || rounded > static_cast<double>(kMaxBocMultiple) ||
+        std::abs(ratio - rounded) > kIntegerRatioTolerance) {
+        return false;
+    }
+    *multiple = static_cast<int>(rounded);
+    return true;
+}
+
+bool boc_subcarrier_value(int multiple, int segment_index, int segment_count, double* value) {
+    if (value == nullptr || multiple <= 0 || segment_count <= 0 || segment_index < 0 ||
+        segment_index >= segment_count || segment_count % (2 * multiple) != 0) {
+        return false;
+    }
+    const int segments_per_half_cycle = segment_count / (2 * multiple);
+    const int half_cycle_index = segment_index / segments_per_half_cycle;
+    *value = (half_cycle_index % 2 == 0) ? 1.0 : -1.0;
+    return true;
+}
+
+std::complex<double> step_waveform_autocorrelation(const std::complex<double>* waveform, int segment_count,
+                                                   double delay_chips) {
+    if (delay_chips < 0.0) {
+        return std::conj(step_waveform_autocorrelation(waveform, segment_count, -delay_chips));
+    }
+    if (delay_chips >= 1.0) {
+        return {0.0, 0.0};
+    }
+
+    double energy = 0.0;
+    for (int index = 0; index < segment_count; ++index) {
+        energy += std::norm(waveform[index]);
+    }
+    energy /= static_cast<double>(segment_count);
+    if (!(energy > 0.0) || !std::isfinite(energy)) {
+        return {0.0, 0.0};
+    }
+
+    std::complex<double> sum{0.0, 0.0};
+    const double inverse_segment_count = 1.0 / static_cast<double>(segment_count);
+    for (int first = 0; first < segment_count; ++first) {
+        const double first_start = static_cast<double>(first) * inverse_segment_count;
+        const double first_end = static_cast<double>(first + 1) * inverse_segment_count;
+        for (int second = 0; second < segment_count; ++second) {
+            const double second_start = delay_chips + static_cast<double>(second) * inverse_segment_count;
+            const double second_end = delay_chips + static_cast<double>(second + 1) * inverse_segment_count;
+            const double overlap_start = std::max(first_start, second_start);
+            const double overlap_end = std::min(first_end, second_end);
+            if (overlap_end > overlap_start) {
+                sum += waveform[first] * std::conj(waveform[second]) * (overlap_end - overlap_start);
+            }
+        }
+    }
+    return sum / energy;
+}
+
+bool boc_autocorrelation(int multiple, double delay_chips, std::complex<double>* correlation) {
+    if (correlation == nullptr || multiple <= 0 || multiple > kMaxBocMultiple) {
+        return false;
+    }
+    const int segment_count = 2 * multiple;
+    std::complex<double> waveform[kMaxCorrelationSegments]{};
+    for (int segment = 0; segment < segment_count; ++segment) {
+        double value = 0.0;
+        if (!boc_subcarrier_value(multiple, segment, segment_count, &value)) {
+            return false;
+        }
+        waveform[segment] = {value, 0.0};
+    }
+    *correlation = step_waveform_autocorrelation(waveform, segment_count, delay_chips);
+    return true;
+}
+
+bool composite_phase_factor(CompositeSubcarrierPhase phase, std::complex<double>* factor) {
+    if (factor == nullptr) {
+        return false;
+    }
+    switch (phase) {
+        case CompositeSubcarrierPhase::kInPhase:
+            *factor = {1.0, 0.0};
+            return true;
+        case CompositeSubcarrierPhase::kAntiPhase:
+            *factor = {-1.0, 0.0};
+            return true;
+        case CompositeSubcarrierPhase::kPositiveQuadrature:
+            *factor = {0.0, 1.0};
+            return true;
+        case CompositeSubcarrierPhase::kNegativeQuadrature:
+            *factor = {0.0, -1.0};
+            return true;
+        case CompositeSubcarrierPhase::kNotApplicable:
+            break;
+    }
+    return false;
+}
+
+bool composite_boc_autocorrelation(const CodeCorrelationProfile& profile, double delay_chips,
+                                   std::complex<double>* correlation) {
+    if (correlation == nullptr) {
+        return false;
+    }
+
+    int primary_multiple = 0;
+    int secondary_multiple = 0;
+    if (!boc_multiple(profile.primary_subcarrier_rate_hz, profile.chip_rate_hz, &primary_multiple) ||
+        !boc_multiple(profile.secondary_subcarrier_rate_hz, profile.chip_rate_hz, &secondary_multiple)) {
+        return false;
+    }
+
+    const int common_multiple = primary_multiple / gcd_int(primary_multiple, secondary_multiple) * secondary_multiple;
+    if (common_multiple <= 0 || common_multiple > kMaxBocMultiple) {
+        return false;
+    }
+    const int segment_count = 2 * common_multiple;
+
+    std::complex<double> secondary_factor{};
+    if (!composite_phase_factor(profile.secondary_phase, &secondary_factor)) {
+        return false;
+    }
+
+    const double primary_weight = std::sqrt(1.0 - profile.secondary_power_fraction);
+    const double secondary_weight = std::sqrt(profile.secondary_power_fraction);
+    std::complex<double> waveform[kMaxCorrelationSegments]{};
+    for (int segment = 0; segment < segment_count; ++segment) {
+        double primary = 0.0;
+        double secondary = 0.0;
+        if (!boc_subcarrier_value(primary_multiple, segment, segment_count, &primary) ||
+            !boc_subcarrier_value(secondary_multiple, segment, segment_count, &secondary)) {
+            return false;
+        }
+        waveform[segment] = primary_weight * primary + secondary_factor * secondary_weight * secondary;
+    }
+
+    *correlation = step_waveform_autocorrelation(waveform, segment_count, delay_chips);
+    return true;
+}
+
+bool tmboc_autocorrelation(const CodeCorrelationProfile& profile, double delay_chips,
+                           std::complex<double>* correlation) {
+    if (correlation == nullptr) {
+        return false;
+    }
+    int primary_multiple = 0;
+    int secondary_multiple = 0;
+    if (!boc_multiple(profile.primary_subcarrier_rate_hz, profile.chip_rate_hz, &primary_multiple) ||
+        !boc_multiple(profile.secondary_subcarrier_rate_hz, profile.chip_rate_hz, &secondary_multiple)) {
+        return false;
+    }
+
+    std::complex<double> primary{};
+    std::complex<double> secondary{};
+    if (!boc_autocorrelation(primary_multiple, delay_chips, &primary) ||
+        !boc_autocorrelation(secondary_multiple, delay_chips, &secondary)) {
+        return false;
+    }
+    *correlation = (1.0 - profile.secondary_power_fraction) * primary +
+                   profile.secondary_power_fraction * secondary;
+    return true;
+}
+
+} // namespace
+
+bool ideal_code_correlation_chips(const CodeCorrelationProfile& profile, double delay_chips,
+                                  std::complex<double>* correlation, std::string* error_message) {
+    if (correlation == nullptr) {
+        set_error(error_message, "ideal code correlation output pointer is null");
+        return false;
+    }
+    *correlation = {0.0, 0.0};
+    if (!std::isfinite(delay_chips)) {
+        set_error(error_message, "ideal code correlation delay is not finite");
+        return false;
+    }
+    if (!validate_code_correlation_profile(profile, error_message)) {
+        return false;
+    }
+    if (profile.model == CodeCorrelationModel::kUnsupported) {
+        set_error(error_message, "signal code-correlation profile is explicitly unsupported");
+        return false;
+    }
+
+    switch (profile.model) {
+        case CodeCorrelationModel::kBpsk: {
+            const double magnitude = std::abs(delay_chips);
+            *correlation = {(magnitude < 1.0) ? 1.0 - magnitude : 0.0, 0.0};
+            return true;
+        }
+        case CodeCorrelationModel::kTmboc:
+            if (tmboc_autocorrelation(profile, delay_chips, correlation)) {
+                return true;
+            }
+            set_error(error_message, "TMBOC subcarrier rates are not supported integer BOC(n,1) multiples");
+            return false;
+        case CodeCorrelationModel::kCboc:
+        case CodeCorrelationModel::kQmboc:
+            if (composite_boc_autocorrelation(profile, delay_chips, correlation)) {
+                return true;
+            }
+            set_error(error_message, "composite BOC subcarrier rates are not supported integer BOC(n,1) multiples");
+            return false;
+        case CodeCorrelationModel::kUnsupported:
+            break;
+    }
+
+    set_error(error_message, "unknown ideal code-correlation model");
+    return false;
+}
+
+bool ideal_signal_code_correlation(const SignalDefinition& definition, double delay_seconds,
+                                   std::complex<double>* correlation, std::string* error_message) {
+    if (!std::isfinite(delay_seconds)) {
+        set_error(error_message, "ideal signal correlation delay is not finite");
+        return false;
+    }
+    if (!signal_has_supported_code_correlation(definition)) {
+        set_error(error_message, "signal has no supported ideal code-correlation profile");
+        if (correlation != nullptr) {
+            *correlation = {0.0, 0.0};
+        }
+        return false;
+    }
+    return ideal_code_correlation_chips(definition.code_correlation,
+                                        delay_seconds * definition.code_correlation.chip_rate_hz, correlation,
+                                        error_message);
+}
+
+bool signal_code_chip_duration_s(const SignalDefinition& definition, double* chip_duration_s,
+                                 std::string* error_message) {
+    if (chip_duration_s == nullptr) {
+        set_error(error_message, "code chip-duration output pointer is null");
+        return false;
+    }
+    *chip_duration_s = 0.0;
+    if (!signal_has_supported_code_correlation(definition)) {
+        set_error(error_message, "signal has no supported code chip-rate metadata");
+        return false;
+    }
+    *chip_duration_s = 1.0 / definition.code_correlation.chip_rate_hz;
+    return true;
+}
+
+bool signal_code_chip_length_m(const SignalDefinition& definition, double* chip_length_m,
+                               std::string* error_message) {
+    if (chip_length_m == nullptr) {
+        set_error(error_message, "code chip-length output pointer is null");
+        return false;
+    }
+    *chip_length_m = 0.0;
+    double duration_s = 0.0;
+    if (!signal_code_chip_duration_s(definition, &duration_s, error_message)) {
+        return false;
+    }
+    *chip_length_m = kSpeedOfLightMps * duration_s;
+    return true;
+}
+
+} // namespace gnss_sim

--- a/src/model/code_correlation.h
+++ b/src/model/code_correlation.h
@@ -24,8 +24,7 @@ bool ideal_signal_code_correlation(const SignalDefinition& definition, double de
 
 bool signal_code_chip_duration_s(const SignalDefinition& definition, double* chip_duration_s,
                                  std::string* error_message);
-bool signal_code_chip_length_m(const SignalDefinition& definition, double* chip_length_m,
-                               std::string* error_message);
+bool signal_code_chip_length_m(const SignalDefinition& definition, double* chip_length_m, std::string* error_message);
 
 } // namespace gnss_sim
 

--- a/src/model/code_correlation.h
+++ b/src/model/code_correlation.h
@@ -1,0 +1,32 @@
+#ifndef GNSS_SIM_SRC_MODEL_CODE_CORRELATION_H_
+#define GNSS_SIM_SRC_MODEL_CODE_CORRELATION_H_
+
+#include "gnss/signal_definitions.h"
+
+#include <complex>
+#include <string>
+
+namespace gnss_sim {
+
+// Evaluate the normalized ideal same-code autocorrelation at a code-phase
+// offset expressed in code chips. The V1 ideal-code model treats different PRN
+// chips as uncorrelated, so the response is exactly zero for |delay| >= 1 chip.
+//
+// Composite profiles are evaluated from the tracked component metadata in the
+// central SignalDefinition table; unsupported profiles fail explicitly.
+bool ideal_code_correlation_chips(const CodeCorrelationProfile& profile, double delay_chips,
+                                  std::complex<double>* correlation, std::string* error_message);
+
+// SignalDefinition wrapper using delay in seconds. This is the narrow interface
+// later DLL/path code should use when propagation supplies physical delays.
+bool ideal_signal_code_correlation(const SignalDefinition& definition, double delay_seconds,
+                                   std::complex<double>* correlation, std::string* error_message);
+
+bool signal_code_chip_duration_s(const SignalDefinition& definition, double* chip_duration_s,
+                                 std::string* error_message);
+bool signal_code_chip_length_m(const SignalDefinition& definition, double* chip_length_m,
+                               std::string* error_message);
+
+} // namespace gnss_sim
+
+#endif // GNSS_SIM_SRC_MODEL_CODE_CORRELATION_H_

--- a/tests/unit/test_code_correlation.cpp
+++ b/tests/unit/test_code_correlation.cpp
@@ -17,8 +17,8 @@ const gnss_sim::SignalDefinition& signal(gnss_sim::SignalId signal_id) {
 std::complex<double> correlation_chips(const gnss_sim::SignalDefinition& definition, double delay_chips) {
     std::complex<double> result{};
     std::string error_message;
-    EXPECT_TRUE(gnss_sim::ideal_code_correlation_chips(definition.code_correlation, delay_chips, &result,
-                                                       &error_message))
+    EXPECT_TRUE(
+        gnss_sim::ideal_code_correlation_chips(definition.code_correlation, delay_chips, &result, &error_message))
         << definition.name << ": " << error_message;
     return result;
 }

--- a/tests/unit/test_code_correlation.cpp
+++ b/tests/unit/test_code_correlation.cpp
@@ -1,0 +1,154 @@
+#include "model/code_correlation.h"
+
+#include <cmath>
+#include <complex>
+#include <gtest/gtest.h>
+#include <limits>
+#include <string>
+
+namespace {
+
+const gnss_sim::SignalDefinition& signal(gnss_sim::SignalId signal_id) {
+    const gnss_sim::SignalDefinition* definition = gnss_sim::find_signal_definition(signal_id);
+    EXPECT_NE(definition, nullptr);
+    return *definition;
+}
+
+std::complex<double> correlation_chips(const gnss_sim::SignalDefinition& definition, double delay_chips) {
+    std::complex<double> result{};
+    std::string error_message;
+    EXPECT_TRUE(gnss_sim::ideal_code_correlation_chips(definition.code_correlation, delay_chips, &result,
+                                                       &error_message))
+        << definition.name << ": " << error_message;
+    return result;
+}
+
+TEST(CodeCorrelation, BpskProfilesProduceExactTriangularChipDomainResponse) {
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    EXPECT_EQ(gps_l1.code_correlation.model, gnss_sim::CodeCorrelationModel::kBpsk);
+
+    EXPECT_EQ(correlation_chips(gps_l1, 0.0), std::complex<double>(1.0, 0.0));
+    EXPECT_EQ(correlation_chips(gps_l1, 0.5), std::complex<double>(0.5, 0.0));
+    EXPECT_EQ(correlation_chips(gps_l1, -0.5), std::complex<double>(0.5, 0.0));
+    EXPECT_EQ(correlation_chips(gps_l1, 1.0), std::complex<double>(0.0, 0.0));
+    EXPECT_EQ(correlation_chips(gps_l1, -1.0), std::complex<double>(0.0, 0.0));
+    EXPECT_EQ(correlation_chips(gps_l1, 1.25), std::complex<double>(0.0, 0.0));
+}
+
+TEST(CodeCorrelation, SignalTimeAndMeterScaleFollowCentralChipRates) {
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    const gnss_sim::SignalDefinition& gps_l5 = signal(gnss_sim::SignalId::kGpsL5Q);
+
+    double l1_duration_s = 0.0;
+    double l5_duration_s = 0.0;
+    double l1_length_m = 0.0;
+    double l5_length_m = 0.0;
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::signal_code_chip_duration_s(gps_l1, &l1_duration_s, &error_message));
+    ASSERT_TRUE(gnss_sim::signal_code_chip_duration_s(gps_l5, &l5_duration_s, &error_message));
+    ASSERT_TRUE(gnss_sim::signal_code_chip_length_m(gps_l1, &l1_length_m, &error_message));
+    ASSERT_TRUE(gnss_sim::signal_code_chip_length_m(gps_l5, &l5_length_m, &error_message));
+
+    EXPECT_NEAR(l1_duration_s / l5_duration_s, 10.0, 1.0e-14);
+    EXPECT_NEAR(l1_length_m / l5_length_m, 10.0, 1.0e-14);
+
+    std::complex<double> l1_half{};
+    std::complex<double> l5_half{};
+    ASSERT_TRUE(gnss_sim::ideal_signal_code_correlation(gps_l1, 0.5 * l1_duration_s, &l1_half, &error_message));
+    ASSERT_TRUE(gnss_sim::ideal_signal_code_correlation(gps_l5, 0.5 * l5_duration_s, &l5_half, &error_message));
+    EXPECT_NEAR(l1_half.real(), 0.5, 1.0e-14);
+    EXPECT_NEAR(l5_half.real(), 0.5, 1.0e-14);
+    EXPECT_NEAR(l1_half.imag(), 0.0, 1.0e-14);
+    EXPECT_NEAR(l5_half.imag(), 0.0, 1.0e-14);
+}
+
+TEST(CodeCorrelation, GpsL1CTmbocUsesWeightedBocStructureInsteadOfTriangle) {
+    const gnss_sim::SignalDefinition& gps_l1c = signal(gnss_sim::SignalId::kGpsL1C);
+    ASSERT_EQ(gps_l1c.code_correlation.model, gnss_sim::CodeCorrelationModel::kTmboc);
+
+    const std::complex<double> at_twelfth = correlation_chips(gps_l1c, 1.0 / 12.0);
+    const std::complex<double> at_quarter = correlation_chips(gps_l1c, 0.25);
+    const std::complex<double> at_half = correlation_chips(gps_l1c, 0.5);
+    EXPECT_NEAR(at_twelfth.real(), 0.5479797979797979, 1.0e-12);
+    EXPECT_NEAR(at_quarter.real(), 0.12878787878787884, 1.0e-12);
+    EXPECT_NEAR(at_half.real(), -0.37878787878787884, 1.0e-12);
+    EXPECT_NEAR(at_twelfth.imag(), 0.0, 1.0e-14);
+    EXPECT_LT(at_twelfth.real(), 1.0 - 1.0 / 12.0);
+}
+
+TEST(CodeCorrelation, GalileoE1PilotCbocKeepsCoherentMinusCombination) {
+    const gnss_sim::SignalDefinition& gal_e1 = signal(gnss_sim::SignalId::kGalileoE1);
+    ASSERT_EQ(gal_e1.code_correlation.model, gnss_sim::CodeCorrelationModel::kCboc);
+    ASSERT_EQ(gal_e1.code_correlation.secondary_phase, gnss_sim::CompositeSubcarrierPhase::kAntiPhase);
+
+    const std::complex<double> at_twelfth = correlation_chips(gal_e1, 1.0 / 12.0);
+    const std::complex<double> at_quarter = correlation_chips(gal_e1, 0.25);
+    const std::complex<double> at_half = correlation_chips(gal_e1, 0.5);
+    EXPECT_NEAR(at_twelfth.real(), 0.5505715506035093, 1.0e-12);
+    EXPECT_NEAR(at_quarter.real(), 0.11117761120957005, 1.0e-12);
+    EXPECT_NEAR(at_half.real(), -0.409090909090909, 1.0e-12);
+    EXPECT_NEAR(at_twelfth.imag(), 0.0, 1.0e-14);
+    EXPECT_NE(at_twelfth.real(), correlation_chips(signal(gnss_sim::SignalId::kGpsL1Ca), 1.0 / 12.0).real());
+}
+
+TEST(CodeCorrelation, BeidouB1CPilotQmbocUsesOrthogonalPowerComposition) {
+    const gnss_sim::SignalDefinition& b1c = signal(gnss_sim::SignalId::kBeidouB1C);
+    ASSERT_EQ(b1c.code_correlation.model, gnss_sim::CodeCorrelationModel::kQmboc);
+    ASSERT_EQ(b1c.code_correlation.secondary_phase, gnss_sim::CompositeSubcarrierPhase::kNegativeQuadrature);
+
+    const std::complex<double> at_twelfth = correlation_chips(b1c, 1.0 / 12.0);
+    const std::complex<double> at_quarter = correlation_chips(b1c, 0.25);
+    const std::complex<double> at_half = correlation_chips(b1c, 0.5);
+    EXPECT_NEAR(at_twelfth.real(), 0.5479797979797979, 1.0e-12);
+    EXPECT_NEAR(at_quarter.real(), 0.12878787878787884, 1.0e-12);
+    EXPECT_NEAR(at_half.real(), -0.37878787878787884, 1.0e-12);
+    EXPECT_NEAR(at_twelfth.imag(), 0.0, 1.0e-12);
+    EXPECT_LT(at_twelfth.real(), 1.0 - 1.0 / 12.0);
+}
+
+TEST(CodeCorrelation, AutocorrelationIsHermitianAndNormalizedForCompositeProfiles) {
+    for (gnss_sim::SignalId signal_id :
+         {gnss_sim::SignalId::kGpsL1C, gnss_sim::SignalId::kGalileoE1, gnss_sim::SignalId::kBeidouB1C}) {
+        const gnss_sim::SignalDefinition& definition = signal(signal_id);
+        const std::complex<double> zero = correlation_chips(definition, 0.0);
+        const std::complex<double> positive = correlation_chips(definition, 0.123);
+        const std::complex<double> negative = correlation_chips(definition, -0.123);
+        EXPECT_NEAR(zero.real(), 1.0, 1.0e-12) << definition.name;
+        EXPECT_NEAR(zero.imag(), 0.0, 1.0e-12) << definition.name;
+        EXPECT_NEAR(negative.real(), positive.real(), 1.0e-12) << definition.name;
+        EXPECT_NEAR(negative.imag(), -positive.imag(), 1.0e-12) << definition.name;
+    }
+}
+
+TEST(CodeCorrelation, UnsupportedAndInvalidProfilesFailExplicitly) {
+    const gnss_sim::SignalDefinition& gps_l2c = signal(gnss_sim::SignalId::kGpsL2C);
+    std::complex<double> result{7.0, 9.0};
+    std::string error_message;
+    EXPECT_FALSE(gnss_sim::ideal_code_correlation_chips(gps_l2c.code_correlation, 0.0, &result, &error_message));
+    EXPECT_EQ(result, std::complex<double>(0.0, 0.0));
+
+    gnss_sim::CodeCorrelationProfile noninteger_boc{gnss_sim::CodeCorrelationModel::kTmboc,
+                                                    1.0e6,
+                                                    1.5e6,
+                                                    6.0e6,
+                                                    4.0 / 33.0,
+                                                    gnss_sim::CompositeSubcarrierPhase::kNotApplicable};
+    EXPECT_TRUE(gnss_sim::validate_code_correlation_profile(noninteger_boc, &error_message));
+    EXPECT_FALSE(gnss_sim::ideal_code_correlation_chips(noninteger_boc, 0.1, &result, &error_message));
+
+    EXPECT_FALSE(gnss_sim::ideal_code_correlation_chips(signal(gnss_sim::SignalId::kGpsL1Ca).code_correlation,
+                                                        std::numeric_limits<double>::quiet_NaN(), &result,
+                                                        &error_message));
+}
+
+TEST(CodeCorrelation, RepeatedEvaluationIsNumericallyIdentical) {
+    const gnss_sim::SignalDefinition& b1c = signal(gnss_sim::SignalId::kBeidouB1C);
+    std::complex<double> first{};
+    std::complex<double> second{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::ideal_code_correlation_chips(b1c.code_correlation, 0.137, &first, &error_message));
+    ASSERT_TRUE(gnss_sim::ideal_code_correlation_chips(b1c.code_correlation, 0.137, &second, &error_message));
+    EXPECT_EQ(first, second);
+}
+
+} // namespace


### PR DESCRIPTION
Closes #134

## Summary

Implements the pure signal-specific ideal code-correlation layer required before #119. The implementation consumes only the central correlation metadata added by #133 and does not introduce a second signal table.

## Implementation Notes

- Adds `model/code_correlation.{h,cpp}` as a pure code-domain correlation module.
- BPSK profiles use the exact normalized triangular chip-domain ACF.
- Composite BOC profiles use deterministic analytic interval-overlap integration of piecewise-constant sine-BOC chip waveforms; no time-sampling approximation is used.
- GPS L1C pilot TMBOC uses the ideal 29/33 BOC(1,1) + 4/33 BOC(6,1) ensemble/time-average ACF.
- Galileo E1-C uses the coherent CBOC(-) waveform with its BOC(1,1)/BOC(6,1) cross terms preserved.
- BeiDou B1C uses the QMBOC complex-envelope convention from #133; the signed quadrature metadata is consumed when constructing the waveform. For same-waveform ideal autocorrelation the orthogonal cross terms cancel, but the complex/Hermitian API preserves the convention for later #119 integration.
- Galileo E5a/E5b Q remain independently tracked 10.23-Mcps sideband components per the #133 V1 convention, not a full-band AltBOC correlator.
- `R(0)=1` and the V1 ideal-code assumption treats distinct PRN chips as uncorrelated, so `R(tau)=0` for `|tau|>=1 chip`.
- Adds wrappers for delay in seconds plus chip duration and chip length, all driven by the central chip-rate metadata.
- Unsupported central profiles and non-representable composite BOC ratios fail explicitly; there is no generic triangle fallback.

## Tests

Adds deterministic unit coverage for:
- exact BPSK triangular anchors and boundary behavior;
- GPS L1C TMBOC reference anchors;
- Galileo E1-C CBOC(-) reference anchors;
- BeiDou B1C QMBOC reference anchors;
- Hermitian symmetry and normalization;
- chip-rate conversion to time/meter scale (GPS L1 C/A vs L5);
- unsupported/invalid profile fail-fast behavior;
- deterministic repeated evaluation.

## Permanent documentation

`docs/IDEAL_CODE_CORRELATION.md` records the V1 ideal-code assumption, equations, profile conventions, representative anchors, supported delay APIs, failure behavior, and scope boundary.

## Scope exclusions

No direct/reflection/diffraction path composition, propagation complex amplitude/phase, Early/Late spacing/discriminator, S-curve root solving, acquisition/tracking policy, CN0, lock, pseudorange, Doppler, carrier/ADR, final observation synthesis, IF/baseband samples, or NAV/EPH/ION changes.

The #130 propagation rule remains binding: rooftop diffraction is a modifier of the direct component and must not later be inserted as a second full-strength direct-like path.

## Data provenance / safety

No NAV/EPH/ION is generated, modified, interpolated, retargeted, or fabricated, and no parameter is tuned to force target PVT behavior.

## Next

After this PR is validated and merged, return to #119 for the complex composite path correlator, noncoherent Early/Late discriminator, stable-root classification/selection, and #117/#118 integration.