### PR TITLE
Integrate coherent urban received power and effective C/N0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ add_library(gnss_sim_core STATIC
     src/model/measurement_model.cpp
     src/model/receiver_truth.cpp
     src/model/signal_tracking.cpp
+    src/model/urban_received_power.cpp
     src/model/urban_reflection_paths.cpp
     src/model/urban_rooftop_diffraction.cpp
     src/model/urban_rf_model.cpp
@@ -201,7 +202,7 @@ add_executable(validate-rangea-roundtrip
     tools/rangea_roundtrip/main.cpp
 )
 target_link_libraries(validate-rangea-roundtrip PRIVATE rangea_roundtrip_core)
-gnss_sim_set_project_warnings(validate-rangea-roundtrip)
+gnss_sim_set_project_warnings(validate-rangea_roundtrip)
 
 add_library(transient_validator_core STATIC
     tools/transient_validator/transient_validator.cpp
@@ -218,7 +219,7 @@ add_executable(validate-transient-observations
     tools/transient_validator/main.cpp
 )
 target_link_libraries(validate-transient-observations PRIVATE transient_validator_core)
-gnss_sim_set_project_warnings(validate-transient-observations)
+gnss_sim_set_project_warnings(validate-transient_observations)
 
 if(BUILD_TESTING)
     include(FetchContent)
@@ -264,6 +265,7 @@ if(BUILD_TESTING)
         tests/unit/test_sim_time.cpp
         tests/unit/test_solution_engine.cpp
         tests/unit/test_solution_signal_policy.cpp
+        tests/unit/test_urban_received_power.cpp
         tests/unit/test_urban_reflection_paths.cpp
         tests/unit/test_urban_rooftop_diffraction.cpp
         tests/unit/test_urban_rf_model.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,7 +202,7 @@ add_executable(validate-rangea-roundtrip
     tools/rangea_roundtrip/main.cpp
 )
 target_link_libraries(validate-rangea-roundtrip PRIVATE rangea_roundtrip_core)
-gnss_sim_set_project_warnings(validate-rangea_roundtrip)
+gnss_sim_set_project_warnings(validate-rangea-roundtrip)
 
 add_library(transient_validator_core STATIC
     tools/transient_validator/transient_validator.cpp
@@ -219,7 +219,7 @@ add_executable(validate-transient-observations
     tools/transient_validator/main.cpp
 )
 target_link_libraries(validate-transient-observations PRIVATE transient_validator_core)
-gnss_sim_set_project_warnings(transient_validator_core)
+gnss_sim_set_project_warnings(validate-transient-observations)
 
 if(BUILD_TESTING)
     include(FetchContent)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,7 +219,7 @@ add_executable(validate-transient-observations
     tools/transient_validator/main.cpp
 )
 target_link_libraries(validate-transient-observations PRIVATE transient_validator_core)
-gnss_sim_set_project_warnings(validate-transient_observations)
+gnss_sim_set_project_warnings(transient_validator_core)
 
 if(BUILD_TESTING)
     include(FetchContent)

--- a/docs/URBAN_RECEIVED_POWER.md
+++ b/docs/URBAN_RECEIVED_POWER.md
@@ -1,0 +1,151 @@
+# Urban Received Power and Effective C/N0
+
+Issue #120 defines the V1 receiver-domain amplitude/power convention that connects the completed open-sky C/N0 model (#104/#105-#108), Low-E/polarization/antenna model (#116), first-order reflections (#117), rooftop diffraction (#118), and the signal-specific correlator/DLL layer (#119).
+
+## Ownership boundary
+
+This layer produces and consumes the same narrow path representation introduced by #119:
+
+`{ code_delay_sec, normalized complex voltage }`.
+
+The voltage is dimensionless and referenced to the unobstructed open-sky direct receiver-domain field for the same satellite/signal. #121 may use the resulting effective C/N0 for tracking decisions, and #122 may use the same physical path set for observable synthesis.
+
+No second signal table, propagation table, or independent urban attenuation random process is introduced.
+
+## Open-sky reference
+
+The open-sky input is obtained through the existing `cn0_model_estimate_dbhz()` path. For the normalized external model its nominal semantics remain
+
+`CN0_open(signal,elevation) = CN0_high_dbhz(receiver,signal) + Delta_CN0_elevation(signal,elevation)`,
+
+followed by the already-existing deterministic time-correlated open-sky variation and compatibility behavior of the C/N0 model.
+
+`CN0_high_dbhz` is receiver/signal specific, and `Delta_CN0_elevation` is the validated normalized real-IGS elevation shape. Issue #120 does not replace either term with a handwritten urban curve.
+
+The corresponding unobstructed direct normalized complex voltage is defined as
+
+`V_direct,open = 1 + j0`.
+
+This is a receiver-domain reference, not a claim that the physical antenna has unit absolute gain. The empirical/configured open-sky C/N0 already establishes the receiver/antenna signal level and elevation behavior. The #116 receive-antenna complex response is therefore used as a **relative multipath polarization/arrival-direction response** when a reflected field is mapped back to this direct reference. This avoids silently applying the receiver/antenna calibration twice.
+
+A future separately calibrated absolute antenna-pattern layer would require an explicit model/schema convention; it must not be added by multiplying the current open-sky baseline again without such a definition.
+
+## Rooftop-affected direct field
+
+The #118 Fresnel coefficient is already referenced to the unobstructed direct field:
+
+`V_direct,roof = F(v)`.
+
+It is the complete roof-transition transfer factor. The V1 receiver path set therefore contains exactly one roof-affected direct component. It never constructs
+
+`full direct + full diffraction`.
+
+The exposed #118 geometric phase is not multiplied into `F(v)` again. #118 already defines the phase-reference identity that prevents this double counting.
+
+### Code-delay convention
+
+The direct-referenced Fresnel field must also recover ordinary LOS code timing on the clear side. Therefore:
+
+- clear/LOS side: roof-affected direct `code_delay_sec = 0`;
+- blocked/shadow side: use #118 `excess_delay_sec` as the deterministic equivalent-edge code delay;
+- exact grazing: #118 excess path tends to zero, so the two rules meet continuously.
+
+This avoids the nonphysical result in which `F(v) -> 1` far into clear LOS while the entire direct code remains shifted by an edge-path delay.
+
+## First-order reflection voltage
+
+For each retained #117 reflection, let
+
+- `D0` be the direct Euclidean source-receiver distance;
+- `Dr` be the reflected Euclidean path length;
+- `G` be #117 `geometric_phase_factor = exp(-j 2*pi*DeltaL/lambda)`;
+- `Gamma_R` and `Gamma_L` be the #116 reflected RHCP/LHCP field coefficients from incident GNSS RHCP;
+- `A_R(arrival)` and `A_L(arrival)` be the #116 receive-antenna complex voltage responses at the reflected arrival elevation;
+- `A_D(elevation)` be the #116 RHCP receive-antenna response in the direct satellite direction.
+
+The polarization-weighted reflected receiver voltage is
+
+`V_pol = Gamma_R * A_R(arrival) + Gamma_L * A_L(arrival)`.
+
+The V1 spherical-spreading field ratio is
+
+`S = D0 / Dr`.
+
+The normalized reflected voltage consumed by #119 is
+
+`V_reflection = S * V_pol / A_D(elevation) * G`.
+
+Thus material response, polarization, receive-antenna relative response, geometric spreading, and excess carrier phase are each applied exactly once.
+
+The reflection code delay is the #117 `excess_delay_sec`. No arbitrary NLOS pseudorange offset is added.
+
+## Composite correlator power
+
+For the signal-specific ideal correlation `R` from #134 and normalized paths `i`, #119 defines
+
+`Z(epsilon) = sum_i V_i * R(epsilon - tau_i)`.
+
+Issue #120 converts this same composite field into effective correlator C/N0 at a supplied local code phase:
+
+`P_ratio(epsilon) = |Z(epsilon)|^2`
+
+`(C/N0)_effective_linear = 10^(CN0_open/10) * P_ratio`
+
+and, for nonzero power,
+
+`CN0_effective = CN0_open + 10*log10(P_ratio)`.
+
+Constructive and destructive interference therefore emerge from the same complex path phases used by the DLL. A delayed path is naturally reduced at a prompt through the signal-specific code correlation rather than through an unrelated attenuation rule.
+
+## Exact cancellation
+
+If the composite correlator field cancels exactly,
+
+`P_ratio = 0`.
+
+The physical linear carrier-to-noise-density ratio is zero. The API records no finite dB-Hz value (`-infinity` plus an explicit `finite_effective_cn0=false`) rather than inventing an arbitrary C/N0 floor. #121 owns tracking thresholds, persistence, and BLOCKED transitions.
+
+## Continuity
+
+For continuous geometry:
+
+- #117 path delay/phase evolves from geometry;
+- #118 Fresnel amplitude/phase evolves continuously across clear/grazing/shadow;
+- the clear/shadow direct code-delay convention joins at zero excess delay at grazing;
+- #119 signal-specific correlation maps continuous path evolution into continuous composite correlator power except at genuine path appearance/disappearance or later tracking-root/state discontinuities.
+
+No independent per-epoch urban white-noise attenuation is introduced.
+
+## Runtime integration boundary
+
+Issue #120 provides the physical normalized path set and effective-C/N0 evaluation. The existing open-sky C/N0 runtime remains unchanged when urban propagation is not consumed.
+
+Issue #121 is the first tracking-state consumer of this result. It owns the 10 dB-Hz tracking threshold, the higher acquisition/reacquisition threshold, hysteresis/persistence, root continuity, and LOS/LOS_MULTIPATH/NLOS_TRACKED/BLOCKED state transitions. Issue #120 does not pre-empt those decisions.
+
+Issue #122 subsequently maps the tracked physical path/DLL result to pseudorange, Doppler, carrier/ADR, lock, and final receiver observations.
+
+## Regression anchors
+
+Permanent #120 tests cover:
+
+- constructive and destructive same-delay field addition in the power domain;
+- signal-code decorrelation of a one-chip-separated path at the direct prompt;
+- exact cancellation without an arbitrary C/N0 floor;
+- rooftop grazing with `F(0)=0.5`, giving approximately 6.0206 dB C/N0 loss with no second direct field;
+- shadow-side direct use of #118 edge excess delay and clear-side direct delay fixed at zero;
+- retained reflection coexistence with the single roof-affected direct component in frozen blocked geometry;
+- high-baseline translation changing open/effective C/N0 without changing normalized propagation paths;
+- continuous clear/grazing/shadow roof response.
+
+## Explicit exclusions
+
+Issue #120 does not implement:
+
+- acquisition/tracking thresholds, hysteresis, persistence, or reacquisition (#121);
+- DLL root policy beyond consuming #119's existing correlator interface;
+- pseudorange/Doppler/carrier/ADR synthesis (#122);
+- truth-output expansion (#123);
+- a dynamic IF/baseband simulation;
+- independent random urban attenuation;
+- NAV/EPH/ION generation, modification, interpolation, retargeting, or fabrication;
+- parameter tuning to force a desired final PVT error.

--- a/src/model/urban_received_power.cpp
+++ b/src/model/urban_received_power.cpp
@@ -63,7 +63,8 @@ bool compute_urban_received_path_set(const Cn0Model& cn0_model, const UrbanScene
                                      const SimTime& time, const ReceiverTruth& receiver,
                                      const SatelliteGeometry& satellite_geometry, UrbanReceivedPathSet* result,
                                      std::string* error_message) {
-    if (result == nullptr || !std::isfinite(satellite_geometry.elevation_rad)) {
+    if (result == nullptr || !std::isfinite(satellite_geometry.azimuth_rad) ||
+        !std::isfinite(satellite_geometry.elevation_rad)) {
         set_error(error_message, "urban received-power request is invalid");
         return false;
     }
@@ -76,7 +77,10 @@ bool compute_urban_received_path_set(const Cn0Model& cn0_model, const UrbanScene
         return false;
     }
 
-    if (!compute_urban_rooftop_diffraction(scene_config, signal, glonass_fcn, receiver, satellite_geometry,
+    if (!compute_urban_direct_path_geometry(scene_config, satellite_geometry.azimuth_rad,
+                                            satellite_geometry.elevation_rad, &output.direct_geometry,
+                                            error_message) ||
+        !compute_urban_rooftop_diffraction(scene_config, signal, glonass_fcn, receiver, satellite_geometry,
                                            &output.diffraction, &output.diffraction_status, error_message) ||
         !compute_urban_first_order_reflections(scene_config, rf_config, signal, glonass_fcn, receiver,
                                                satellite_geometry, &output.reflections, error_message)) {
@@ -91,7 +95,9 @@ bool compute_urban_received_path_set(const Cn0Model& cn0_model, const UrbanScene
             set_error(error_message, "urban rooftop direct transfer voltage is non-finite");
             return false;
         }
-        output.paths[output.path_count++] = {output.diffraction.excess_delay_sec, output.direct_voltage};
+        const double direct_code_delay_sec =
+            output.direct_geometry.line_of_sight ? 0.0 : output.diffraction.excess_delay_sec;
+        output.paths[output.path_count++] = {direct_code_delay_sec, output.direct_voltage};
     } else {
         output.direct_voltage = {1.0, 0.0};
         output.paths[output.path_count++] = {0.0, output.direct_voltage};

--- a/src/model/urban_received_power.cpp
+++ b/src/model/urban_received_power.cpp
@@ -32,8 +32,8 @@ bool reflection_normalized_voltage(const UrbanRfResolvedConfig& rf_config, const
     }
 
     std::complex<double> direct_reference_antenna{};
-    if (!evaluate_urban_antenna_response(rf_config.antenna, UrbanCircularPolarization::kRhcp,
-                                         geometry.elevation_rad, &direct_reference_antenna, error_message)) {
+    if (!evaluate_urban_antenna_response(rf_config.antenna, UrbanCircularPolarization::kRhcp, geometry.elevation_rad,
+                                         &direct_reference_antenna, error_message)) {
         return false;
     }
     const double direct_reference_magnitude = std::abs(direct_reference_antenna);
@@ -46,8 +46,8 @@ bool reflection_normalized_voltage(const UrbanRfResolvedConfig& rf_config, const
         reflection.rf_response.gamma_rhcp_from_rhcp * reflection.antenna_rhcp_voltage +
         reflection.rf_response.gamma_lhcp_from_rhcp * reflection.antenna_lhcp_voltage;
     const double spreading_ratio = reflection.direct_euclidean_range_m / reflection.reflected_euclidean_range_m;
-    const std::complex<double> result = spreading_ratio * reflected_receiver_voltage /
-                                        direct_reference_antenna * reflection.geometric_phase_factor;
+    const std::complex<double> result =
+        spreading_ratio * reflected_receiver_voltage / direct_reference_antenna * reflection.geometric_phase_factor;
     if (!std::isfinite(spreading_ratio) || !(spreading_ratio > 0.0) || !finite_complex(result)) {
         set_error(error_message, "urban normalized reflection voltage is non-finite");
         return false;
@@ -78,8 +78,7 @@ bool compute_urban_received_path_set(const Cn0Model& cn0_model, const UrbanScene
     }
 
     if (!compute_urban_direct_path_geometry(scene_config, satellite_geometry.azimuth_rad,
-                                            satellite_geometry.elevation_rad, &output.direct_geometry,
-                                            error_message) ||
+                                            satellite_geometry.elevation_rad, &output.direct_geometry, error_message) ||
         !compute_urban_rooftop_diffraction(scene_config, signal, glonass_fcn, receiver, satellite_geometry,
                                            &output.diffraction, &output.diffraction_status, error_message) ||
         !compute_urban_first_order_reflections(scene_config, rf_config, signal, glonass_fcn, receiver,
@@ -160,8 +159,7 @@ bool compute_effective_cn0_from_paths(double open_cn0_dbhz, const SignalDefiniti
     output.carrier_to_noise_density_hz = open_linear * output.composite_power_ratio;
     output.effective_cn0_dbhz = open_cn0_dbhz + 10.0 * std::log10(output.composite_power_ratio);
     output.finite_effective_cn0 = std::isfinite(output.carrier_to_noise_density_hz) &&
-                                  output.carrier_to_noise_density_hz > 0.0 &&
-                                  std::isfinite(output.effective_cn0_dbhz);
+                                  output.carrier_to_noise_density_hz > 0.0 && std::isfinite(output.effective_cn0_dbhz);
     if (!output.finite_effective_cn0) {
         set_error(error_message, "effective CN0 conversion is outside the supported numeric range");
         return false;
@@ -171,8 +169,7 @@ bool compute_effective_cn0_from_paths(double open_cn0_dbhz, const SignalDefiniti
 }
 
 bool compute_urban_effective_cn0(const SignalDefinition& signal, const UrbanReceivedPathSet& paths,
-                                 double local_code_phase_sec, UrbanEffectiveCn0* result,
-                                 std::string* error_message) {
+                                 double local_code_phase_sec, UrbanEffectiveCn0* result, std::string* error_message) {
     if (paths.path_count <= 0 || paths.path_count > kMaxUrbanReceivedPaths) {
         set_error(error_message, "urban effective CN0 path set is invalid");
         return false;

--- a/src/model/urban_received_power.cpp
+++ b/src/model/urban_received_power.cpp
@@ -1,0 +1,178 @@
+#include "model/urban_received_power.h"
+
+#include "model/urban_rf_model.h"
+
+#include <cmath>
+#include <limits>
+
+namespace gnss_sim {
+namespace {
+
+void set_error(std::string* error_message, const char* message) {
+    if (error_message != nullptr) {
+        *error_message = message;
+    }
+}
+
+bool finite_complex(const std::complex<double>& value) {
+    return std::isfinite(value.real()) && std::isfinite(value.imag());
+}
+
+bool reflection_normalized_voltage(const UrbanRfResolvedConfig& rf_config, const SatelliteGeometry& geometry,
+                                   const UrbanFirstOrderReflectionPath& reflection,
+                                   std::complex<double>* normalized_voltage, std::string* error_message) {
+    if (normalized_voltage == nullptr || !std::isfinite(geometry.elevation_rad) ||
+        !(reflection.direct_euclidean_range_m > 0.0) || !(reflection.reflected_euclidean_range_m > 0.0) ||
+        !finite_complex(reflection.geometric_phase_factor) ||
+        !finite_complex(reflection.rf_response.gamma_rhcp_from_rhcp) ||
+        !finite_complex(reflection.rf_response.gamma_lhcp_from_rhcp) ||
+        !finite_complex(reflection.antenna_rhcp_voltage) || !finite_complex(reflection.antenna_lhcp_voltage)) {
+        set_error(error_message, "urban reflection received-voltage request is invalid");
+        return false;
+    }
+
+    std::complex<double> direct_reference_antenna{};
+    if (!evaluate_urban_antenna_response(rf_config.antenna, UrbanCircularPolarization::kRhcp,
+                                         geometry.elevation_rad, &direct_reference_antenna, error_message)) {
+        return false;
+    }
+    const double direct_reference_magnitude = std::abs(direct_reference_antenna);
+    if (!(direct_reference_magnitude > 0.0) || !std::isfinite(direct_reference_magnitude)) {
+        set_error(error_message, "urban direct RHCP antenna reference voltage is zero or non-finite");
+        return false;
+    }
+
+    const std::complex<double> reflected_receiver_voltage =
+        reflection.rf_response.gamma_rhcp_from_rhcp * reflection.antenna_rhcp_voltage +
+        reflection.rf_response.gamma_lhcp_from_rhcp * reflection.antenna_lhcp_voltage;
+    const double spreading_ratio = reflection.direct_euclidean_range_m / reflection.reflected_euclidean_range_m;
+    const std::complex<double> result = spreading_ratio * reflected_receiver_voltage /
+                                        direct_reference_antenna * reflection.geometric_phase_factor;
+    if (!std::isfinite(spreading_ratio) || !(spreading_ratio > 0.0) || !finite_complex(result)) {
+        set_error(error_message, "urban normalized reflection voltage is non-finite");
+        return false;
+    }
+    *normalized_voltage = result;
+    return true;
+}
+
+} // namespace
+
+bool compute_urban_received_path_set(const Cn0Model& cn0_model, const UrbanSceneGeometryConfig& scene_config,
+                                     const UrbanRfConfig& rf_config, const SignalDefinition& signal, int glonass_fcn,
+                                     const SimTime& time, const ReceiverTruth& receiver,
+                                     const SatelliteGeometry& satellite_geometry, UrbanReceivedPathSet* result,
+                                     std::string* error_message) {
+    if (result == nullptr || !std::isfinite(satellite_geometry.elevation_rad)) {
+        set_error(error_message, "urban received-power request is invalid");
+        return false;
+    }
+
+    UrbanReceivedPathSet output{};
+    const double elevation_deg = satellite_geometry.elevation_rad * 180.0 / 3.141592653589793238462643383279502884;
+    if (!cn0_model_estimate_dbhz(cn0_model, signal.signal_id, elevation_deg, time, &output.open_cn0_dbhz) ||
+        !std::isfinite(output.open_cn0_dbhz)) {
+        set_error(error_message, "cannot evaluate open-sky CN0 for urban received-power model");
+        return false;
+    }
+
+    if (!compute_urban_rooftop_diffraction(scene_config, signal, glonass_fcn, receiver, satellite_geometry,
+                                           &output.diffraction, &output.diffraction_status, error_message) ||
+        !compute_urban_first_order_reflections(scene_config, rf_config, signal, glonass_fcn, receiver,
+                                               satellite_geometry, &output.reflections, error_message)) {
+        return false;
+    }
+
+    if (output.diffraction_status == UrbanRooftopDiffractionStatus::BELOW_LOCAL_HORIZON) {
+        output.direct_voltage = {0.0, 0.0};
+    } else if (output.diffraction_status == UrbanRooftopDiffractionStatus::VALID) {
+        output.direct_voltage = output.diffraction.fresnel_coefficient;
+        if (!finite_complex(output.direct_voltage)) {
+            set_error(error_message, "urban rooftop direct transfer voltage is non-finite");
+            return false;
+        }
+        output.paths[output.path_count++] = {output.diffraction.excess_delay_sec, output.direct_voltage};
+    } else {
+        output.direct_voltage = {1.0, 0.0};
+        output.paths[output.path_count++] = {0.0, output.direct_voltage};
+    }
+
+    UrbanRfResolvedConfig resolved_rf{};
+    if (!resolve_urban_rf_signal_config(rf_config, signal, &resolved_rf, error_message)) {
+        return false;
+    }
+    for (int index = 0; index < output.reflections.path_count; ++index) {
+        if (output.path_count >= kMaxUrbanReceivedPaths) {
+            set_error(error_message, "urban received path capacity exceeded");
+            return false;
+        }
+        std::complex<double> reflection_voltage{};
+        if (!reflection_normalized_voltage(resolved_rf, satellite_geometry, output.reflections.paths[index],
+                                           &reflection_voltage, error_message)) {
+            return false;
+        }
+        output.paths[output.path_count++] = {output.reflections.paths[index].excess_delay_sec, reflection_voltage};
+    }
+
+    if (output.path_count == 0) {
+        set_error(error_message, "urban received-power model has no above-horizon propagation component");
+        return false;
+    }
+    *result = output;
+    return true;
+}
+
+bool compute_effective_cn0_from_paths(double open_cn0_dbhz, const SignalDefinition& signal,
+                                      const CodeTrackingDllPath* paths, int path_count, double local_code_phase_sec,
+                                      UrbanEffectiveCn0* result, std::string* error_message) {
+    if (result == nullptr || !std::isfinite(open_cn0_dbhz) || !std::isfinite(local_code_phase_sec)) {
+        set_error(error_message, "effective CN0 request is invalid");
+        return false;
+    }
+
+    UrbanEffectiveCn0 output{};
+    output.open_cn0_dbhz = open_cn0_dbhz;
+    if (!compute_code_tracking_composite_correlation(signal, paths, path_count, local_code_phase_sec,
+                                                     &output.composite_correlation, error_message)) {
+        return false;
+    }
+    output.composite_power_ratio = std::norm(output.composite_correlation);
+    if (!std::isfinite(output.composite_power_ratio) || output.composite_power_ratio < 0.0) {
+        set_error(error_message, "effective CN0 composite power ratio is invalid");
+        return false;
+    }
+
+    if (output.composite_power_ratio == 0.0) {
+        output.carrier_to_noise_density_hz = 0.0;
+        output.effective_cn0_dbhz = -std::numeric_limits<double>::infinity();
+        output.finite_effective_cn0 = false;
+        *result = output;
+        return true;
+    }
+
+    const double open_linear = std::pow(10.0, 0.1 * open_cn0_dbhz);
+    output.carrier_to_noise_density_hz = open_linear * output.composite_power_ratio;
+    output.effective_cn0_dbhz = open_cn0_dbhz + 10.0 * std::log10(output.composite_power_ratio);
+    output.finite_effective_cn0 = std::isfinite(output.carrier_to_noise_density_hz) &&
+                                  output.carrier_to_noise_density_hz > 0.0 &&
+                                  std::isfinite(output.effective_cn0_dbhz);
+    if (!output.finite_effective_cn0) {
+        set_error(error_message, "effective CN0 conversion is outside the supported numeric range");
+        return false;
+    }
+    *result = output;
+    return true;
+}
+
+bool compute_urban_effective_cn0(const SignalDefinition& signal, const UrbanReceivedPathSet& paths,
+                                 double local_code_phase_sec, UrbanEffectiveCn0* result,
+                                 std::string* error_message) {
+    if (paths.path_count <= 0 || paths.path_count > kMaxUrbanReceivedPaths) {
+        set_error(error_message, "urban effective CN0 path set is invalid");
+        return false;
+    }
+    return compute_effective_cn0_from_paths(paths.open_cn0_dbhz, signal, paths.paths, paths.path_count,
+                                            local_code_phase_sec, result, error_message);
+}
+
+} // namespace gnss_sim

--- a/src/model/urban_received_power.h
+++ b/src/model/urban_received_power.h
@@ -51,8 +51,7 @@ bool compute_effective_cn0_from_paths(double open_cn0_dbhz, const SignalDefiniti
                                       UrbanEffectiveCn0* result, std::string* error_message);
 
 bool compute_urban_effective_cn0(const SignalDefinition& signal, const UrbanReceivedPathSet& paths,
-                                 double local_code_phase_sec, UrbanEffectiveCn0* result,
-                                 std::string* error_message);
+                                 double local_code_phase_sec, UrbanEffectiveCn0* result, std::string* error_message);
 
 } // namespace gnss_sim
 

--- a/src/model/urban_received_power.h
+++ b/src/model/urban_received_power.h
@@ -1,0 +1,58 @@
+#ifndef GNSS_SIM_SRC_MODEL_URBAN_RECEIVED_POWER_H_
+#define GNSS_SIM_SRC_MODEL_URBAN_RECEIVED_POWER_H_
+
+#include "model/cn0_model.h"
+#include "model/code_tracking_dll.h"
+#include "model/receiver_truth.h"
+#include "model/urban_reflection_paths.h"
+#include "model/urban_rooftop_diffraction.h"
+
+#include <complex>
+#include <string>
+
+namespace gnss_sim {
+
+constexpr int kMaxUrbanReceivedPaths = 1 + kUrbanFirstOrderWallCount;
+
+struct UrbanReceivedPathSet {
+    double open_cn0_dbhz;
+    std::complex<double> direct_voltage;
+    UrbanRooftopDiffractionStatus diffraction_status;
+    UrbanRooftopDiffractionPath diffraction;
+    UrbanFirstOrderReflectionSet reflections;
+    CodeTrackingDllPath paths[kMaxUrbanReceivedPaths];
+    int path_count;
+};
+
+struct UrbanEffectiveCn0 {
+    double open_cn0_dbhz;
+    std::complex<double> composite_correlation;
+    double composite_power_ratio;
+    double carrier_to_noise_density_hz;
+    double effective_cn0_dbhz;
+    bool finite_effective_cn0;
+};
+
+// Build one common receiver-domain normalized path set. CN0_open already owns
+// the nominal direct receiver/antenna response. Urban path voltages are
+// dimensionless relative to that unobstructed direct reference voltage.
+bool compute_urban_received_path_set(const Cn0Model& cn0_model, const UrbanSceneGeometryConfig& scene_config,
+                                     const UrbanRfConfig& rf_config, const SignalDefinition& signal, int glonass_fcn,
+                                     const SimTime& time, const ReceiverTruth& receiver,
+                                     const SatelliteGeometry& satellite_geometry, UrbanReceivedPathSet* result,
+                                     std::string* error_message);
+
+// Convert an arbitrary normalized #119 path set into effective correlator C/N0
+// at the supplied local code phase. Zero composite power is represented by
+// finite_effective_cn0=false and effective_cn0_dbhz=-infinity.
+bool compute_effective_cn0_from_paths(double open_cn0_dbhz, const SignalDefinition& signal,
+                                      const CodeTrackingDllPath* paths, int path_count, double local_code_phase_sec,
+                                      UrbanEffectiveCn0* result, std::string* error_message);
+
+bool compute_urban_effective_cn0(const SignalDefinition& signal, const UrbanReceivedPathSet& paths,
+                                 double local_code_phase_sec, UrbanEffectiveCn0* result,
+                                 std::string* error_message);
+
+} // namespace gnss_sim
+
+#endif // GNSS_SIM_SRC_MODEL_URBAN_RECEIVED_POWER_H_

--- a/src/model/urban_received_power.h
+++ b/src/model/urban_received_power.h
@@ -16,6 +16,7 @@ constexpr int kMaxUrbanReceivedPaths = 1 + kUrbanFirstOrderWallCount;
 
 struct UrbanReceivedPathSet {
     double open_cn0_dbhz;
+    UrbanDirectPathGeometry direct_geometry;
     std::complex<double> direct_voltage;
     UrbanRooftopDiffractionStatus diffraction_status;
     UrbanRooftopDiffractionPath diffraction;

--- a/tests/unit/test_urban_received_power.cpp
+++ b/tests/unit/test_urban_received_power.cpp
@@ -144,17 +144,21 @@ TEST(UrbanReceivedPower, RooftopGrazingAppliesDiffractionTransferExactlyOnce) {
                                                          &paths, &error_message))
         << error_message;
     ASSERT_EQ(paths.diffraction_status, gnss_sim::UrbanRooftopDiffractionStatus::VALID);
-    ASSERT_EQ(paths.reflections.path_count, 0);
-    ASSERT_EQ(paths.path_count, 1);
+    ASSERT_EQ(paths.reflections.path_count, 1);
+    ASSERT_EQ(paths.path_count, 2);
+    EXPECT_FALSE(paths.direct_geometry.line_of_sight);
     EXPECT_NEAR(paths.diffraction.fresnel_v, 0.0, 1.0e-8);
     EXPECT_NEAR(paths.direct_voltage.real(), 0.5, 1.0e-10);
     EXPECT_NEAR(paths.direct_voltage.imag(), 0.0, 1.0e-10);
-    EXPECT_NEAR(paths.paths[0].code_delay_sec, 0.0, 1.0e-18);
+    EXPECT_NEAR(paths.paths[0].code_delay_sec, paths.diffraction.excess_delay_sec, 1.0e-18);
 
-    gnss_sim::UrbanEffectiveCn0 effective{};
-    ASSERT_TRUE(gnss_sim::compute_urban_effective_cn0(gps_l1, paths, 0.0, &effective, &error_message))
+    const gnss_sim::CodeTrackingDllPath direct_only[] = {{paths.paths[0].code_delay_sec, paths.direct_voltage}};
+    gnss_sim::UrbanEffectiveCn0 direct_effective{};
+    ASSERT_TRUE(gnss_sim::compute_effective_cn0_from_paths(paths.open_cn0_dbhz, gps_l1, direct_only, 1,
+                                                           paths.paths[0].code_delay_sec, &direct_effective,
+                                                           &error_message))
         << error_message;
-    EXPECT_NEAR(effective.effective_cn0_dbhz, paths.open_cn0_dbhz - 6.020599913279624, 1.0e-9);
+    EXPECT_NEAR(direct_effective.effective_cn0_dbhz, paths.open_cn0_dbhz - 6.020599913279624, 1.0e-9);
 }
 
 TEST(UrbanReceivedPower, FrozenBlockedGeometryRetainsIndependentReflectionAsSecondPath) {

--- a/tests/unit/test_urban_received_power.cpp
+++ b/tests/unit/test_urban_received_power.cpp
@@ -79,11 +79,9 @@ TEST(UrbanReceivedPower, ConstructiveAndDestructiveFieldsMapToPowerDomainCn0) {
     gnss_sim::UrbanEffectiveCn0 high{};
     gnss_sim::UrbanEffectiveCn0 low{};
     std::string error_message;
-    ASSERT_TRUE(gnss_sim::compute_effective_cn0_from_paths(45.0, gps_l1, constructive, 2, 0.0, &high,
-                                                           &error_message))
+    ASSERT_TRUE(gnss_sim::compute_effective_cn0_from_paths(45.0, gps_l1, constructive, 2, 0.0, &high, &error_message))
         << error_message;
-    ASSERT_TRUE(gnss_sim::compute_effective_cn0_from_paths(45.0, gps_l1, destructive, 2, 0.0, &low,
-                                                           &error_message))
+    ASSERT_TRUE(gnss_sim::compute_effective_cn0_from_paths(45.0, gps_l1, destructive, 2, 0.0, &low, &error_message))
         << error_message;
     EXPECT_NEAR(high.composite_power_ratio, 2.25, 1.0e-14);
     EXPECT_NEAR(high.effective_cn0_dbhz, 45.0 + 10.0 * std::log10(2.25), 1.0e-12);
@@ -100,8 +98,7 @@ TEST(UrbanReceivedPower, CodeDelayDecorrelatesASeparatedPathAtDirectPrompt) {
     };
     gnss_sim::UrbanEffectiveCn0 effective{};
     std::string error_message;
-    ASSERT_TRUE(gnss_sim::compute_effective_cn0_from_paths(43.0, gps_l1, paths, 2, 0.0, &effective,
-                                                           &error_message))
+    ASSERT_TRUE(gnss_sim::compute_effective_cn0_from_paths(43.0, gps_l1, paths, 2, 0.0, &effective, &error_message))
         << error_message;
     EXPECT_NEAR(effective.composite_correlation.real(), 1.0, 1.0e-14);
     EXPECT_NEAR(effective.composite_correlation.imag(), 0.0, 1.0e-14);
@@ -116,8 +113,7 @@ TEST(UrbanReceivedPower, ExactCancellationHasNoArbitraryCn0Floor) {
     };
     gnss_sim::UrbanEffectiveCn0 effective{};
     std::string error_message;
-    ASSERT_TRUE(gnss_sim::compute_effective_cn0_from_paths(45.0, gps_l1, paths, 2, 0.0, &effective,
-                                                           &error_message))
+    ASSERT_TRUE(gnss_sim::compute_effective_cn0_from_paths(45.0, gps_l1, paths, 2, 0.0, &effective, &error_message))
         << error_message;
     EXPECT_DOUBLE_EQ(effective.composite_power_ratio, 0.0);
     EXPECT_DOUBLE_EQ(effective.carrier_to_noise_density_hz, 0.0);
@@ -140,8 +136,8 @@ TEST(UrbanReceivedPower, RooftopGrazingAppliesDiffractionTransferExactlyOnce) {
     make_synthetic_geometry(0.0, skyline_rad / kDegreesToRadians, &receiver, &geometry);
     gnss_sim::UrbanReceivedPathSet paths{};
     ASSERT_TRUE(gnss_sim::compute_urban_received_path_set(normalized_model(gps_l1.signal_id, 47.0), scene,
-                                                         config.urban_rf, gps_l1, 0, test_time(), receiver, geometry,
-                                                         &paths, &error_message))
+                                                          config.urban_rf, gps_l1, 0, test_time(), receiver, geometry,
+                                                          &paths, &error_message))
         << error_message;
     ASSERT_EQ(paths.diffraction_status, gnss_sim::UrbanRooftopDiffractionStatus::VALID);
     ASSERT_EQ(paths.reflections.path_count, 1);
@@ -154,9 +150,8 @@ TEST(UrbanReceivedPower, RooftopGrazingAppliesDiffractionTransferExactlyOnce) {
 
     const gnss_sim::CodeTrackingDllPath direct_only[] = {{paths.paths[0].code_delay_sec, paths.direct_voltage}};
     gnss_sim::UrbanEffectiveCn0 direct_effective{};
-    ASSERT_TRUE(gnss_sim::compute_effective_cn0_from_paths(paths.open_cn0_dbhz, gps_l1, direct_only, 1,
-                                                           paths.paths[0].code_delay_sec, &direct_effective,
-                                                           &error_message))
+    ASSERT_TRUE(gnss_sim::compute_effective_cn0_from_paths(
+        paths.open_cn0_dbhz, gps_l1, direct_only, 1, paths.paths[0].code_delay_sec, &direct_effective, &error_message))
         << error_message;
     EXPECT_NEAR(direct_effective.effective_cn0_dbhz, paths.open_cn0_dbhz - 6.020599913279624, 1.0e-9);
 }
@@ -172,8 +167,8 @@ TEST(UrbanReceivedPower, FrozenBlockedGeometryRetainsIndependentReflectionAsSeco
     gnss_sim::UrbanReceivedPathSet paths{};
     std::string error_message;
     ASSERT_TRUE(gnss_sim::compute_urban_received_path_set(normalized_model(gps_l1.signal_id, 46.0), scene,
-                                                         config.urban_rf, gps_l1, 0, test_time(), receiver, geometry,
-                                                         &paths, &error_message))
+                                                          config.urban_rf, gps_l1, 0, test_time(), receiver, geometry,
+                                                          &paths, &error_message))
         << error_message;
     ASSERT_EQ(paths.diffraction_status, gnss_sim::UrbanRooftopDiffractionStatus::VALID);
     ASSERT_EQ(paths.reflections.path_count, 1);
@@ -199,19 +194,19 @@ TEST(UrbanReceivedPower, ChangingOnlyHighBaselineTranslatesOpenAndEffectiveCn0) 
     gnss_sim::UrbanReceivedPathSet higher_paths{};
     std::string error_message;
     ASSERT_TRUE(gnss_sim::compute_urban_received_path_set(normalized_model(gps_l1.signal_id, 45.0), scene,
-                                                         config.urban_rf, gps_l1, 0, test_time(), receiver, geometry,
-                                                         &lower_paths, &error_message))
+                                                          config.urban_rf, gps_l1, 0, test_time(), receiver, geometry,
+                                                          &lower_paths, &error_message))
         << error_message;
     ASSERT_TRUE(gnss_sim::compute_urban_received_path_set(normalized_model(gps_l1.signal_id, 48.0), scene,
-                                                         config.urban_rf, gps_l1, 0, test_time(), receiver, geometry,
-                                                         &higher_paths, &error_message))
+                                                          config.urban_rf, gps_l1, 0, test_time(), receiver, geometry,
+                                                          &higher_paths, &error_message))
         << error_message;
     EXPECT_NEAR(higher_paths.open_cn0_dbhz - lower_paths.open_cn0_dbhz, 3.0, 1.0e-12);
     ASSERT_EQ(higher_paths.path_count, lower_paths.path_count);
     for (int index = 0; index < lower_paths.path_count; ++index) {
         EXPECT_NEAR(higher_paths.paths[index].code_delay_sec, lower_paths.paths[index].code_delay_sec, 1.0e-18);
-        EXPECT_NEAR(std::abs(higher_paths.paths[index].complex_voltage - lower_paths.paths[index].complex_voltage),
-                    0.0, 1.0e-14);
+        EXPECT_NEAR(std::abs(higher_paths.paths[index].complex_voltage - lower_paths.paths[index].complex_voltage), 0.0,
+                    1.0e-14);
     }
 
     gnss_sim::UrbanEffectiveCn0 lower{};
@@ -243,9 +238,9 @@ TEST(UrbanReceivedPower, ClearSideRoofTransitionIsContinuous) {
     gnss_sim::UrbanReceivedPathSet high{};
     const gnss_sim::Cn0Model model = normalized_model(gps_l1.signal_id, 47.0);
     ASSERT_TRUE(gnss_sim::compute_urban_received_path_set(model, scene, config.urban_rf, gps_l1, 0, test_time(),
-                                                         receiver_low, geometry_low, &low, &error_message));
+                                                          receiver_low, geometry_low, &low, &error_message));
     ASSERT_TRUE(gnss_sim::compute_urban_received_path_set(model, scene, config.urban_rf, gps_l1, 0, test_time(),
-                                                         receiver_high, geometry_high, &high, &error_message));
+                                                          receiver_high, geometry_high, &high, &error_message));
     ASSERT_GT(low.path_count, 0);
     ASSERT_GT(high.path_count, 0);
     EXPECT_FALSE(low.direct_geometry.line_of_sight);

--- a/tests/unit/test_urban_received_power.cpp
+++ b/tests/unit/test_urban_received_power.cpp
@@ -149,10 +149,10 @@ TEST(UrbanReceivedPower, RooftopGrazingAppliesDiffractionTransferExactlyOnce) {
     EXPECT_NEAR(paths.diffraction.fresnel_v, 0.0, 1.0e-8);
     EXPECT_NEAR(paths.direct_voltage.real(), 0.5, 1.0e-10);
     EXPECT_NEAR(paths.direct_voltage.imag(), 0.0, 1.0e-10);
+    EXPECT_NEAR(paths.paths[0].code_delay_sec, 0.0, 1.0e-18);
 
     gnss_sim::UrbanEffectiveCn0 effective{};
-    ASSERT_TRUE(gnss_sim::compute_urban_effective_cn0(gps_l1, paths, paths.diffraction.excess_delay_sec, &effective,
-                                                      &error_message))
+    ASSERT_TRUE(gnss_sim::compute_urban_effective_cn0(gps_l1, paths, 0.0, &effective, &error_message))
         << error_message;
     EXPECT_NEAR(effective.effective_cn0_dbhz, paths.open_cn0_dbhz - 6.020599913279624, 1.0e-9);
 }
@@ -174,7 +174,9 @@ TEST(UrbanReceivedPower, FrozenBlockedGeometryRetainsIndependentReflectionAsSeco
     ASSERT_EQ(paths.diffraction_status, gnss_sim::UrbanRooftopDiffractionStatus::VALID);
     ASSERT_EQ(paths.reflections.path_count, 1);
     ASSERT_EQ(paths.path_count, 2);
+    EXPECT_FALSE(paths.direct_geometry.line_of_sight);
     EXPECT_EQ(paths.paths[0].complex_voltage, paths.diffraction.fresnel_coefficient);
+    EXPECT_NEAR(paths.paths[0].code_delay_sec, paths.diffraction.excess_delay_sec, 1.0e-18);
     EXPECT_GT(std::abs(paths.paths[1].complex_voltage), 0.0);
     EXPECT_TRUE(std::isfinite(paths.paths[1].complex_voltage.real()));
     EXPECT_TRUE(std::isfinite(paths.paths[1].complex_voltage.imag()));
@@ -240,6 +242,12 @@ TEST(UrbanReceivedPower, ClearSideRoofTransitionIsContinuous) {
                                                          receiver_low, geometry_low, &low, &error_message));
     ASSERT_TRUE(gnss_sim::compute_urban_received_path_set(model, scene, config.urban_rf, gps_l1, 0, test_time(),
                                                          receiver_high, geometry_high, &high, &error_message));
+    ASSERT_GT(low.path_count, 0);
+    ASSERT_GT(high.path_count, 0);
+    EXPECT_FALSE(low.direct_geometry.line_of_sight);
+    EXPECT_TRUE(high.direct_geometry.line_of_sight);
+    EXPECT_NEAR(low.paths[0].code_delay_sec, low.diffraction.excess_delay_sec, 1.0e-18);
+    EXPECT_NEAR(high.paths[0].code_delay_sec, 0.0, 1.0e-18);
     EXPECT_LT(std::abs(std::abs(high.direct_voltage) - std::abs(low.direct_voltage)), 0.01);
 }
 

--- a/tests/unit/test_urban_received_power.cpp
+++ b/tests/unit/test_urban_received_power.cpp
@@ -1,0 +1,254 @@
+#include "gnss/signal_definitions.h"
+#include "gnss_sim/sim_config.h"
+#include "model/urban_received_power.h"
+
+#include <cmath>
+#include <complex>
+#include <gtest/gtest.h>
+#include <limits>
+#include <string>
+
+namespace {
+
+constexpr double kPi = 3.141592653589793238462643383279502884;
+constexpr double kDegreesToRadians = kPi / 180.0;
+constexpr double kSyntheticSatelliteDistanceM = 20000000.0;
+
+const gnss_sim::SignalDefinition& signal(gnss_sim::SignalId signal_id) {
+    const gnss_sim::SignalDefinition* definition = gnss_sim::find_signal_definition(signal_id);
+    EXPECT_NE(definition, nullptr);
+    return *definition;
+}
+
+void make_synthetic_geometry(double azimuth_deg, double elevation_deg, gnss_sim::ReceiverTruth* receiver,
+                             gnss_sim::SatelliteGeometry* geometry) {
+    ASSERT_NE(receiver, nullptr);
+    ASSERT_NE(geometry, nullptr);
+    *receiver = {};
+    *geometry = {};
+    receiver->position_ecef_m[0] = 0.0;
+    receiver->position_ecef_m[1] = 0.0;
+    receiver->position_ecef_m[2] = 0.0;
+    geometry->satellite_state.position_ecef_m[0] = kSyntheticSatelliteDistanceM;
+    geometry->satellite_state.position_ecef_m[1] = 0.0;
+    geometry->satellite_state.position_ecef_m[2] = 0.0;
+    geometry->azimuth_rad = azimuth_deg * kDegreesToRadians;
+    geometry->elevation_rad = elevation_deg * kDegreesToRadians;
+    geometry->geometric_range_m = kSyntheticSatelliteDistanceM;
+    geometry->healthy = true;
+    geometry->above_elevation_mask = true;
+    geometry->visible = true;
+}
+
+gnss_sim::Cn0Model normalized_model(gnss_sim::SignalId signal_id, double high_cn0_dbhz) {
+    gnss_sim::Cn0Model model{};
+    model.source = gnss_sim::Cn0ModelSource::kCalibratedCsv;
+    model.semantic = gnss_sim::Cn0ModelSemantic::kNormalizedElevationShape;
+    model.seed = 17;
+    gnss_sim::Cn0CalibratedBin bin{};
+    bin.signal_id = signal_id;
+    bin.elevation_min_deg = 0.0;
+    bin.elevation_max_deg = 90.0;
+    bin.elevation_center_deg = 45.0;
+    bin.delta_p50_db = -2.0;
+    bin.support_count = 5;
+    bin.upper_edge_inclusive = true;
+    bin.ready = true;
+    model.calibrated_bins.push_back(bin);
+    model.high_baselines.push_back({signal_id, high_cn0_dbhz});
+    return model;
+}
+
+gnss_sim::SimTime test_time() {
+    gnss_sim::SimTime time{};
+    time.gps_week = 2400;
+    time.tow_ns = 100000000000LL;
+    return time;
+}
+
+TEST(UrbanReceivedPower, ConstructiveAndDestructiveFieldsMapToPowerDomainCn0) {
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    const gnss_sim::CodeTrackingDllPath constructive[] = {
+        {0.0, {1.0, 0.0}},
+        {0.0, {0.5, 0.0}},
+    };
+    const gnss_sim::CodeTrackingDllPath destructive[] = {
+        {0.0, {1.0, 0.0}},
+        {0.0, {-0.5, 0.0}},
+    };
+    gnss_sim::UrbanEffectiveCn0 high{};
+    gnss_sim::UrbanEffectiveCn0 low{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::compute_effective_cn0_from_paths(45.0, gps_l1, constructive, 2, 0.0, &high,
+                                                           &error_message))
+        << error_message;
+    ASSERT_TRUE(gnss_sim::compute_effective_cn0_from_paths(45.0, gps_l1, destructive, 2, 0.0, &low,
+                                                           &error_message))
+        << error_message;
+    EXPECT_NEAR(high.composite_power_ratio, 2.25, 1.0e-14);
+    EXPECT_NEAR(high.effective_cn0_dbhz, 45.0 + 10.0 * std::log10(2.25), 1.0e-12);
+    EXPECT_NEAR(low.composite_power_ratio, 0.25, 1.0e-14);
+    EXPECT_NEAR(low.effective_cn0_dbhz, 45.0 + 10.0 * std::log10(0.25), 1.0e-12);
+}
+
+TEST(UrbanReceivedPower, CodeDelayDecorrelatesASeparatedPathAtDirectPrompt) {
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    const double chip_duration_s = 1.0 / gps_l1.code_correlation.chip_rate_hz;
+    const gnss_sim::CodeTrackingDllPath paths[] = {
+        {0.0, {1.0, 0.0}},
+        {chip_duration_s, {0.75, 0.0}},
+    };
+    gnss_sim::UrbanEffectiveCn0 effective{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::compute_effective_cn0_from_paths(43.0, gps_l1, paths, 2, 0.0, &effective,
+                                                           &error_message))
+        << error_message;
+    EXPECT_NEAR(effective.composite_correlation.real(), 1.0, 1.0e-14);
+    EXPECT_NEAR(effective.composite_correlation.imag(), 0.0, 1.0e-14);
+    EXPECT_NEAR(effective.effective_cn0_dbhz, 43.0, 1.0e-12);
+}
+
+TEST(UrbanReceivedPower, ExactCancellationHasNoArbitraryCn0Floor) {
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    const gnss_sim::CodeTrackingDllPath paths[] = {
+        {0.0, {1.0, 0.0}},
+        {0.0, {-1.0, 0.0}},
+    };
+    gnss_sim::UrbanEffectiveCn0 effective{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::compute_effective_cn0_from_paths(45.0, gps_l1, paths, 2, 0.0, &effective,
+                                                           &error_message))
+        << error_message;
+    EXPECT_DOUBLE_EQ(effective.composite_power_ratio, 0.0);
+    EXPECT_DOUBLE_EQ(effective.carrier_to_noise_density_hz, 0.0);
+    EXPECT_FALSE(effective.finite_effective_cn0);
+    EXPECT_TRUE(std::isinf(effective.effective_cn0_dbhz));
+    EXPECT_LT(effective.effective_cn0_dbhz, 0.0);
+}
+
+TEST(UrbanReceivedPower, RooftopGrazingAppliesDiffractionTransferExactlyOnce) {
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    const gnss_sim::UrbanSceneGeometryConfig scene = gnss_sim::default_urban_scene_geometry_config();
+    const gnss_sim::SimConfig config = gnss_sim::default_sim_config();
+    double skyline_rad = 0.0;
+    double wall_distance_m = 0.0;
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::compute_urban_skyline_elevation(scene, 0.0, &skyline_rad, &wall_distance_m, &error_message));
+
+    gnss_sim::ReceiverTruth receiver{};
+    gnss_sim::SatelliteGeometry geometry{};
+    make_synthetic_geometry(0.0, skyline_rad / kDegreesToRadians, &receiver, &geometry);
+    gnss_sim::UrbanReceivedPathSet paths{};
+    ASSERT_TRUE(gnss_sim::compute_urban_received_path_set(normalized_model(gps_l1.signal_id, 47.0), scene,
+                                                         config.urban_rf, gps_l1, 0, test_time(), receiver, geometry,
+                                                         &paths, &error_message))
+        << error_message;
+    ASSERT_EQ(paths.diffraction_status, gnss_sim::UrbanRooftopDiffractionStatus::VALID);
+    ASSERT_EQ(paths.reflections.path_count, 0);
+    ASSERT_EQ(paths.path_count, 1);
+    EXPECT_NEAR(paths.diffraction.fresnel_v, 0.0, 1.0e-8);
+    EXPECT_NEAR(paths.direct_voltage.real(), 0.5, 1.0e-10);
+    EXPECT_NEAR(paths.direct_voltage.imag(), 0.0, 1.0e-10);
+
+    gnss_sim::UrbanEffectiveCn0 effective{};
+    ASSERT_TRUE(gnss_sim::compute_urban_effective_cn0(gps_l1, paths, paths.diffraction.excess_delay_sec, &effective,
+                                                      &error_message))
+        << error_message;
+    EXPECT_NEAR(effective.effective_cn0_dbhz, paths.open_cn0_dbhz - 6.020599913279624, 1.0e-9);
+}
+
+TEST(UrbanReceivedPower, FrozenBlockedGeometryRetainsIndependentReflectionAsSecondPath) {
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    const gnss_sim::UrbanSceneGeometryConfig scene = gnss_sim::default_urban_scene_geometry_config();
+    const gnss_sim::SimConfig config = gnss_sim::default_sim_config();
+    gnss_sim::ReceiverTruth receiver{};
+    gnss_sim::SatelliteGeometry geometry{};
+    make_synthetic_geometry(180.0, 20.0, &receiver, &geometry);
+
+    gnss_sim::UrbanReceivedPathSet paths{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::compute_urban_received_path_set(normalized_model(gps_l1.signal_id, 46.0), scene,
+                                                         config.urban_rf, gps_l1, 0, test_time(), receiver, geometry,
+                                                         &paths, &error_message))
+        << error_message;
+    ASSERT_EQ(paths.diffraction_status, gnss_sim::UrbanRooftopDiffractionStatus::VALID);
+    ASSERT_EQ(paths.reflections.path_count, 1);
+    ASSERT_EQ(paths.path_count, 2);
+    EXPECT_EQ(paths.paths[0].complex_voltage, paths.diffraction.fresnel_coefficient);
+    EXPECT_GT(std::abs(paths.paths[1].complex_voltage), 0.0);
+    EXPECT_TRUE(std::isfinite(paths.paths[1].complex_voltage.real()));
+    EXPECT_TRUE(std::isfinite(paths.paths[1].complex_voltage.imag()));
+    EXPECT_NEAR(paths.paths[1].code_delay_sec, paths.reflections.paths[0].excess_delay_sec, 1.0e-18);
+}
+
+TEST(UrbanReceivedPower, ChangingOnlyHighBaselineTranslatesOpenAndEffectiveCn0) {
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    const gnss_sim::UrbanSceneGeometryConfig scene = gnss_sim::default_urban_scene_geometry_config();
+    const gnss_sim::SimConfig config = gnss_sim::default_sim_config();
+    gnss_sim::ReceiverTruth receiver{};
+    gnss_sim::SatelliteGeometry geometry{};
+    make_synthetic_geometry(0.0, 60.0, &receiver, &geometry);
+
+    gnss_sim::UrbanReceivedPathSet lower_paths{};
+    gnss_sim::UrbanReceivedPathSet higher_paths{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::compute_urban_received_path_set(normalized_model(gps_l1.signal_id, 45.0), scene,
+                                                         config.urban_rf, gps_l1, 0, test_time(), receiver, geometry,
+                                                         &lower_paths, &error_message))
+        << error_message;
+    ASSERT_TRUE(gnss_sim::compute_urban_received_path_set(normalized_model(gps_l1.signal_id, 48.0), scene,
+                                                         config.urban_rf, gps_l1, 0, test_time(), receiver, geometry,
+                                                         &higher_paths, &error_message))
+        << error_message;
+    EXPECT_NEAR(higher_paths.open_cn0_dbhz - lower_paths.open_cn0_dbhz, 3.0, 1.0e-12);
+    ASSERT_EQ(higher_paths.path_count, lower_paths.path_count);
+    for (int index = 0; index < lower_paths.path_count; ++index) {
+        EXPECT_NEAR(higher_paths.paths[index].code_delay_sec, lower_paths.paths[index].code_delay_sec, 1.0e-18);
+        EXPECT_NEAR(std::abs(higher_paths.paths[index].complex_voltage - lower_paths.paths[index].complex_voltage),
+                    0.0, 1.0e-14);
+    }
+
+    gnss_sim::UrbanEffectiveCn0 lower{};
+    gnss_sim::UrbanEffectiveCn0 higher{};
+    ASSERT_TRUE(gnss_sim::compute_urban_effective_cn0(gps_l1, lower_paths, lower_paths.paths[0].code_delay_sec, &lower,
+                                                      &error_message));
+    ASSERT_TRUE(gnss_sim::compute_urban_effective_cn0(gps_l1, higher_paths, higher_paths.paths[0].code_delay_sec,
+                                                      &higher, &error_message));
+    EXPECT_NEAR(higher.effective_cn0_dbhz - lower.effective_cn0_dbhz, 3.0, 1.0e-12);
+}
+
+TEST(UrbanReceivedPower, ClearSideRoofTransitionIsContinuous) {
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    const gnss_sim::UrbanSceneGeometryConfig scene = gnss_sim::default_urban_scene_geometry_config();
+    const gnss_sim::SimConfig config = gnss_sim::default_sim_config();
+    double skyline_rad = 0.0;
+    double wall_distance_m = 0.0;
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::compute_urban_skyline_elevation(scene, 0.0, &skyline_rad, &wall_distance_m, &error_message));
+    const double skyline_deg = skyline_rad / kDegreesToRadians;
+
+    gnss_sim::ReceiverTruth receiver_low{};
+    gnss_sim::ReceiverTruth receiver_high{};
+    gnss_sim::SatelliteGeometry geometry_low{};
+    gnss_sim::SatelliteGeometry geometry_high{};
+    make_synthetic_geometry(0.0, skyline_deg - 0.001, &receiver_low, &geometry_low);
+    make_synthetic_geometry(0.0, skyline_deg + 0.001, &receiver_high, &geometry_high);
+    gnss_sim::UrbanReceivedPathSet low{};
+    gnss_sim::UrbanReceivedPathSet high{};
+    const gnss_sim::Cn0Model model = normalized_model(gps_l1.signal_id, 47.0);
+    ASSERT_TRUE(gnss_sim::compute_urban_received_path_set(model, scene, config.urban_rf, gps_l1, 0, test_time(),
+                                                         receiver_low, geometry_low, &low, &error_message));
+    ASSERT_TRUE(gnss_sim::compute_urban_received_path_set(model, scene, config.urban_rf, gps_l1, 0, test_time(),
+                                                         receiver_high, geometry_high, &high, &error_message));
+    EXPECT_LT(std::abs(std::abs(high.direct_voltage) - std::abs(low.direct_voltage)), 0.01);
+}
+
+TEST(UrbanReceivedPower, InvalidInputsFailExplicitly) {
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    const gnss_sim::CodeTrackingDllPath path[] = {{0.0, {1.0, 0.0}}};
+    std::string error_message;
+    EXPECT_FALSE(gnss_sim::compute_effective_cn0_from_paths(std::numeric_limits<double>::quiet_NaN(), gps_l1, path, 1,
+                                                            0.0, nullptr, &error_message));
+}
+
+} // namespace


### PR DESCRIPTION
Closes #120

## Summary

Implements the V1 receiver-domain propagation/power layer that maps the existing open-sky C/N0 model plus #116/#117/#118 urban propagation physics into the same normalized complex path representation consumed by #119.

## Open-sky baseline

- Reuses the existing `cn0_model_estimate_dbhz()` runtime path; normalized-model semantics remain `CN0_high_dbhz + Delta_CN0_elevation` plus the already-existing deterministic open-sky temporal variation/compatibility behavior.
- Does not replace real-IGS normalized elevation behavior with a handwritten urban curve.
- Defines the unobstructed receiver-domain direct reference voltage as `1+j0`.

## One common complex-voltage convention

Each #119 path is `{code_delay_sec, normalized complex voltage}` relative to the unobstructed direct receiver-domain field.

For retained #117 reflections, the voltage applies exactly once:
- Euclidean spherical-spreading field ratio `D_direct / D_reflected`;
- #116 Low-E RHCP/LHCP complex reflection response;
- #116 receive-antenna RHCP/LHCP response at the reflected arrival elevation, normalized by the direct RHCP antenna response in the satellite direction;
- #117 geometric excess carrier phase.

This treats #116 antenna response as relative multipath polarization/arrival-direction weighting and avoids applying the receiver/antenna calibration already represented by open-sky C/N0 twice.

## Rooftop diffraction / #130 rule

- #118 `fresnel_coefficient` is used exactly once as the complete direct-referenced roof transfer voltage.
- No `full direct + full diffraction` path pair is created.
- The #118 geometric phase is not multiplied into the Fresnel coefficient again.
- Clear/LOS side uses direct code delay `0`.
- Blocked/shadow side uses #118 `excess_delay_sec` as the equivalent edge code delay.
- At grazing the excess delay tends to zero, preserving the transition without leaving a false edge delay in far-clear LOS.

## Effective C/N0

Uses the #119/#134 composite correlator at the supplied local code phase:

`Z(epsilon) = sum_i V_i R(epsilon - tau_i)`

`P_ratio = |Z|^2`

`CN0_effective = CN0_open + 10*log10(P_ratio)` for nonzero power.

Exact cancellation is represented as zero linear C/N0 and no finite dB-Hz value (`-infinity`, explicit validity flag), not an arbitrary floor. #121 remains responsible for tracking thresholds, hysteresis, persistence, and BLOCKED transitions.

## Tests

Adds deterministic coverage for:
- constructive/destructive coherent field addition;
- one-chip code decorrelation at direct prompt;
- exact cancellation without a C/N0 floor;
- rooftop grazing `F(0)=0.5` / ~6.0206 dB loss with exactly one direct component;
- clear-side direct delay = 0 and shadow-side direct delay = #118 edge excess delay;
- frozen blocked geometry with roof-affected direct + independent retained #117 reflection;
- receiver/signal high-baseline translation shifting open/effective C/N0 without changing normalized paths;
- clear/grazing/shadow continuity;
- explicit invalid-input failure.

## Permanent documentation

`docs/URBAN_RECEIVED_POWER.md` freezes the open-sky reference, antenna ownership, reflection voltage equation, diffraction phase/delay ownership, effective-C/N0 equation, zero-power semantics, and #121/#122 integration boundary.

## Scope boundary

This PR intentionally does not implement #121 tracking thresholds/state transitions or #122 observable synthesis. The current legacy/open-sky tracking behavior remains unchanged until #121 consumes this effective-C/N0/path layer. This prevents #120 from pre-empting the tracking-state contract.

No independent per-epoch urban attenuation noise is introduced.

## Data provenance / safety

No NAV/EPH/ION is generated, modified, interpolated, retargeted, or fabricated. No RF/CN0 parameter is tuned to force a target PVT error.