### PR TITLE
Implement basic noncoherent Early-Late power DLL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,6 +240,7 @@ if(BUILD_TESTING)
         tests/unit/test_cn0_statistics.cpp
         tests/unit/test_code_correlation.cpp
         tests/unit/test_code_tracking_dll.cpp
+        tests/unit/test_code_tracking_dll_boundaries.cpp
         tests/unit/test_deterministic_rng.cpp
         tests/unit/test_galileo_has_adapter.cpp
         tests/unit/test_low_elevation_signal_geometry.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ add_library(gnss_sim_core STATIC
     src/model/bestpos_rtk_model.cpp
     src/model/cn0_model.cpp
     src/model/code_correlation.cpp
+    src/model/code_tracking_dll.cpp
     src/model/measurement_error_model.cpp
     src/model/measurement_model.cpp
     src/model/receiver_truth.cpp
@@ -238,6 +239,7 @@ if(BUILD_TESTING)
         tests/unit/test_cn0_normalized_builder.cpp
         tests/unit/test_cn0_statistics.cpp
         tests/unit/test_code_correlation.cpp
+        tests/unit/test_code_tracking_dll.cpp
         tests/unit/test_deterministic_rng.cpp
         tests/unit/test_galileo_has_adapter.cpp
         tests/unit/test_low_elevation_signal_geometry.cpp

--- a/docs/BASIC_CODE_TRACKING_DLL.md
+++ b/docs/BASIC_CODE_TRACKING_DLL.md
@@ -76,7 +76,7 @@ The V1 solver:
 6. computes prompt power and local discriminator slope for every root;
 7. surfaces stable and unstable roots rather than hiding side-peak solutions.
 
-The search is deliberately bounded. If a caller supplies a path-delay span requiring more than the fixed V1 scan budget, the solver fails explicitly instead of silently coarsening the grid and risking missed BOC roots.
+The search is deliberately bounded. If a caller supplies a path-delay span requiring more than the fixed V1 scan budget, the solver fails explicitly instead of silently coarsening the grid and risking missed BOC roots. The required interval count is validated as a finite bounded floating-point value **before** conversion to the integer loop count, so pathological delay spans cannot rely on an out-of-range floating-to-integer conversion.
 
 ## Root selection
 
@@ -90,7 +90,7 @@ Among stable roots, choose the root nearest the previous tracked code phase. Exa
 
 Among stable roots, choose the largest prompt-power candidate. Exact-power ties prefer the candidate nearest zero relative delay, then lower code phase.
 
-The root set remains visible to later tracking-state code; #119 does not hide alternative stable roots behind a first-match rule.
+The root set remains visible to later tracking-state code; #119 does not hide alternative stable roots behind a first-match rule. Unknown selection-mode enum values fail explicitly rather than inheriting a first-candidate result.
 
 ## Physical regression behavior
 
@@ -103,6 +103,7 @@ Permanent tests cover:
 - changing total E/L spacing changes the two-path equilibrium;
 - complex path voltages are summed as supplied without RF reinterpretation;
 - unsupported signal profiles and malformed inputs fail explicitly;
+- excessive path-delay spans and unknown root-selection modes fail explicitly;
 - repeated root enumeration is bitwise deterministic for identical inputs.
 
 ## Explicit exclusions

--- a/docs/BASIC_CODE_TRACKING_DLL.md
+++ b/docs/BASIC_CODE_TRACKING_DLL.md
@@ -1,0 +1,119 @@
+# Basic Noncoherent Early-Late Power DLL
+
+Issue #119 implements the receiver-layer DLL engine after #133 centralized signal correlation metadata and #134 implemented the pure signal-specific ideal code correlation functions.
+
+## Ownership boundary
+
+The DLL consumes normalized path-domain inputs:
+
+- relative code delay in seconds;
+- normalized complex voltage contribution.
+
+The voltage value is already in one common receiver-domain convention. The DLL does **not** reinterpret wall TE/TM response, polarization, receive-antenna gain, free-space/path loss, Fresnel diffraction, open-sky C/N0, or any other RF/power term.
+
+Issue #120 owns the production mapping from #116/#117/#118 plus open-sky C/N0 into this common complex-voltage convention.
+
+This boundary is important for #118/#130: rooftop diffraction modifies the direct component. It must be represented exactly once by the producer of the direct complex voltage. The DLL must never construct `full direct + full diffraction` itself.
+
+## Composite correlator
+
+For one signal and normalized propagation paths `i`, the local composite correlator is
+
+`Z(epsilon) = sum_i V_i * R(epsilon - tau_i)`
+
+where:
+
+- `epsilon` is the candidate local code phase relative to the caller's reference path;
+- `tau_i` is each relative path delay;
+- `V_i` is the supplied complex voltage;
+- `R` is the signal-specific ideal correlation from #134.
+
+All paths for one call therefore use the same central `SignalDefinition`; there is no DLL-local signal mapping table.
+
+## Early/Late discriminator
+
+The frozen default **total** Early/Late spacing is
+
+`early_late_total_spacing_chips = 0.2`.
+
+Thus the default taps are `-0.1 chip` and `+0.1 chip` around the candidate code phase.
+
+The noncoherent power discriminator is
+
+`D(epsilon) = |Z(epsilon - s/2)|^2 - |Z(epsilon + s/2)|^2`
+
+where `s` is the total spacing.
+
+The V1 configuration API accepts finite spacing in `(0, 2] chip`; it does not implement a dynamic DLL loop filter.
+
+## Stability sign convention
+
+The documented conceptual correction law is
+
+`epsilon_next = epsilon - k * D(epsilon)`, with `k > 0`.
+
+Under this sign convention a locally stable equilibrium has
+
+`dD/depsilon > 0`.
+
+The implementation estimates that local slope symmetrically around each refined root and records both the slope and the resulting `stable` classification. This avoids an unlabeled sign convention.
+
+## Bounded deterministic root search
+
+Only the active correlation-support interval is searched. For path delays measured in chips, with total spacing `s`, the interval is bounded by
+
+`[min(tau) - 1 - s/2, max(tau) + 1 + s/2]`.
+
+This excludes the infinite external region where both E/L correlators are identically zero and prevents those zero plateaus from being reported as tracking equilibria.
+
+The V1 solver:
+
+1. scans the active interval at a fixed maximum step of `1/512 chip`;
+2. ignores samples numerically indistinguishable from zero while retaining the last nonzero sign;
+3. brackets every detected sign change;
+4. refines each bracket deterministically by bisection;
+5. de-duplicates numerically coincident roots;
+6. computes prompt power and local discriminator slope for every root;
+7. surfaces stable and unstable roots rather than hiding side-peak solutions.
+
+The search is deliberately bounded. If a caller supplies a path-delay span requiring more than the fixed V1 scan budget, the solver fails explicitly instead of silently coarsening the grid and risking missed BOC roots.
+
+## Root selection
+
+Two deterministic policies are exposed:
+
+### Tracked
+
+Among stable roots, choose the root nearest the previous tracked code phase. Exact-distance ties prefer larger prompt power, then lower code phase.
+
+### Acquisition / reacquisition
+
+Among stable roots, choose the largest prompt-power candidate. Exact-power ties prefer the candidate nearest zero relative delay, then lower code phase.
+
+The root set remains visible to later tracking-state code; #119 does not hide alternative stable roots behind a first-match rule.
+
+## Physical regression behavior
+
+Permanent tests cover:
+
+- one normalized LOS path: zero-bias stable root at the reference code phase;
+- delayed in-phase second path: positive/later code bias;
+- delayed opposite-phase path: negative near-direct bias plus additional stable solution(s);
+- GPS L1C TMBOC side-peak roots: multiple roots are surfaced and deterministic selection remains explicit;
+- changing total E/L spacing changes the two-path equilibrium;
+- complex path voltages are summed as supplied without RF reinterpretation;
+- unsupported signal profiles and malformed inputs fail explicitly;
+- repeated root enumeration is bitwise deterministic for identical inputs.
+
+## Explicit exclusions
+
+Issue #119 does not implement:
+
+- open-sky or effective C/N0;
+- conversion of #116/#117/#118 physics into final path voltage amplitudes (#120);
+- tracking C/N0 thresholds/hysteresis/reacquisition timers (#121);
+- pseudorange/Doppler/carrier/ADR synthesis (#122);
+- carrier smoothing or proprietary multipath mitigation;
+- navigation-layer multipath rejection;
+- IF/baseband samples;
+- NAV/EPH/ION generation, modification, interpolation, or retargeting.

--- a/src/model/code_tracking_dll.cpp
+++ b/src/model/code_tracking_dll.cpp
@@ -172,8 +172,8 @@ bool refine_sign_change_root(const SignalDefinition& signal, const CodeTrackingD
 }
 
 bool append_root(const SignalDefinition& signal, const CodeTrackingDllPath* paths, int path_count,
-                 const CodeTrackingDllConfig& config, double root_chips, double power_scale,
-                 CodeTrackingDllRoot* roots, int root_capacity, int* root_count, std::string* error_message) {
+                 const CodeTrackingDllConfig& config, double root_chips, double power_scale, CodeTrackingDllRoot* roots,
+                 int root_capacity, int* root_count, std::string* error_message) {
     if (roots == nullptr || root_count == nullptr || *root_count < 0 || *root_count > root_capacity) {
         set_error(error_message, "invalid code tracking DLL root output buffer");
         return false;
@@ -359,9 +359,10 @@ bool find_code_tracking_dll_roots(const SignalDefinition& signal, const CodeTrac
         }
         if (have_last_nonzero && ((last_value < 0.0 && value > 0.0) || (last_value > 0.0 && value < 0.0))) {
             double root_chips = 0.0;
-            if (!refine_sign_change_root(signal, paths, path_count, config, last_x, x, last_value, value, &root_chips) ||
-                !append_root(signal, paths, path_count, config, root_chips, power_scale, roots, root_capacity, root_count,
-                             error_message)) {
+            if (!refine_sign_change_root(signal, paths, path_count, config, last_x, x, last_value, value,
+                                         &root_chips) ||
+                !append_root(signal, paths, path_count, config, root_chips, power_scale, roots, root_capacity,
+                             root_count, error_message)) {
                 *root_count = 0;
                 return false;
             }
@@ -378,9 +379,8 @@ bool find_code_tracking_dll_roots(const SignalDefinition& signal, const CodeTrac
     return true;
 }
 
-bool select_code_tracking_dll_root(const CodeTrackingDllRoot* roots, int root_count,
-                                   CodeTrackingDllSelectionMode mode, double previous_code_phase_sec,
-                                   int* selected_index, std::string* error_message) {
+bool select_code_tracking_dll_root(const CodeTrackingDllRoot* roots, int root_count, CodeTrackingDllSelectionMode mode,
+                                   double previous_code_phase_sec, int* selected_index, std::string* error_message) {
     if (roots == nullptr || root_count <= 0 || selected_index == nullptr) {
         set_error(error_message, "invalid code tracking DLL root-selection arguments");
         return false;

--- a/src/model/code_tracking_dll.cpp
+++ b/src/model/code_tracking_dll.cpp
@@ -333,11 +333,13 @@ bool find_code_tracking_dll_roots(const SignalDefinition& signal, const CodeTrac
         set_error(error_message, "code tracking DLL root search interval is invalid");
         return false;
     }
-    const int interval_count = static_cast<int>(std::ceil(width / kRootScanStepChips));
-    if (interval_count <= 0 || interval_count > kMaxRootScanIntervals) {
+    const double interval_count_double = std::ceil(width / kRootScanStepChips);
+    if (!std::isfinite(interval_count_double) || interval_count_double < 1.0 ||
+        interval_count_double > static_cast<double>(kMaxRootScanIntervals)) {
         set_error(error_message, "code tracking DLL path-delay span exceeds the bounded V1 root-search interval");
         return false;
     }
+    const int interval_count = static_cast<int>(interval_count_double);
 
     const double zero_tolerance = kDiscriminatorZeroRelativeTolerance * power_scale;
     bool have_last_nonzero = false;
@@ -384,6 +386,10 @@ bool select_code_tracking_dll_root(const CodeTrackingDllRoot* roots, int root_co
         return false;
     }
     *selected_index = -1;
+    if (mode != CodeTrackingDllSelectionMode::TRACKED && mode != CodeTrackingDllSelectionMode::ACQUISITION) {
+        set_error(error_message, "unknown code tracking DLL root-selection mode");
+        return false;
+    }
     if (mode == CodeTrackingDllSelectionMode::TRACKED && !std::isfinite(previous_code_phase_sec)) {
         set_error(error_message, "tracked DLL root selection requires a finite previous code phase");
         return false;

--- a/src/model/code_tracking_dll.cpp
+++ b/src/model/code_tracking_dll.cpp
@@ -1,0 +1,423 @@
+#include "model/code_tracking_dll.h"
+
+#include "model/code_correlation.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace gnss_sim {
+namespace {
+
+constexpr double kDefaultEarlyLateTotalSpacingChips = 0.2;
+constexpr double kMaxEarlyLateTotalSpacingChips = 2.0;
+constexpr double kRootScanStepChips = 1.0 / 512.0;
+constexpr int kMaxRootScanIntervals = 32768;
+constexpr int kRootBisectionIterations = 80;
+constexpr double kRootToleranceChips = 1.0e-11;
+constexpr double kRootDedupToleranceChips = 1.0e-7;
+constexpr double kSlopeProbeChips = 1.0e-5;
+constexpr double kDiscriminatorZeroRelativeTolerance = 1.0e-13;
+constexpr double kStableSlopeRelativeTolerance = 1.0e-10;
+
+void set_error(std::string* error_message, const char* message) {
+    if (error_message != nullptr) {
+        *error_message = message;
+    }
+}
+
+bool finite_complex(const std::complex<double>& value) {
+    return std::isfinite(value.real()) && std::isfinite(value.imag());
+}
+
+bool validate_paths(const SignalDefinition& signal, const CodeTrackingDllPath* paths, int path_count,
+                    double* chip_rate_hz, double* power_scale, double* min_delay_chips, double* max_delay_chips,
+                    std::string* error_message) {
+    if (paths == nullptr || path_count <= 0) {
+        set_error(error_message, "code tracking DLL requires at least one path");
+        return false;
+    }
+    if (!signal_has_supported_code_correlation(signal)) {
+        set_error(error_message, "signal has no supported ideal code-correlation profile");
+        return false;
+    }
+
+    const double rate_hz = signal.code_correlation.chip_rate_hz;
+    double sum_abs_voltage = 0.0;
+    double min_delay = std::numeric_limits<double>::infinity();
+    double max_delay = -std::numeric_limits<double>::infinity();
+    for (int index = 0; index < path_count; ++index) {
+        if (!std::isfinite(paths[index].code_delay_sec) || !finite_complex(paths[index].complex_voltage)) {
+            set_error(error_message, "code tracking DLL path contains a non-finite delay or complex voltage");
+            return false;
+        }
+        const double magnitude = std::abs(paths[index].complex_voltage);
+        sum_abs_voltage += magnitude;
+        const double delay_chips = paths[index].code_delay_sec * rate_hz;
+        if (!std::isfinite(delay_chips) || !std::isfinite(sum_abs_voltage)) {
+            set_error(error_message, "code tracking DLL path scale is outside the supported numeric range");
+            return false;
+        }
+        min_delay = std::min(min_delay, delay_chips);
+        max_delay = std::max(max_delay, delay_chips);
+    }
+    if (!(sum_abs_voltage > 0.0)) {
+        set_error(error_message, "code tracking DLL requires non-zero path voltage");
+        return false;
+    }
+
+    if (chip_rate_hz != nullptr) {
+        *chip_rate_hz = rate_hz;
+    }
+    if (power_scale != nullptr) {
+        *power_scale = sum_abs_voltage * sum_abs_voltage;
+        if (!std::isfinite(*power_scale)) {
+            set_error(error_message, "code tracking DLL voltage power scale is not finite");
+            return false;
+        }
+    }
+    if (min_delay_chips != nullptr) {
+        *min_delay_chips = min_delay;
+    }
+    if (max_delay_chips != nullptr) {
+        *max_delay_chips = max_delay;
+    }
+    return true;
+}
+
+bool composite_correlation_chips(const SignalDefinition& signal, const CodeTrackingDllPath* paths, int path_count,
+                                 double local_code_phase_chips, std::complex<double>* correlation) {
+    if (correlation == nullptr) {
+        return false;
+    }
+    *correlation = {0.0, 0.0};
+    const double rate_hz = signal.code_correlation.chip_rate_hz;
+    for (int index = 0; index < path_count; ++index) {
+        const double path_delay_chips = paths[index].code_delay_sec * rate_hz;
+        std::complex<double> path_correlation{};
+        if (!ideal_code_correlation_chips(signal.code_correlation, local_code_phase_chips - path_delay_chips,
+                                          &path_correlation, nullptr)) {
+            return false;
+        }
+        *correlation += paths[index].complex_voltage * path_correlation;
+    }
+    return finite_complex(*correlation);
+}
+
+bool discriminator_chips(const SignalDefinition& signal, const CodeTrackingDllPath* paths, int path_count,
+                         const CodeTrackingDllConfig& config, double local_code_phase_chips, double* discriminator) {
+    if (discriminator == nullptr) {
+        return false;
+    }
+    const double half_spacing_chips = 0.5 * config.early_late_total_spacing_chips;
+    std::complex<double> early{};
+    std::complex<double> late{};
+    if (!composite_correlation_chips(signal, paths, path_count, local_code_phase_chips - half_spacing_chips, &early) ||
+        !composite_correlation_chips(signal, paths, path_count, local_code_phase_chips + half_spacing_chips, &late)) {
+        return false;
+    }
+    *discriminator = std::norm(early) - std::norm(late);
+    return std::isfinite(*discriminator);
+}
+
+bool prompt_power_chips(const SignalDefinition& signal, const CodeTrackingDllPath* paths, int path_count,
+                        double local_code_phase_chips, double* prompt_power) {
+    if (prompt_power == nullptr) {
+        return false;
+    }
+    std::complex<double> prompt{};
+    if (!composite_correlation_chips(signal, paths, path_count, local_code_phase_chips, &prompt)) {
+        return false;
+    }
+    *prompt_power = std::norm(prompt);
+    return std::isfinite(*prompt_power);
+}
+
+bool refine_sign_change_root(const SignalDefinition& signal, const CodeTrackingDllPath* paths, int path_count,
+                             const CodeTrackingDllConfig& config, double left, double right, double left_value,
+                             double right_value, double* root) {
+    if (root == nullptr || !(left < right) || !std::isfinite(left_value) || !std::isfinite(right_value) ||
+        left_value * right_value >= 0.0) {
+        return false;
+    }
+
+    double a = left;
+    double b = right;
+    double fa = left_value;
+    for (int iteration = 0; iteration < kRootBisectionIterations; ++iteration) {
+        const double mid = 0.5 * (a + b);
+        double fm = 0.0;
+        if (!discriminator_chips(signal, paths, path_count, config, mid, &fm)) {
+            return false;
+        }
+        if ((b - a) <= kRootToleranceChips) {
+            a = mid;
+            b = mid;
+            break;
+        }
+        if (fm == 0.0) {
+            a = mid;
+            b = mid;
+            break;
+        }
+        if ((fa < 0.0 && fm < 0.0) || (fa > 0.0 && fm > 0.0)) {
+            a = mid;
+            fa = fm;
+        } else {
+            b = mid;
+        }
+    }
+    *root = 0.5 * (a + b);
+    return std::isfinite(*root);
+}
+
+bool append_root(const SignalDefinition& signal, const CodeTrackingDllPath* paths, int path_count,
+                 const CodeTrackingDllConfig& config, double root_chips, double power_scale,
+                 CodeTrackingDllRoot* roots, int root_capacity, int* root_count, std::string* error_message) {
+    if (roots == nullptr || root_count == nullptr || *root_count < 0 || *root_count > root_capacity) {
+        set_error(error_message, "invalid code tracking DLL root output buffer");
+        return false;
+    }
+    if (*root_count > 0 && std::abs(root_chips - roots[*root_count - 1].code_phase_chips) <= kRootDedupToleranceChips) {
+        return true;
+    }
+    if (*root_count >= root_capacity || *root_count >= kMaxCodeTrackingDllRoots) {
+        set_error(error_message, "code tracking DLL root output capacity is insufficient");
+        return false;
+    }
+
+    double discriminator = 0.0;
+    double left_value = 0.0;
+    double right_value = 0.0;
+    double prompt_power = 0.0;
+    if (!discriminator_chips(signal, paths, path_count, config, root_chips, &discriminator) ||
+        !discriminator_chips(signal, paths, path_count, config, root_chips - kSlopeProbeChips, &left_value) ||
+        !discriminator_chips(signal, paths, path_count, config, root_chips + kSlopeProbeChips, &right_value) ||
+        !prompt_power_chips(signal, paths, path_count, root_chips, &prompt_power)) {
+        set_error(error_message, "failed to evaluate code tracking DLL root metrics");
+        return false;
+    }
+
+    const double slope = (right_value - left_value) / (2.0 * kSlopeProbeChips);
+    CodeTrackingDllRoot& output = roots[*root_count];
+    output.code_phase_chips = root_chips;
+    output.code_phase_sec = root_chips / signal.code_correlation.chip_rate_hz;
+    output.discriminator = discriminator;
+    output.discriminator_slope_per_chip = slope;
+    output.prompt_power = prompt_power;
+    output.stable = std::isfinite(slope) && slope > kStableSlopeRelativeTolerance * power_scale;
+    ++(*root_count);
+    return true;
+}
+
+bool prefer_tracked_candidate(const CodeTrackingDllRoot& candidate, const CodeTrackingDllRoot& current,
+                              double previous_code_phase_sec) {
+    const double candidate_distance = std::abs(candidate.code_phase_sec - previous_code_phase_sec);
+    const double current_distance = std::abs(current.code_phase_sec - previous_code_phase_sec);
+    if (candidate_distance != current_distance) {
+        return candidate_distance < current_distance;
+    }
+    if (candidate.prompt_power != current.prompt_power) {
+        return candidate.prompt_power > current.prompt_power;
+    }
+    return candidate.code_phase_sec < current.code_phase_sec;
+}
+
+bool prefer_acquisition_candidate(const CodeTrackingDllRoot& candidate, const CodeTrackingDllRoot& current) {
+    if (candidate.prompt_power != current.prompt_power) {
+        return candidate.prompt_power > current.prompt_power;
+    }
+    const double candidate_abs_phase = std::abs(candidate.code_phase_sec);
+    const double current_abs_phase = std::abs(current.code_phase_sec);
+    if (candidate_abs_phase != current_abs_phase) {
+        return candidate_abs_phase < current_abs_phase;
+    }
+    return candidate.code_phase_sec < current.code_phase_sec;
+}
+
+} // namespace
+
+CodeTrackingDllConfig default_code_tracking_dll_config() {
+    CodeTrackingDllConfig config{};
+    config.early_late_total_spacing_chips = kDefaultEarlyLateTotalSpacingChips;
+    return config;
+}
+
+bool validate_code_tracking_dll_config(const CodeTrackingDllConfig& config, std::string* error_message) {
+    if (!std::isfinite(config.early_late_total_spacing_chips) || config.early_late_total_spacing_chips <= 0.0 ||
+        config.early_late_total_spacing_chips > kMaxEarlyLateTotalSpacingChips) {
+        set_error(error_message, "early_late_total_spacing_chips must be finite and in (0, 2]");
+        return false;
+    }
+    return true;
+}
+
+bool compute_code_tracking_composite_correlation(const SignalDefinition& signal, const CodeTrackingDllPath* paths,
+                                                 int path_count, double local_code_phase_sec,
+                                                 std::complex<double>* correlation, std::string* error_message) {
+    if (correlation == nullptr) {
+        set_error(error_message, "code tracking composite-correlation output pointer is null");
+        return false;
+    }
+    *correlation = {0.0, 0.0};
+    if (!std::isfinite(local_code_phase_sec)) {
+        set_error(error_message, "code tracking local code phase is not finite");
+        return false;
+    }
+    double chip_rate_hz = 0.0;
+    if (!validate_paths(signal, paths, path_count, &chip_rate_hz, nullptr, nullptr, nullptr, error_message)) {
+        return false;
+    }
+    const double local_phase_chips = local_code_phase_sec * chip_rate_hz;
+    if (!std::isfinite(local_phase_chips) ||
+        !composite_correlation_chips(signal, paths, path_count, local_phase_chips, correlation)) {
+        set_error(error_message, "failed to evaluate code tracking composite correlation");
+        return false;
+    }
+    return true;
+}
+
+bool compute_code_tracking_dll_discriminator(const SignalDefinition& signal, const CodeTrackingDllPath* paths,
+                                             int path_count, const CodeTrackingDllConfig& config,
+                                             double local_code_phase_sec, double* discriminator,
+                                             std::string* error_message) {
+    if (discriminator == nullptr) {
+        set_error(error_message, "code tracking DLL discriminator output pointer is null");
+        return false;
+    }
+    *discriminator = 0.0;
+    if (!validate_code_tracking_dll_config(config, error_message) || !std::isfinite(local_code_phase_sec)) {
+        if (!std::isfinite(local_code_phase_sec)) {
+            set_error(error_message, "code tracking local code phase is not finite");
+        }
+        return false;
+    }
+    double chip_rate_hz = 0.0;
+    if (!validate_paths(signal, paths, path_count, &chip_rate_hz, nullptr, nullptr, nullptr, error_message)) {
+        return false;
+    }
+    const double local_phase_chips = local_code_phase_sec * chip_rate_hz;
+    if (!std::isfinite(local_phase_chips) ||
+        !discriminator_chips(signal, paths, path_count, config, local_phase_chips, discriminator)) {
+        set_error(error_message, "failed to evaluate code tracking DLL discriminator");
+        return false;
+    }
+    return true;
+}
+
+bool find_code_tracking_dll_roots(const SignalDefinition& signal, const CodeTrackingDllPath* paths, int path_count,
+                                  const CodeTrackingDllConfig& config, CodeTrackingDllRoot* roots, int root_capacity,
+                                  int* root_count, std::string* error_message) {
+    if (root_count == nullptr || roots == nullptr || root_capacity <= 0 || root_capacity > kMaxCodeTrackingDllRoots) {
+        set_error(error_message, "invalid code tracking DLL root output arguments");
+        return false;
+    }
+    *root_count = 0;
+    if (!validate_code_tracking_dll_config(config, error_message)) {
+        return false;
+    }
+
+    double power_scale = 0.0;
+    double min_delay_chips = 0.0;
+    double max_delay_chips = 0.0;
+    if (!validate_paths(signal, paths, path_count, nullptr, &power_scale, &min_delay_chips, &max_delay_chips,
+                        error_message)) {
+        return false;
+    }
+
+    const double half_spacing = 0.5 * config.early_late_total_spacing_chips;
+    const double lower = min_delay_chips - 1.0 - half_spacing;
+    const double upper = max_delay_chips + 1.0 + half_spacing;
+    const double width = upper - lower;
+    if (!(width > 0.0) || !std::isfinite(width)) {
+        set_error(error_message, "code tracking DLL root search interval is invalid");
+        return false;
+    }
+    const int interval_count = static_cast<int>(std::ceil(width / kRootScanStepChips));
+    if (interval_count <= 0 || interval_count > kMaxRootScanIntervals) {
+        set_error(error_message, "code tracking DLL path-delay span exceeds the bounded V1 root-search interval");
+        return false;
+    }
+
+    const double zero_tolerance = kDiscriminatorZeroRelativeTolerance * power_scale;
+    bool have_last_nonzero = false;
+    double last_x = 0.0;
+    double last_value = 0.0;
+    for (int sample = 0; sample <= interval_count; ++sample) {
+        const double fraction = static_cast<double>(sample) / static_cast<double>(interval_count);
+        const double x = lower + fraction * width;
+        double value = 0.0;
+        if (!discriminator_chips(signal, paths, path_count, config, x, &value)) {
+            set_error(error_message, "failed while scanning code tracking DLL discriminator roots");
+            *root_count = 0;
+            return false;
+        }
+        if (std::abs(value) <= zero_tolerance) {
+            continue;
+        }
+        if (have_last_nonzero && ((last_value < 0.0 && value > 0.0) || (last_value > 0.0 && value < 0.0))) {
+            double root_chips = 0.0;
+            if (!refine_sign_change_root(signal, paths, path_count, config, last_x, x, last_value, value, &root_chips) ||
+                !append_root(signal, paths, path_count, config, root_chips, power_scale, roots, root_capacity, root_count,
+                             error_message)) {
+                *root_count = 0;
+                return false;
+            }
+        }
+        have_last_nonzero = true;
+        last_x = x;
+        last_value = value;
+    }
+
+    if (*root_count == 0) {
+        set_error(error_message, "code tracking DLL found no discriminator roots in the active support region");
+        return false;
+    }
+    return true;
+}
+
+bool select_code_tracking_dll_root(const CodeTrackingDllRoot* roots, int root_count,
+                                   CodeTrackingDllSelectionMode mode, double previous_code_phase_sec,
+                                   int* selected_index, std::string* error_message) {
+    if (roots == nullptr || root_count <= 0 || selected_index == nullptr) {
+        set_error(error_message, "invalid code tracking DLL root-selection arguments");
+        return false;
+    }
+    *selected_index = -1;
+    if (mode == CodeTrackingDllSelectionMode::TRACKED && !std::isfinite(previous_code_phase_sec)) {
+        set_error(error_message, "tracked DLL root selection requires a finite previous code phase");
+        return false;
+    }
+
+    for (int index = 0; index < root_count; ++index) {
+        if (!roots[index].stable) {
+            continue;
+        }
+        if (*selected_index < 0) {
+            *selected_index = index;
+            continue;
+        }
+        const CodeTrackingDllRoot& candidate = roots[index];
+        const CodeTrackingDllRoot& current = roots[*selected_index];
+        bool prefer = false;
+        switch (mode) {
+            case CodeTrackingDllSelectionMode::TRACKED:
+                prefer = prefer_tracked_candidate(candidate, current, previous_code_phase_sec);
+                break;
+            case CodeTrackingDllSelectionMode::ACQUISITION:
+                prefer = prefer_acquisition_candidate(candidate, current);
+                break;
+        }
+        if (prefer) {
+            *selected_index = index;
+        }
+    }
+
+    if (*selected_index < 0) {
+        set_error(error_message, "code tracking DLL root set contains no stable candidate");
+        return false;
+    }
+    return true;
+}
+
+} // namespace gnss_sim

--- a/src/model/code_tracking_dll.h
+++ b/src/model/code_tracking_dll.h
@@ -60,9 +60,8 @@ bool find_code_tracking_dll_roots(const SignalDefinition& signal, const CodeTrac
                                   const CodeTrackingDllConfig& config, CodeTrackingDllRoot* roots, int root_capacity,
                                   int* root_count, std::string* error_message);
 
-bool select_code_tracking_dll_root(const CodeTrackingDllRoot* roots, int root_count,
-                                   CodeTrackingDllSelectionMode mode, double previous_code_phase_sec,
-                                   int* selected_index, std::string* error_message);
+bool select_code_tracking_dll_root(const CodeTrackingDllRoot* roots, int root_count, CodeTrackingDllSelectionMode mode,
+                                   double previous_code_phase_sec, int* selected_index, std::string* error_message);
 
 } // namespace gnss_sim
 

--- a/src/model/code_tracking_dll.h
+++ b/src/model/code_tracking_dll.h
@@ -1,0 +1,69 @@
+#ifndef GNSS_SIM_SRC_MODEL_CODE_TRACKING_DLL_H_
+#define GNSS_SIM_SRC_MODEL_CODE_TRACKING_DLL_H_
+
+#include "gnss/signal_definitions.h"
+
+#include <complex>
+#include <string>
+
+namespace gnss_sim {
+
+constexpr int kMaxCodeTrackingDllRoots = 64;
+
+struct CodeTrackingDllConfig {
+    double early_late_total_spacing_chips;
+};
+
+struct CodeTrackingDllPath {
+    // Relative propagation/code delay from the caller's chosen reference path.
+    // #120 owns the production mapping from urban propagation into this value.
+    double code_delay_sec;
+
+    // Normalized complex voltage contribution in one common receiver-domain
+    // convention. #119 does not reinterpret RF/material/antenna/CN0 terms.
+    std::complex<double> complex_voltage;
+};
+
+struct CodeTrackingDllRoot {
+    double code_phase_sec;
+    double code_phase_chips;
+    double discriminator;
+    double discriminator_slope_per_chip;
+    double prompt_power;
+    bool stable;
+};
+
+enum class CodeTrackingDllSelectionMode {
+    TRACKED = 0,
+    ACQUISITION,
+};
+
+CodeTrackingDllConfig default_code_tracking_dll_config();
+bool validate_code_tracking_dll_config(const CodeTrackingDllConfig& config, std::string* error_message);
+
+bool compute_code_tracking_composite_correlation(const SignalDefinition& signal, const CodeTrackingDllPath* paths,
+                                                 int path_count, double local_code_phase_sec,
+                                                 std::complex<double>* correlation, std::string* error_message);
+
+// D(epsilon) = |Z(epsilon - spacing/2)|^2 - |Z(epsilon + spacing/2)|^2.
+// With the documented correction law epsilon_next = epsilon - k*D(epsilon),
+// stable roots have positive local dD/depsilon.
+bool compute_code_tracking_dll_discriminator(const SignalDefinition& signal, const CodeTrackingDllPath* paths,
+                                             int path_count, const CodeTrackingDllConfig& config,
+                                             double local_code_phase_sec, double* discriminator,
+                                             std::string* error_message);
+
+// Enumerate deterministic discriminator roots in the active correlation support
+// region. Both stable and unstable roots are surfaced; callers select only stable
+// roots according to the explicit policy below.
+bool find_code_tracking_dll_roots(const SignalDefinition& signal, const CodeTrackingDllPath* paths, int path_count,
+                                  const CodeTrackingDllConfig& config, CodeTrackingDllRoot* roots, int root_capacity,
+                                  int* root_count, std::string* error_message);
+
+bool select_code_tracking_dll_root(const CodeTrackingDllRoot* roots, int root_count,
+                                   CodeTrackingDllSelectionMode mode, double previous_code_phase_sec,
+                                   int* selected_index, std::string* error_message);
+
+} // namespace gnss_sim
+
+#endif // GNSS_SIM_SRC_MODEL_CODE_TRACKING_DLL_H_

--- a/tests/unit/test_code_tracking_dll.cpp
+++ b/tests/unit/test_code_tracking_dll.cpp
@@ -49,8 +49,8 @@ TEST(CodeTrackingDll, OnePathLosHasStableZeroBiasRoot) {
     std::string error_message;
     ASSERT_TRUE(gnss_sim::compute_code_tracking_dll_discriminator(
         gps_l1, paths, 1, config, chips_to_seconds(gps_l1, -0.01), &negative, &error_message));
-    ASSERT_TRUE(gnss_sim::compute_code_tracking_dll_discriminator(gps_l1, paths, 1, config, 0.0, &zero,
-                                                                 &error_message));
+    ASSERT_TRUE(
+        gnss_sim::compute_code_tracking_dll_discriminator(gps_l1, paths, 1, config, 0.0, &zero, &error_message));
     ASSERT_TRUE(gnss_sim::compute_code_tracking_dll_discriminator(
         gps_l1, paths, 1, config, chips_to_seconds(gps_l1, 0.01), &positive, &error_message));
     EXPECT_LT(negative, 0.0);
@@ -59,9 +59,8 @@ TEST(CodeTrackingDll, OnePathLosHasStableZeroBiasRoot) {
 
     gnss_sim::CodeTrackingDllRoot roots[gnss_sim::kMaxCodeTrackingDllRoots]{};
     int root_count = 0;
-    ASSERT_TRUE(gnss_sim::find_code_tracking_dll_roots(gps_l1, paths, 1, config, roots,
-                                                       gnss_sim::kMaxCodeTrackingDllRoots, &root_count,
-                                                       &error_message));
+    ASSERT_TRUE(gnss_sim::find_code_tracking_dll_roots(
+        gps_l1, paths, 1, config, roots, gnss_sim::kMaxCodeTrackingDllRoots, &root_count, &error_message));
     ASSERT_EQ(root_count, 1);
     EXPECT_TRUE(roots[0].stable);
     EXPECT_NEAR(roots[0].code_phase_chips, 0.0, 1.0e-8);
@@ -79,14 +78,12 @@ TEST(CodeTrackingDll, ConstructiveDelayedPathPullsTrackedCodeLater) {
     gnss_sim::CodeTrackingDllRoot roots[gnss_sim::kMaxCodeTrackingDllRoots]{};
     int root_count = 0;
     std::string error_message;
-    ASSERT_TRUE(gnss_sim::find_code_tracking_dll_roots(gps_l1, paths, 2, config, roots,
-                                                       gnss_sim::kMaxCodeTrackingDllRoots, &root_count,
-                                                       &error_message));
+    ASSERT_TRUE(gnss_sim::find_code_tracking_dll_roots(
+        gps_l1, paths, 2, config, roots, gnss_sim::kMaxCodeTrackingDllRoots, &root_count, &error_message));
 
     int selected = -1;
-    ASSERT_TRUE(gnss_sim::select_code_tracking_dll_root(roots, root_count,
-                                                       gnss_sim::CodeTrackingDllSelectionMode::ACQUISITION, 0.0,
-                                                       &selected, &error_message));
+    ASSERT_TRUE(gnss_sim::select_code_tracking_dll_root(
+        roots, root_count, gnss_sim::CodeTrackingDllSelectionMode::ACQUISITION, 0.0, &selected, &error_message));
     ASSERT_GE(selected, 0);
     EXPECT_TRUE(roots[selected].stable);
     EXPECT_NEAR(roots[selected].code_phase_chips, 0.05, 1.0e-6);
@@ -103,9 +100,8 @@ TEST(CodeTrackingDll, OppositePhasePathCanProduceNegativeBiasAndMultipleStableRo
     gnss_sim::CodeTrackingDllRoot roots[gnss_sim::kMaxCodeTrackingDllRoots]{};
     int root_count = 0;
     std::string error_message;
-    ASSERT_TRUE(gnss_sim::find_code_tracking_dll_roots(gps_l1, paths, 2, config, roots,
-                                                       gnss_sim::kMaxCodeTrackingDllRoots, &root_count,
-                                                       &error_message));
+    ASSERT_TRUE(gnss_sim::find_code_tracking_dll_roots(
+        gps_l1, paths, 2, config, roots, gnss_sim::kMaxCodeTrackingDllRoots, &root_count, &error_message));
 
     int stable_count = 0;
     for (int index = 0; index < root_count; ++index) {
@@ -116,16 +112,15 @@ TEST(CodeTrackingDll, OppositePhasePathCanProduceNegativeBiasAndMultipleStableRo
     EXPECT_GE(stable_count, 2);
 
     int selected = -1;
-    ASSERT_TRUE(gnss_sim::select_code_tracking_dll_root(
-        roots, root_count, gnss_sim::CodeTrackingDllSelectionMode::TRACKED, chips_to_seconds(gps_l1, -0.03),
-        &selected, &error_message));
+    ASSERT_TRUE(gnss_sim::select_code_tracking_dll_root(roots, root_count,
+                                                        gnss_sim::CodeTrackingDllSelectionMode::TRACKED,
+                                                        chips_to_seconds(gps_l1, -0.03), &selected, &error_message));
     ASSERT_GE(selected, 0);
     EXPECT_NEAR(roots[selected].code_phase_chips, -0.05, 1.0e-6);
 
     int acquisition = -1;
-    ASSERT_TRUE(gnss_sim::select_code_tracking_dll_root(roots, root_count,
-                                                       gnss_sim::CodeTrackingDllSelectionMode::ACQUISITION, 0.0,
-                                                       &acquisition, &error_message));
+    ASSERT_TRUE(gnss_sim::select_code_tracking_dll_root(
+        roots, root_count, gnss_sim::CodeTrackingDllSelectionMode::ACQUISITION, 0.0, &acquisition, &error_message));
     ASSERT_GE(acquisition, 0);
     EXPECT_NEAR(roots[acquisition].code_phase_chips, -0.05, 1.0e-6);
 }
@@ -137,9 +132,8 @@ TEST(CodeTrackingDll, BocSidePeaksAreSurfacedAndSelectionPolicyIsDeterministic) 
     gnss_sim::CodeTrackingDllRoot roots[gnss_sim::kMaxCodeTrackingDllRoots]{};
     int root_count = 0;
     std::string error_message;
-    ASSERT_TRUE(gnss_sim::find_code_tracking_dll_roots(gps_l1c, paths, 1, config, roots,
-                                                       gnss_sim::kMaxCodeTrackingDllRoots, &root_count,
-                                                       &error_message));
+    ASSERT_TRUE(gnss_sim::find_code_tracking_dll_roots(
+        gps_l1c, paths, 1, config, roots, gnss_sim::kMaxCodeTrackingDllRoots, &root_count, &error_message));
     EXPECT_GT(root_count, 1);
 
     const int zero_root = nearest_root_index(roots, root_count, 0.0);
@@ -148,15 +142,14 @@ TEST(CodeTrackingDll, BocSidePeaksAreSurfacedAndSelectionPolicyIsDeterministic) 
     EXPECT_NEAR(roots[zero_root].code_phase_chips, 0.0, 1.0e-8);
 
     int acquisition = -1;
-    ASSERT_TRUE(gnss_sim::select_code_tracking_dll_root(roots, root_count,
-                                                       gnss_sim::CodeTrackingDllSelectionMode::ACQUISITION, 0.0,
-                                                       &acquisition, &error_message));
+    ASSERT_TRUE(gnss_sim::select_code_tracking_dll_root(
+        roots, root_count, gnss_sim::CodeTrackingDllSelectionMode::ACQUISITION, 0.0, &acquisition, &error_message));
     EXPECT_EQ(acquisition, zero_root);
 
     int tracked = -1;
-    ASSERT_TRUE(gnss_sim::select_code_tracking_dll_root(
-        roots, root_count, gnss_sim::CodeTrackingDllSelectionMode::TRACKED, chips_to_seconds(gps_l1c, 0.55),
-        &tracked, &error_message));
+    ASSERT_TRUE(gnss_sim::select_code_tracking_dll_root(roots, root_count,
+                                                        gnss_sim::CodeTrackingDllSelectionMode::TRACKED,
+                                                        chips_to_seconds(gps_l1c, 0.55), &tracked, &error_message));
     ASSERT_GE(tracked, 0);
     EXPECT_TRUE(roots[tracked].stable);
     EXPECT_GT(roots[tracked].code_phase_chips, 0.4);
@@ -174,13 +167,11 @@ TEST(CodeTrackingDll, ConfigurableSpacingChangesTwoPathEquilibrium) {
     std::string error_message;
 
     config.early_late_total_spacing_chips = 0.4;
-    ASSERT_TRUE(gnss_sim::find_code_tracking_dll_roots(gps_l1, paths, 2, config, roots,
-                                                       gnss_sim::kMaxCodeTrackingDllRoots, &root_count,
-                                                       &error_message));
+    ASSERT_TRUE(gnss_sim::find_code_tracking_dll_roots(
+        gps_l1, paths, 2, config, roots, gnss_sim::kMaxCodeTrackingDllRoots, &root_count, &error_message));
     int selected = -1;
-    ASSERT_TRUE(gnss_sim::select_code_tracking_dll_root(roots, root_count,
-                                                       gnss_sim::CodeTrackingDllSelectionMode::ACQUISITION, 0.0,
-                                                       &selected, &error_message));
+    ASSERT_TRUE(gnss_sim::select_code_tracking_dll_root(
+        roots, root_count, gnss_sim::CodeTrackingDllSelectionMode::ACQUISITION, 0.0, &selected, &error_message));
     EXPECT_NEAR(roots[selected].code_phase_chips, 0.1, 1.0e-6);
 }
 
@@ -192,8 +183,8 @@ TEST(CodeTrackingDll, CompositeCorrelationUsesNormalizedComplexVoltageWithoutRei
     };
     std::complex<double> correlation{};
     std::string error_message;
-    ASSERT_TRUE(gnss_sim::compute_code_tracking_composite_correlation(gps_l1, paths, 2, 0.0, &correlation,
-                                                                      &error_message));
+    ASSERT_TRUE(
+        gnss_sim::compute_code_tracking_composite_correlation(gps_l1, paths, 2, 0.0, &correlation, &error_message));
     EXPECT_NEAR(correlation.real(), 1.0, 1.0e-15);
     EXPECT_NEAR(correlation.imag(), 0.5, 1.0e-15);
 }
@@ -210,22 +201,19 @@ TEST(CodeTrackingDll, InvalidInputsFailExplicitly) {
     const gnss_sim::CodeTrackingDllPath zero_path[] = {{0.0, {0.0, 0.0}}};
     gnss_sim::CodeTrackingDllRoot roots[gnss_sim::kMaxCodeTrackingDllRoots]{};
     int root_count = 0;
-    EXPECT_FALSE(gnss_sim::find_code_tracking_dll_roots(gps_l1, zero_path, 1,
-                                                        gnss_sim::default_code_tracking_dll_config(), roots,
-                                                        gnss_sim::kMaxCodeTrackingDllRoots, &root_count,
-                                                        &error_message));
+    EXPECT_FALSE(
+        gnss_sim::find_code_tracking_dll_roots(gps_l1, zero_path, 1, gnss_sim::default_code_tracking_dll_config(),
+                                               roots, gnss_sim::kMaxCodeTrackingDllRoots, &root_count, &error_message));
 
     const gnss_sim::CodeTrackingDllPath path[] = {{0.0, {1.0, 0.0}}};
-    EXPECT_FALSE(gnss_sim::find_code_tracking_dll_roots(gps_l2c, path, 1,
-                                                        gnss_sim::default_code_tracking_dll_config(), roots,
-                                                        gnss_sim::kMaxCodeTrackingDllRoots, &root_count,
+    EXPECT_FALSE(gnss_sim::find_code_tracking_dll_roots(gps_l2c, path, 1, gnss_sim::default_code_tracking_dll_config(),
+                                                        roots, gnss_sim::kMaxCodeTrackingDllRoots, &root_count,
                                                         &error_message));
 
     int selected = -1;
     gnss_sim::CodeTrackingDllRoot unstable{};
     unstable.stable = false;
-    EXPECT_FALSE(gnss_sim::select_code_tracking_dll_root(&unstable, 1,
-                                                         gnss_sim::CodeTrackingDllSelectionMode::TRACKED,
+    EXPECT_FALSE(gnss_sim::select_code_tracking_dll_root(&unstable, 1, gnss_sim::CodeTrackingDllSelectionMode::TRACKED,
                                                          std::numeric_limits<double>::quiet_NaN(), &selected,
                                                          &error_message));
 }
@@ -242,12 +230,10 @@ TEST(CodeTrackingDll, RepeatedRootEnumerationIsNumericallyIdentical) {
     int first_count = 0;
     int second_count = 0;
     std::string error_message;
-    ASSERT_TRUE(gnss_sim::find_code_tracking_dll_roots(gps_l1, paths, 2, config, first,
-                                                       gnss_sim::kMaxCodeTrackingDllRoots, &first_count,
-                                                       &error_message));
-    ASSERT_TRUE(gnss_sim::find_code_tracking_dll_roots(gps_l1, paths, 2, config, second,
-                                                       gnss_sim::kMaxCodeTrackingDllRoots, &second_count,
-                                                       &error_message));
+    ASSERT_TRUE(gnss_sim::find_code_tracking_dll_roots(
+        gps_l1, paths, 2, config, first, gnss_sim::kMaxCodeTrackingDllRoots, &first_count, &error_message));
+    ASSERT_TRUE(gnss_sim::find_code_tracking_dll_roots(
+        gps_l1, paths, 2, config, second, gnss_sim::kMaxCodeTrackingDllRoots, &second_count, &error_message));
     ASSERT_EQ(first_count, second_count);
     for (int index = 0; index < first_count; ++index) {
         EXPECT_DOUBLE_EQ(first[index].code_phase_sec, second[index].code_phase_sec);

--- a/tests/unit/test_code_tracking_dll.cpp
+++ b/tests/unit/test_code_tracking_dll.cpp
@@ -1,0 +1,260 @@
+#include "model/code_tracking_dll.h"
+
+#include <cmath>
+#include <complex>
+#include <gtest/gtest.h>
+#include <limits>
+#include <string>
+
+namespace {
+
+const gnss_sim::SignalDefinition& signal(gnss_sim::SignalId signal_id) {
+    const gnss_sim::SignalDefinition* definition = gnss_sim::find_signal_definition(signal_id);
+    EXPECT_NE(definition, nullptr);
+    return *definition;
+}
+
+double chips_to_seconds(const gnss_sim::SignalDefinition& definition, double chips) {
+    return chips / definition.code_correlation.chip_rate_hz;
+}
+
+int nearest_root_index(const gnss_sim::CodeTrackingDllRoot* roots, int root_count, double target_chips) {
+    int best = -1;
+    double best_distance = std::numeric_limits<double>::infinity();
+    for (int index = 0; index < root_count; ++index) {
+        const double distance = std::abs(roots[index].code_phase_chips - target_chips);
+        if (distance < best_distance) {
+            best = index;
+            best_distance = distance;
+        }
+    }
+    return best;
+}
+
+TEST(CodeTrackingDll, DefaultConfigUsesFrozenPointTwoChipTotalSpacing) {
+    const gnss_sim::CodeTrackingDllConfig config = gnss_sim::default_code_tracking_dll_config();
+    EXPECT_DOUBLE_EQ(config.early_late_total_spacing_chips, 0.2);
+    std::string error_message;
+    EXPECT_TRUE(gnss_sim::validate_code_tracking_dll_config(config, &error_message));
+}
+
+TEST(CodeTrackingDll, OnePathLosHasStableZeroBiasRoot) {
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    const gnss_sim::CodeTrackingDllPath paths[] = {{0.0, {1.0, 0.0}}};
+    const gnss_sim::CodeTrackingDllConfig config = gnss_sim::default_code_tracking_dll_config();
+
+    double negative = 0.0;
+    double zero = 0.0;
+    double positive = 0.0;
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::compute_code_tracking_dll_discriminator(
+        gps_l1, paths, 1, config, chips_to_seconds(gps_l1, -0.01), &negative, &error_message));
+    ASSERT_TRUE(gnss_sim::compute_code_tracking_dll_discriminator(gps_l1, paths, 1, config, 0.0, &zero,
+                                                                 &error_message));
+    ASSERT_TRUE(gnss_sim::compute_code_tracking_dll_discriminator(
+        gps_l1, paths, 1, config, chips_to_seconds(gps_l1, 0.01), &positive, &error_message));
+    EXPECT_LT(negative, 0.0);
+    EXPECT_NEAR(zero, 0.0, 1.0e-15);
+    EXPECT_GT(positive, 0.0);
+
+    gnss_sim::CodeTrackingDllRoot roots[gnss_sim::kMaxCodeTrackingDllRoots]{};
+    int root_count = 0;
+    ASSERT_TRUE(gnss_sim::find_code_tracking_dll_roots(gps_l1, paths, 1, config, roots,
+                                                       gnss_sim::kMaxCodeTrackingDllRoots, &root_count,
+                                                       &error_message));
+    ASSERT_EQ(root_count, 1);
+    EXPECT_TRUE(roots[0].stable);
+    EXPECT_NEAR(roots[0].code_phase_chips, 0.0, 1.0e-8);
+    EXPECT_NEAR(roots[0].prompt_power, 1.0, 1.0e-10);
+    EXPECT_GT(roots[0].discriminator_slope_per_chip, 0.0);
+}
+
+TEST(CodeTrackingDll, ConstructiveDelayedPathPullsTrackedCodeLater) {
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    const gnss_sim::CodeTrackingDllPath paths[] = {
+        {0.0, {1.0, 0.0}},
+        {chips_to_seconds(gps_l1, 0.3), {0.5, 0.0}},
+    };
+    const gnss_sim::CodeTrackingDllConfig config = gnss_sim::default_code_tracking_dll_config();
+    gnss_sim::CodeTrackingDllRoot roots[gnss_sim::kMaxCodeTrackingDllRoots]{};
+    int root_count = 0;
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::find_code_tracking_dll_roots(gps_l1, paths, 2, config, roots,
+                                                       gnss_sim::kMaxCodeTrackingDllRoots, &root_count,
+                                                       &error_message));
+
+    int selected = -1;
+    ASSERT_TRUE(gnss_sim::select_code_tracking_dll_root(roots, root_count,
+                                                       gnss_sim::CodeTrackingDllSelectionMode::ACQUISITION, 0.0,
+                                                       &selected, &error_message));
+    ASSERT_GE(selected, 0);
+    EXPECT_TRUE(roots[selected].stable);
+    EXPECT_NEAR(roots[selected].code_phase_chips, 0.05, 1.0e-6);
+    EXPECT_GT(roots[selected].code_phase_chips, 0.0);
+}
+
+TEST(CodeTrackingDll, OppositePhasePathCanProduceNegativeBiasAndMultipleStableRoots) {
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    const gnss_sim::CodeTrackingDllPath paths[] = {
+        {0.0, {1.0, 0.0}},
+        {chips_to_seconds(gps_l1, 0.3), {-0.5, 0.0}},
+    };
+    const gnss_sim::CodeTrackingDllConfig config = gnss_sim::default_code_tracking_dll_config();
+    gnss_sim::CodeTrackingDllRoot roots[gnss_sim::kMaxCodeTrackingDllRoots]{};
+    int root_count = 0;
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::find_code_tracking_dll_roots(gps_l1, paths, 2, config, roots,
+                                                       gnss_sim::kMaxCodeTrackingDllRoots, &root_count,
+                                                       &error_message));
+
+    int stable_count = 0;
+    for (int index = 0; index < root_count; ++index) {
+        if (roots[index].stable) {
+            ++stable_count;
+        }
+    }
+    EXPECT_GE(stable_count, 2);
+
+    int selected = -1;
+    ASSERT_TRUE(gnss_sim::select_code_tracking_dll_root(
+        roots, root_count, gnss_sim::CodeTrackingDllSelectionMode::TRACKED, chips_to_seconds(gps_l1, -0.03),
+        &selected, &error_message));
+    ASSERT_GE(selected, 0);
+    EXPECT_NEAR(roots[selected].code_phase_chips, -0.05, 1.0e-6);
+
+    int acquisition = -1;
+    ASSERT_TRUE(gnss_sim::select_code_tracking_dll_root(roots, root_count,
+                                                       gnss_sim::CodeTrackingDllSelectionMode::ACQUISITION, 0.0,
+                                                       &acquisition, &error_message));
+    ASSERT_GE(acquisition, 0);
+    EXPECT_NEAR(roots[acquisition].code_phase_chips, -0.05, 1.0e-6);
+}
+
+TEST(CodeTrackingDll, BocSidePeaksAreSurfacedAndSelectionPolicyIsDeterministic) {
+    const gnss_sim::SignalDefinition& gps_l1c = signal(gnss_sim::SignalId::kGpsL1C);
+    const gnss_sim::CodeTrackingDllPath paths[] = {{0.0, {1.0, 0.0}}};
+    const gnss_sim::CodeTrackingDllConfig config = gnss_sim::default_code_tracking_dll_config();
+    gnss_sim::CodeTrackingDllRoot roots[gnss_sim::kMaxCodeTrackingDllRoots]{};
+    int root_count = 0;
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::find_code_tracking_dll_roots(gps_l1c, paths, 1, config, roots,
+                                                       gnss_sim::kMaxCodeTrackingDllRoots, &root_count,
+                                                       &error_message));
+    EXPECT_GT(root_count, 1);
+
+    const int zero_root = nearest_root_index(roots, root_count, 0.0);
+    ASSERT_GE(zero_root, 0);
+    EXPECT_TRUE(roots[zero_root].stable);
+    EXPECT_NEAR(roots[zero_root].code_phase_chips, 0.0, 1.0e-8);
+
+    int acquisition = -1;
+    ASSERT_TRUE(gnss_sim::select_code_tracking_dll_root(roots, root_count,
+                                                       gnss_sim::CodeTrackingDllSelectionMode::ACQUISITION, 0.0,
+                                                       &acquisition, &error_message));
+    EXPECT_EQ(acquisition, zero_root);
+
+    int tracked = -1;
+    ASSERT_TRUE(gnss_sim::select_code_tracking_dll_root(
+        roots, root_count, gnss_sim::CodeTrackingDllSelectionMode::TRACKED, chips_to_seconds(gps_l1c, 0.55),
+        &tracked, &error_message));
+    ASSERT_GE(tracked, 0);
+    EXPECT_TRUE(roots[tracked].stable);
+    EXPECT_GT(roots[tracked].code_phase_chips, 0.4);
+}
+
+TEST(CodeTrackingDll, ConfigurableSpacingChangesTwoPathEquilibrium) {
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    const gnss_sim::CodeTrackingDllPath paths[] = {
+        {0.0, {1.0, 0.0}},
+        {chips_to_seconds(gps_l1, 0.3), {0.5, 0.0}},
+    };
+    gnss_sim::CodeTrackingDllConfig config = gnss_sim::default_code_tracking_dll_config();
+    gnss_sim::CodeTrackingDllRoot roots[gnss_sim::kMaxCodeTrackingDllRoots]{};
+    int root_count = 0;
+    std::string error_message;
+
+    config.early_late_total_spacing_chips = 0.4;
+    ASSERT_TRUE(gnss_sim::find_code_tracking_dll_roots(gps_l1, paths, 2, config, roots,
+                                                       gnss_sim::kMaxCodeTrackingDllRoots, &root_count,
+                                                       &error_message));
+    int selected = -1;
+    ASSERT_TRUE(gnss_sim::select_code_tracking_dll_root(roots, root_count,
+                                                       gnss_sim::CodeTrackingDllSelectionMode::ACQUISITION, 0.0,
+                                                       &selected, &error_message));
+    EXPECT_NEAR(roots[selected].code_phase_chips, 0.1, 1.0e-6);
+}
+
+TEST(CodeTrackingDll, CompositeCorrelationUsesNormalizedComplexVoltageWithoutReinterpretation) {
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    const gnss_sim::CodeTrackingDllPath paths[] = {
+        {0.0, {1.0, 0.0}},
+        {0.0, {0.0, 0.5}},
+    };
+    std::complex<double> correlation{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::compute_code_tracking_composite_correlation(gps_l1, paths, 2, 0.0, &correlation,
+                                                                      &error_message));
+    EXPECT_NEAR(correlation.real(), 1.0, 1.0e-15);
+    EXPECT_NEAR(correlation.imag(), 0.5, 1.0e-15);
+}
+
+TEST(CodeTrackingDll, InvalidInputsFailExplicitly) {
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    const gnss_sim::SignalDefinition& gps_l2c = signal(gnss_sim::SignalId::kGpsL2C);
+    gnss_sim::CodeTrackingDllConfig config = gnss_sim::default_code_tracking_dll_config();
+    std::string error_message;
+
+    config.early_late_total_spacing_chips = 0.0;
+    EXPECT_FALSE(gnss_sim::validate_code_tracking_dll_config(config, &error_message));
+
+    const gnss_sim::CodeTrackingDllPath zero_path[] = {{0.0, {0.0, 0.0}}};
+    gnss_sim::CodeTrackingDllRoot roots[gnss_sim::kMaxCodeTrackingDllRoots]{};
+    int root_count = 0;
+    EXPECT_FALSE(gnss_sim::find_code_tracking_dll_roots(gps_l1, zero_path, 1,
+                                                        gnss_sim::default_code_tracking_dll_config(), roots,
+                                                        gnss_sim::kMaxCodeTrackingDllRoots, &root_count,
+                                                        &error_message));
+
+    const gnss_sim::CodeTrackingDllPath path[] = {{0.0, {1.0, 0.0}}};
+    EXPECT_FALSE(gnss_sim::find_code_tracking_dll_roots(gps_l2c, path, 1,
+                                                        gnss_sim::default_code_tracking_dll_config(), roots,
+                                                        gnss_sim::kMaxCodeTrackingDllRoots, &root_count,
+                                                        &error_message));
+
+    int selected = -1;
+    gnss_sim::CodeTrackingDllRoot unstable{};
+    unstable.stable = false;
+    EXPECT_FALSE(gnss_sim::select_code_tracking_dll_root(&unstable, 1,
+                                                         gnss_sim::CodeTrackingDllSelectionMode::TRACKED,
+                                                         std::numeric_limits<double>::quiet_NaN(), &selected,
+                                                         &error_message));
+}
+
+TEST(CodeTrackingDll, RepeatedRootEnumerationIsNumericallyIdentical) {
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    const gnss_sim::CodeTrackingDllPath paths[] = {
+        {0.0, {1.0, 0.0}},
+        {chips_to_seconds(gps_l1, 0.3), {0.5, 0.0}},
+    };
+    const gnss_sim::CodeTrackingDllConfig config = gnss_sim::default_code_tracking_dll_config();
+    gnss_sim::CodeTrackingDllRoot first[gnss_sim::kMaxCodeTrackingDllRoots]{};
+    gnss_sim::CodeTrackingDllRoot second[gnss_sim::kMaxCodeTrackingDllRoots]{};
+    int first_count = 0;
+    int second_count = 0;
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::find_code_tracking_dll_roots(gps_l1, paths, 2, config, first,
+                                                       gnss_sim::kMaxCodeTrackingDllRoots, &first_count,
+                                                       &error_message));
+    ASSERT_TRUE(gnss_sim::find_code_tracking_dll_roots(gps_l1, paths, 2, config, second,
+                                                       gnss_sim::kMaxCodeTrackingDllRoots, &second_count,
+                                                       &error_message));
+    ASSERT_EQ(first_count, second_count);
+    for (int index = 0; index < first_count; ++index) {
+        EXPECT_DOUBLE_EQ(first[index].code_phase_sec, second[index].code_phase_sec);
+        EXPECT_DOUBLE_EQ(first[index].code_phase_chips, second[index].code_phase_chips);
+        EXPECT_DOUBLE_EQ(first[index].prompt_power, second[index].prompt_power);
+        EXPECT_EQ(first[index].stable, second[index].stable);
+    }
+}
+
+} // namespace

--- a/tests/unit/test_code_tracking_dll_boundaries.cpp
+++ b/tests/unit/test_code_tracking_dll_boundaries.cpp
@@ -1,0 +1,47 @@
+#include "model/code_tracking_dll.h"
+
+#include <complex>
+#include <gtest/gtest.h>
+#include <string>
+
+namespace {
+
+const gnss_sim::SignalDefinition& gps_l1_ca() {
+    const gnss_sim::SignalDefinition* definition =
+        gnss_sim::find_signal_definition(gnss_sim::SignalId::kGpsL1Ca);
+    EXPECT_NE(definition, nullptr);
+    return *definition;
+}
+
+TEST(CodeTrackingDllBoundaries, RejectsExcessiveDelaySpanBeforeIntegerConversion) {
+    const gnss_sim::SignalDefinition& signal = gps_l1_ca();
+    const gnss_sim::CodeTrackingDllPath paths[] = {
+        {0.0, {1.0, 0.0}},
+        {1.0e12, {0.5, 0.0}},
+    };
+    gnss_sim::CodeTrackingDllRoot roots[gnss_sim::kMaxCodeTrackingDllRoots]{};
+    int root_count = 0;
+    std::string error_message;
+
+    EXPECT_FALSE(gnss_sim::find_code_tracking_dll_roots(
+        signal, paths, 2, gnss_sim::default_code_tracking_dll_config(), roots,
+        gnss_sim::kMaxCodeTrackingDllRoots, &root_count, &error_message));
+    EXPECT_EQ(root_count, 0);
+    EXPECT_FALSE(error_message.empty());
+}
+
+TEST(CodeTrackingDllBoundaries, RejectsUnknownRootSelectionMode) {
+    gnss_sim::CodeTrackingDllRoot root{};
+    root.stable = true;
+    root.prompt_power = 1.0;
+    int selected_index = -1;
+    std::string error_message;
+
+    EXPECT_FALSE(gnss_sim::select_code_tracking_dll_root(
+        &root, 1, static_cast<gnss_sim::CodeTrackingDllSelectionMode>(99), 0.0, &selected_index,
+        &error_message));
+    EXPECT_EQ(selected_index, -1);
+    EXPECT_FALSE(error_message.empty());
+}
+
+} // namespace

--- a/tests/unit/test_code_tracking_dll_boundaries.cpp
+++ b/tests/unit/test_code_tracking_dll_boundaries.cpp
@@ -7,8 +7,7 @@
 namespace {
 
 const gnss_sim::SignalDefinition& gps_l1_ca() {
-    const gnss_sim::SignalDefinition* definition =
-        gnss_sim::find_signal_definition(gnss_sim::SignalId::kGpsL1Ca);
+    const gnss_sim::SignalDefinition* definition = gnss_sim::find_signal_definition(gnss_sim::SignalId::kGpsL1Ca);
     EXPECT_NE(definition, nullptr);
     return *definition;
 }
@@ -23,9 +22,9 @@ TEST(CodeTrackingDllBoundaries, RejectsExcessiveDelaySpanBeforeIntegerConversion
     int root_count = 0;
     std::string error_message;
 
-    EXPECT_FALSE(gnss_sim::find_code_tracking_dll_roots(
-        signal, paths, 2, gnss_sim::default_code_tracking_dll_config(), roots,
-        gnss_sim::kMaxCodeTrackingDllRoots, &root_count, &error_message));
+    EXPECT_FALSE(gnss_sim::find_code_tracking_dll_roots(signal, paths, 2, gnss_sim::default_code_tracking_dll_config(),
+                                                        roots, gnss_sim::kMaxCodeTrackingDllRoots, &root_count,
+                                                        &error_message));
     EXPECT_EQ(root_count, 0);
     EXPECT_FALSE(error_message.empty());
 }
@@ -38,8 +37,7 @@ TEST(CodeTrackingDllBoundaries, RejectsUnknownRootSelectionMode) {
     std::string error_message;
 
     EXPECT_FALSE(gnss_sim::select_code_tracking_dll_root(
-        &root, 1, static_cast<gnss_sim::CodeTrackingDllSelectionMode>(99), 0.0, &selected_index,
-        &error_message));
+        &root, 1, static_cast<gnss_sim::CodeTrackingDllSelectionMode>(99), 0.0, &selected_index, &error_message));
     EXPECT_EQ(selected_index, -1);
     EXPECT_FALSE(error_message.empty());
 }


### PR DESCRIPTION
Closes #119

## Summary

Implements the remaining receiver-layer work for the frozen V1 basic code DLL after prerequisite #133 (central correlation metadata) and #134 (pure signal-specific ideal correlation functions).

## Receiver-layer boundary

This PR deliberately consumes normalized path inputs `{code_delay_sec, complex_voltage}`. It does **not** define a second propagation/RF/power convention.

- #120 remains the owner of the production mapping from open-sky CN0 + #116/#117/#118 into one common complex-voltage convention.
- #118 rooftop diffraction remains a transfer factor on the direct component, never a second full-strength path.
- Independent #117 reflections can become additional normalized path inputs once #120 applies the common voltage convention.
- The DLL does not reinterpret TE/TM, polarization, antenna gain, path loss, Fresnel coefficients, or CN0.

## DLL model

- Frozen default **total** E/L spacing: `0.2 chip` (`-0.1/+0.1`).
- Composite correlator: `Z(epsilon) = sum_i V_i R(epsilon - tau_i)`, using #134 signal-specific correlation.
- Noncoherent power discriminator:
  `D(epsilon) = |Z(epsilon-s/2)|^2 - |Z(epsilon+s/2)|^2`.
- Stability convention is explicit: for conceptual correction `epsilon_next = epsilon - k D(epsilon)`, a stable root has positive local `dD/depsilon`.
- No dynamic DLL loop filter is introduced.

## Deterministic root solver

- Searches only the active correlation support around supplied path delays; it does not report the external all-zero discriminator plateau as roots.
- Fixed bounded scan step <= `1/512 chip`.
- Sign-change brackets refined by deterministic bisection.
- Roots are de-duplicated and returned with code phase, discriminator, local slope, prompt power, and stable/unstable classification.
- Excessive path-delay span fails before floating-to-integer interval conversion; the solver never silently coarsens the scan.

## Root selection

- `TRACKED`: stable candidate nearest previous code phase; ties prefer higher prompt power then lower phase.
- `ACQUISITION`: stable candidate with highest prompt power; ties prefer nearest zero relative delay then lower phase.
- Alternative stable/unstable roots remain visible to later #121 tracking logic.
- Unknown selection modes fail explicitly.

## Tests

Adds deterministic regressions for:
- one-path LOS zero-bias stable root and discriminator sign;
- delayed in-phase two-path positive/later bias;
- delayed opposite-phase path with negative near-direct bias and multiple stable roots;
- GPS L1C TMBOC side-peak roots and deterministic root policies;
- configurable E/L spacing changing the equilibrium;
- complex voltages summed exactly as supplied;
- unsupported signal profiles/zero voltage/invalid config fail-fast;
- excessive delay span and invalid selection mode fail-fast;
- bitwise-identical repeated root enumeration.

## Permanent documentation

`docs/BASIC_CODE_TRACKING_DLL.md` records the amplitude ownership boundary, equations, sign/stability convention, bounded search, root policies, and exclusions.

## Explicit exclusions

No open/effective CN0, #116/#117/#118-to-voltage production adapter, tracking thresholds/hysteresis/reacquisition, pseudorange/Doppler/carrier/ADR synthesis, carrier smoothing, proprietary multipath mitigation, navigation-layer rejection, IF/baseband samples, or NAV/EPH/ION changes.

## Data provenance / safety

No NAV/EPH/ION is generated, modified, interpolated, retargeted, or fabricated. No DLL parameter is tuned to force a target PVT error.

## Next

After this PR is validated and merged, continue #120 to establish the single physical propagation/power convention and map open-sky CN0 plus #116/#117/#118 into the normalized complex-voltage inputs consumed here.