### PR TITLE
Implement urban signal tracking hysteresis and receiver state machine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,7 @@ add_library(gnss_sim_core STATIC
     src/model/urban_rooftop_diffraction.cpp
     src/model/urban_rf_model.cpp
     src/model/urban_scene_geometry.cpp
+    src/model/urban_signal_tracking.cpp
     src/output/novatel_nav_writer.cpp
     src/output/novatel_range_writer.cpp
     src/output/novatel_solution_writer.cpp
@@ -270,6 +271,7 @@ if(BUILD_TESTING)
         tests/unit/test_urban_rooftop_diffraction.cpp
         tests/unit/test_urban_rf_model.cpp
         tests/unit/test_urban_scene_geometry.cpp
+        tests/unit/test_urban_signal_tracking.cpp
     )
     target_include_directories(gnss_sim_unit_tests PRIVATE
         "${CMAKE_CURRENT_SOURCE_DIR}/src")

--- a/docs/URBAN_SIGNAL_TRACKING.md
+++ b/docs/URBAN_SIGNAL_TRACKING.md
@@ -1,0 +1,89 @@
+# Urban signal tracking and propagation-state semantics
+
+Issue #121 extends the existing per-signal `SignalTracker`; it does not create a second acquisition/tracking state machine.
+
+## Two independent state axes
+
+`SignalTrackingPhase` continues to describe receiver progress:
+
+- `SIGNAL_OFF`
+- `SEARCHING`
+- `ACQUIRING`
+- `TRACKING`
+
+`UrbanSignalState` describes the propagation/tracking interpretation:
+
+- `LOS`
+- `LOS_MULTIPATH`
+- `NLOS_TRACKED`
+- `BLOCKED`
+
+An open-sky signal may therefore be `SEARCHING + LOS`. `BLOCKED` is not used as a synonym for startup delay.
+
+## V1 engineering defaults
+
+These values are deterministic receiver-model assumptions. They are configurable in `SignalTrackingModelConfig`; they are not measurements of a named commercial receiver and must not be tuned to force a desired PVT result.
+
+| Parameter | Default |
+| --- | ---: |
+| minimum tracking C/N0 | 10.0 dB-Hz |
+| acquisition/reacquisition C/N0 | 18.0 dB-Hz |
+| acquisition C/N0 persistence | 200 ms |
+| tracking-loss C/N0 persistence | 500 ms |
+| abrupt DLL root jump | > 0.25 chip/update |
+| LOS multipath C/N0 significance | >= 0.5 dB |
+| LOS multipath DLL bias significance | >= 0.02 chip |
+
+The 10/18 dB-Hz pair provides explicit acquisition/tracking hysteresis. Threshold persistence prevents one-epoch chatter.
+
+## Acquisition and reacquisition
+
+The existing seeded acquisition/reacquisition delay distributions remain authoritative. The urban-aware update adds a physical eligibility gate around that schedule:
+
+1. Search must already be ready.
+2. Effective C/N0 from the common #120 result must remain at or above 18 dB-Hz continuously for 200 ms.
+3. The existing sampled acquisition/reacquisition completion time must have elapsed.
+4. A stable #119 DLL root must exist.
+
+Only after all four conditions are satisfied does the tracker enter a fresh lock. PSR, Doppler, ADR, and carrier-continuity validity delays restart from the actual new-lock epoch.
+
+After a physical loss, `reacquisition_pending=true` and `scheduled=false`. The existing `schedule_signal_acquisition(..., kReacquisition, ...)` function is then used to sample/schedule the deterministic reacquisition delay; the urban state machine does not invent a second delay distribution.
+
+## Tracking loss
+
+While tracking:
+
+- effective C/N0 >= 10 dB-Hz immediately resets the low-C/N0 loss timer;
+- effective C/N0 < 10 dB-Hz starts/continues the timer;
+- a low-C/N0 interval shorter than 500 ms preserves lock;
+- at 500 ms the lock is lost deterministically;
+- disappearance of every stable DLL root causes immediate loss;
+- a selected root jump greater than 0.25 chip relative to the prior accepted root causes immediate loss.
+
+Loss clears observation validity, lock time, ADR/carrier continuity, and DLL continuity. The deterministic reason is retained as one of `LOW_CN0`, `NO_STABLE_DLL_ROOT`, `ABRUPT_DLL_ROOT_SWITCH`, or `SIGNAL_UNAVAILABLE`.
+
+## DLL continuity
+
+The state machine consumes #119 roots directly:
+
+- acquisition/reacquisition uses #119 `ACQUISITION` selection;
+- tracking uses #119 `TRACKED` selection with the previous selected code phase;
+- root-jump comparison uses `CodeTrackingDllRoot::code_phase_chips`, which is already derived from signal-specific code/correlation metadata.
+
+No generic chip-rate table is introduced in #121.
+
+## LOS classification
+
+Direct geometry comes from #115. For direct LOS, the label is based on the common #119/#120 receiver-domain result rather than a Fresnel-v cutoff:
+
+- `LOS_MULTIPATH` if `abs(CN0_effective - CN0_open) >= 0.5 dB`, or
+- `LOS_MULTIPATH` if `abs(selected DLL code bias) >= 0.02 chip`, or
+- otherwise `LOS`.
+
+A retained #117 reflection is neither required nor sufficient as a special-case state rule. This preserves #130: clear-side rooftop diffraction can make `LOS_MULTIPATH` reachable without weakening the frozen four-wall occlusion geometry.
+
+When direct geometry is blocked, the signal is `NLOS_TRACKED` only while the receiver actually retains a tracking lock. Otherwise it is `BLOCKED`.
+
+## Scope
+
+#121 owns receiver state, hysteresis, lock continuity, and classification. It does not synthesize final pseudorange/Doppler/carrier/ADR (#122), serialize truth (#123), modify authentic NAV/EPH/ION, add random urban attenuation, or tune final PVT errors.

--- a/src/model/signal_tracking.cpp
+++ b/src/model/signal_tracking.cpp
@@ -158,14 +158,12 @@ bool validate_signal_tracking_model_config(const SignalTrackingModelConfig& conf
         set_error(error_message, "measurement-valid delays must be nonnegative");
         return false;
     }
-    if (!std::isfinite(config.minimum_tracking_cn0_dbhz) ||
-        !std::isfinite(config.acquisition_cn0_threshold_dbhz) ||
+    if (!std::isfinite(config.minimum_tracking_cn0_dbhz) || !std::isfinite(config.acquisition_cn0_threshold_dbhz) ||
         !(config.acquisition_cn0_threshold_dbhz > config.minimum_tracking_cn0_dbhz) ||
         config.acquisition_cn0_persistence_ns < 0 || config.tracking_loss_cn0_persistence_ns < 0 ||
         !std::isfinite(config.dll_root_jump_threshold_chips) || !(config.dll_root_jump_threshold_chips > 0.0) ||
         !std::isfinite(config.los_multipath_cn0_delta_db) || !(config.los_multipath_cn0_delta_db >= 0.0) ||
-        !std::isfinite(config.los_multipath_code_bias_chips) ||
-        !(config.los_multipath_code_bias_chips >= 0.0)) {
+        !std::isfinite(config.los_multipath_code_bias_chips) || !(config.los_multipath_code_bias_chips >= 0.0)) {
         set_error(error_message, "urban signal-tracking thresholds are invalid");
         return false;
     }

--- a/src/model/signal_tracking.cpp
+++ b/src/model/signal_tracking.cpp
@@ -86,6 +86,27 @@ void clear_observation_state(SignalTracker* tracker) {
     tracker->doppler_valid = false;
     tracker->adr_valid = false;
     tracker->observation_available = false;
+    tracker->carrier_continuity_valid = false;
+}
+
+void reset_urban_tracking_overlay(SignalTracker* tracker, const SimTime& time) {
+    tracker->urban_state = UrbanSignalState::kBlocked;
+    tracker->loss_reason = SignalTrackingLossReason::kNone;
+    tracker->above_acquisition_threshold_since = time;
+    tracker->below_tracking_threshold_since = time;
+    tracker->above_acquisition_threshold_active = false;
+    tracker->below_tracking_threshold_active = false;
+    tracker->has_tracking_lock = false;
+    tracker->previous_dll_root_valid = false;
+    tracker->current_dll_root_valid = false;
+    tracker->previous_dll_code_phase_sec = 0.0;
+    tracker->previous_dll_code_phase_chips = 0.0;
+    tracker->current_dll_code_phase_sec = 0.0;
+    tracker->current_dll_code_phase_chips = 0.0;
+    tracker->current_dll_prompt_power = 0.0;
+    tracker->reacquisition_pending = false;
+    tracker->reacquisition_event = false;
+    tracker->carrier_continuity_valid = false;
 }
 
 } // namespace
@@ -109,6 +130,14 @@ SignalTrackingModelConfig default_signal_tracking_model_config() {
     config.psr_valid_delay_ns = milliseconds(100);
     config.doppler_valid_delay_ns = milliseconds(150);
     config.adr_valid_delay_ns = milliseconds(500);
+
+    config.minimum_tracking_cn0_dbhz = 10.0;
+    config.acquisition_cn0_threshold_dbhz = 18.0;
+    config.acquisition_cn0_persistence_ns = milliseconds(200);
+    config.tracking_loss_cn0_persistence_ns = milliseconds(500);
+    config.dll_root_jump_threshold_chips = 0.25;
+    config.los_multipath_cn0_delta_db = 0.5;
+    config.los_multipath_code_bias_chips = 0.02;
     return config;
 }
 
@@ -127,6 +156,17 @@ bool validate_signal_tracking_model_config(const SignalTrackingModelConfig& conf
     }
     if (config.psr_valid_delay_ns < 0 || config.doppler_valid_delay_ns < 0 || config.adr_valid_delay_ns < 0) {
         set_error(error_message, "measurement-valid delays must be nonnegative");
+        return false;
+    }
+    if (!std::isfinite(config.minimum_tracking_cn0_dbhz) ||
+        !std::isfinite(config.acquisition_cn0_threshold_dbhz) ||
+        !(config.acquisition_cn0_threshold_dbhz > config.minimum_tracking_cn0_dbhz) ||
+        config.acquisition_cn0_persistence_ns < 0 || config.tracking_loss_cn0_persistence_ns < 0 ||
+        !std::isfinite(config.dll_root_jump_threshold_chips) || !(config.dll_root_jump_threshold_chips > 0.0) ||
+        !std::isfinite(config.los_multipath_cn0_delta_db) || !(config.los_multipath_cn0_delta_db >= 0.0) ||
+        !std::isfinite(config.los_multipath_code_bias_chips) ||
+        !(config.los_multipath_code_bias_chips >= 0.0)) {
+        set_error(error_message, "urban signal-tracking thresholds are invalid");
         return false;
     }
     return true;
@@ -168,6 +208,7 @@ void reset_signal_tracker(SignalTracker* tracker, SignalId signal_id, const SimT
     tracker->doppler_valid_time = reset_time;
     tracker->adr_valid_time = reset_time;
     clear_observation_state(tracker);
+    reset_urban_tracking_overlay(tracker, reset_time);
 }
 
 bool schedule_signal_acquisition(SignalTracker* tracker, AcquisitionContext context, const SimTime& signal_on_time,
@@ -223,6 +264,14 @@ bool schedule_signal_acquisition(SignalTracker* tracker, AcquisitionContext cont
     tracker->doppler_valid = false;
     tracker->adr_valid = false;
     tracker->observation_available = false;
+    tracker->above_acquisition_threshold_active = false;
+    tracker->below_tracking_threshold_active = false;
+    tracker->has_tracking_lock = false;
+    tracker->previous_dll_root_valid = false;
+    tracker->current_dll_root_valid = false;
+    tracker->reacquisition_pending = false;
+    tracker->reacquisition_event = false;
+    tracker->carrier_continuity_valid = false;
     return true;
 }
 
@@ -238,6 +287,7 @@ bool update_signal_tracker(SignalTracker* tracker, const SimTime& current_time, 
         tracker->phase = SignalTrackingPhase::kSignalOff;
         tracker->state_since = current_time;
         tracker->scheduled = false;
+        tracker->has_tracking_lock = false;
         clear_observation_state(tracker);
         return true;
     }
@@ -262,6 +312,7 @@ bool update_signal_tracker(SignalTracker* tracker, const SimTime& current_time, 
         tracker->doppler_valid = false;
         tracker->adr_valid = false;
         tracker->observation_available = false;
+        tracker->carrier_continuity_valid = false;
         return true;
     }
     if (compare_sim_time(current_time, tracker->acquisition_complete_time) < 0) {
@@ -274,11 +325,13 @@ bool update_signal_tracker(SignalTracker* tracker, const SimTime& current_time, 
         tracker->doppler_valid = false;
         tracker->adr_valid = false;
         tracker->observation_available = false;
+        tracker->carrier_continuity_valid = false;
         return true;
     }
 
     tracker->phase = SignalTrackingPhase::kTracking;
     tracker->state_since = tracker->tracking_start_time;
+    tracker->has_tracking_lock = true;
     std::int64_t lock_time_ns = 0;
     if (!difference_time_ns(current_time, tracker->tracking_start_time, &lock_time_ns) || lock_time_ns < 0) {
         set_error(error_message, "cannot compute signal lock time");
@@ -289,6 +342,7 @@ bool update_signal_tracker(SignalTracker* tracker, const SimTime& current_time, 
     tracker->doppler_valid = compare_sim_time(current_time, tracker->doppler_valid_time) >= 0;
     tracker->adr_valid = compare_sim_time(current_time, tracker->adr_valid_time) >= 0;
     tracker->observation_available = tracker->psr_valid;
+    tracker->carrier_continuity_valid = tracker->adr_valid;
     return true;
 }
 

--- a/src/model/signal_tracking.h
+++ b/src/model/signal_tracking.h
@@ -6,6 +6,7 @@
 #include "gnss_sim/sim_config.h"
 #include "gnss_sim/sim_types.h"
 #include "model/cn0_model.h"
+#include "model/code_tracking_dll.h"
 
 #include <cstdint>
 #include <string>
@@ -26,6 +27,21 @@ enum class AcquisitionContext {
     kReacquisition,
 };
 
+enum class UrbanSignalState {
+    kLos,
+    kLosMultipath,
+    kNlosTracked,
+    kBlocked,
+};
+
+enum class SignalTrackingLossReason {
+    kNone,
+    kSignalUnavailable,
+    kLowCn0,
+    kNoStableDllRoot,
+    kAbruptDllRootSwitch,
+};
+
 struct DelayDistribution {
     std::int64_t minimum_ns;
     std::int64_t p50_ns;
@@ -42,6 +58,17 @@ struct SignalTrackingModelConfig {
     std::int64_t psr_valid_delay_ns;
     std::int64_t doppler_valid_delay_ns;
     std::int64_t adr_valid_delay_ns;
+
+    // V1 receiver-model engineering assumptions. These are deterministic and
+    // configurable, but are not vendor-specific measurements or PVT tuning
+    // targets.
+    double minimum_tracking_cn0_dbhz;
+    double acquisition_cn0_threshold_dbhz;
+    std::int64_t acquisition_cn0_persistence_ns;
+    std::int64_t tracking_loss_cn0_persistence_ns;
+    double dll_root_jump_threshold_chips;
+    double los_multipath_cn0_delta_db;
+    double los_multipath_code_bias_chips;
 };
 
 struct ReceiverStartupTiming {
@@ -49,6 +76,15 @@ struct ReceiverStartupTiming {
     std::int64_t common_startup_delay_ns;
     std::int64_t search_uncertainty_delay_ns;
     std::int64_t total_search_ready_delay_ns;
+};
+
+struct UrbanSignalTrackingInput {
+    bool signal_available;
+    bool direct_line_of_sight;
+    double open_cn0_dbhz;
+    double effective_cn0_dbhz;
+    const CodeTrackingDllRoot* dll_roots;
+    int dll_root_count;
 };
 
 struct SignalTracker {
@@ -69,6 +105,24 @@ struct SignalTracker {
     bool doppler_valid;
     bool adr_valid;
     bool observation_available;
+
+    UrbanSignalState urban_state;
+    SignalTrackingLossReason loss_reason;
+    SimTime above_acquisition_threshold_since;
+    SimTime below_tracking_threshold_since;
+    bool above_acquisition_threshold_active;
+    bool below_tracking_threshold_active;
+    bool has_tracking_lock;
+    bool previous_dll_root_valid;
+    bool current_dll_root_valid;
+    double previous_dll_code_phase_sec;
+    double previous_dll_code_phase_chips;
+    double current_dll_code_phase_sec;
+    double current_dll_code_phase_chips;
+    double current_dll_prompt_power;
+    bool reacquisition_pending;
+    bool reacquisition_event;
+    bool carrier_continuity_valid;
 };
 
 SignalTrackingModelConfig default_signal_tracking_model_config();
@@ -85,7 +139,16 @@ bool schedule_signal_acquisition(SignalTracker* tracker, AcquisitionContext cont
 bool update_signal_tracker(SignalTracker* tracker, const SimTime& current_time, bool signal_available,
                            double elevation_deg, const Cn0Model& cn0_model, std::string* error_message);
 
+// Urban-aware deterministic receiver update. The existing sampled acquisition
+// schedule remains authoritative; this overlay adds effective-CN0 eligibility,
+// tracking-loss persistence, DLL-root continuity, and the four urban states.
+bool update_urban_signal_tracker(SignalTracker* tracker, const SimTime& current_time,
+                                 const UrbanSignalTrackingInput& input, const SignalTrackingModelConfig& config,
+                                 std::string* error_message);
+
 const char* signal_tracking_phase_name(SignalTrackingPhase phase);
+const char* urban_signal_state_name(UrbanSignalState state);
+const char* signal_tracking_loss_reason_name(SignalTrackingLossReason reason);
 
 } // namespace gnss_sim
 

--- a/src/model/urban_signal_tracking.cpp
+++ b/src/model/urban_signal_tracking.cpp
@@ -1,6 +1,5 @@
-#include "model/signal_tracking.h"
-
 #include "gnss_sim/sim_time.h"
+#include "model/signal_tracking.h"
 
 #include <cmath>
 #include <cstdint>
@@ -22,8 +21,7 @@ bool valid_effective_cn0(double cn0_dbhz) {
     return std::isfinite(cn0_dbhz) || (std::isinf(cn0_dbhz) && cn0_dbhz < 0.0);
 }
 
-bool elapsed_at_least(const SimTime& current_time, const SimTime& start_time, std::int64_t required_ns,
-                      bool* reached) {
+bool elapsed_at_least(const SimTime& current_time, const SimTime& start_time, std::int64_t required_ns, bool* reached) {
     if (reached == nullptr || required_ns < 0) {
         return false;
     }
@@ -54,8 +52,9 @@ void clear_dll_continuity(SignalTracker* tracker) {
     tracker->current_dll_prompt_power = 0.0;
 }
 
-bool select_root(const UrbanSignalTrackingInput& input, CodeTrackingDllSelectionMode mode, double previous_code_phase_sec,
-                 CodeTrackingDllRoot* selected, bool* found, std::string* error_message) {
+bool select_root(const UrbanSignalTrackingInput& input, CodeTrackingDllSelectionMode mode,
+                 double previous_code_phase_sec, CodeTrackingDllRoot* selected, bool* found,
+                 std::string* error_message) {
     if (selected == nullptr || found == nullptr || input.dll_root_count < 0 ||
         (input.dll_root_count > 0 && input.dll_roots == nullptr)) {
         set_error(error_message, "urban DLL root input is invalid");
@@ -98,9 +97,9 @@ void update_direct_classification(SignalTracker* tracker, const UrbanSignalTrack
     }
 
     const double cn0_delta_db = std::abs(input.effective_cn0_dbhz - input.open_cn0_dbhz);
-    const double code_bias_chips = tracker->current_dll_root_valid ? std::abs(tracker->current_dll_code_phase_chips) : 0.0;
-    if (cn0_delta_db >= config.los_multipath_cn0_delta_db ||
-        code_bias_chips >= config.los_multipath_code_bias_chips) {
+    const double code_bias_chips =
+        tracker->current_dll_root_valid ? std::abs(tracker->current_dll_code_phase_chips) : 0.0;
+    if (cn0_delta_db >= config.los_multipath_cn0_delta_db || code_bias_chips >= config.los_multipath_code_bias_chips) {
         tracker->urban_state = UrbanSignalState::kLosMultipath;
     } else {
         tracker->urban_state = UrbanSignalState::kLos;
@@ -208,7 +207,8 @@ bool update_urban_signal_tracker(SignalTracker* tracker, const SimTime& current_
                                  std::string* error_message) {
     if (tracker == nullptr || !valid_time(current_time) || !std::isfinite(input.open_cn0_dbhz) ||
         !valid_effective_cn0(input.effective_cn0_dbhz) || input.dll_root_count < 0 ||
-        (input.dll_root_count > 0 && input.dll_roots == nullptr) || find_signal_definition(tracker->signal_id) == nullptr ||
+        (input.dll_root_count > 0 && input.dll_roots == nullptr) ||
+        find_signal_definition(tracker->signal_id) == nullptr ||
         !validate_signal_tracking_model_config(config, nullptr)) {
         set_error(error_message, "urban signal tracking update has invalid arguments");
         return false;
@@ -292,8 +292,8 @@ bool update_urban_signal_tracker(SignalTracker* tracker, const SimTime& current_
 
     CodeTrackingDllRoot selected_root{};
     bool root_found = false;
-    if (!select_root(input, CodeTrackingDllSelectionMode::TRACKED, tracker->previous_dll_code_phase_sec,
-                     &selected_root, &root_found, error_message)) {
+    if (!select_root(input, CodeTrackingDllSelectionMode::TRACKED, tracker->previous_dll_code_phase_sec, &selected_root,
+                     &root_found, error_message)) {
         return false;
     }
     if (!root_found) {

--- a/src/model/urban_signal_tracking.cpp
+++ b/src/model/urban_signal_tracking.cpp
@@ -1,0 +1,378 @@
+#include "model/signal_tracking.h"
+
+#include "gnss_sim/sim_time.h"
+
+#include <cmath>
+#include <cstdint>
+
+namespace gnss_sim {
+namespace {
+
+void set_error(std::string* error_message, const char* message) {
+    if (error_message != nullptr) {
+        *error_message = message;
+    }
+}
+
+bool valid_time(const SimTime& time) {
+    return time.gps_week >= 0 && time.tow_ns >= 0 && time.tow_ns < GPS_WEEK_NANOSECONDS;
+}
+
+bool valid_effective_cn0(double cn0_dbhz) {
+    return std::isfinite(cn0_dbhz) || (std::isinf(cn0_dbhz) && cn0_dbhz < 0.0);
+}
+
+bool elapsed_at_least(const SimTime& current_time, const SimTime& start_time, std::int64_t required_ns,
+                      bool* reached) {
+    if (reached == nullptr || required_ns < 0) {
+        return false;
+    }
+    std::int64_t elapsed_ns = 0;
+    if (!difference_time_ns(current_time, start_time, &elapsed_ns) || elapsed_ns < 0) {
+        return false;
+    }
+    *reached = elapsed_ns >= required_ns;
+    return true;
+}
+
+void clear_measurement_validity(SignalTracker* tracker) {
+    tracker->lock_time_ns = 0;
+    tracker->psr_valid = false;
+    tracker->doppler_valid = false;
+    tracker->adr_valid = false;
+    tracker->observation_available = false;
+    tracker->carrier_continuity_valid = false;
+}
+
+void clear_dll_continuity(SignalTracker* tracker) {
+    tracker->previous_dll_root_valid = false;
+    tracker->current_dll_root_valid = false;
+    tracker->previous_dll_code_phase_sec = 0.0;
+    tracker->previous_dll_code_phase_chips = 0.0;
+    tracker->current_dll_code_phase_sec = 0.0;
+    tracker->current_dll_code_phase_chips = 0.0;
+    tracker->current_dll_prompt_power = 0.0;
+}
+
+bool select_root(const UrbanSignalTrackingInput& input, CodeTrackingDllSelectionMode mode, double previous_code_phase_sec,
+                 CodeTrackingDllRoot* selected, bool* found, std::string* error_message) {
+    if (selected == nullptr || found == nullptr || input.dll_root_count < 0 ||
+        (input.dll_root_count > 0 && input.dll_roots == nullptr)) {
+        set_error(error_message, "urban DLL root input is invalid");
+        return false;
+    }
+    *found = false;
+    if (input.dll_root_count == 0) {
+        return true;
+    }
+
+    bool has_stable_root = false;
+    for (int index = 0; index < input.dll_root_count; ++index) {
+        if (input.dll_roots[index].stable) {
+            has_stable_root = true;
+            break;
+        }
+    }
+    if (!has_stable_root) {
+        return true;
+    }
+
+    int selected_index = -1;
+    if (!select_code_tracking_dll_root(input.dll_roots, input.dll_root_count, mode, previous_code_phase_sec,
+                                       &selected_index, error_message) ||
+        selected_index < 0 || selected_index >= input.dll_root_count || !input.dll_roots[selected_index].stable) {
+        return false;
+    }
+    *selected = input.dll_roots[selected_index];
+    *found = true;
+    return true;
+}
+
+void update_direct_classification(SignalTracker* tracker, const UrbanSignalTrackingInput& input,
+                                  const SignalTrackingModelConfig& config) {
+    if (!input.direct_line_of_sight) {
+        tracker->urban_state = tracker->phase == SignalTrackingPhase::kTracking && tracker->has_tracking_lock
+                                   ? UrbanSignalState::kNlosTracked
+                                   : UrbanSignalState::kBlocked;
+        return;
+    }
+
+    const double cn0_delta_db = std::abs(input.effective_cn0_dbhz - input.open_cn0_dbhz);
+    const double code_bias_chips = tracker->current_dll_root_valid ? std::abs(tracker->current_dll_code_phase_chips) : 0.0;
+    if (cn0_delta_db >= config.los_multipath_cn0_delta_db ||
+        code_bias_chips >= config.los_multipath_code_bias_chips) {
+        tracker->urban_state = UrbanSignalState::kLosMultipath;
+    } else {
+        tracker->urban_state = UrbanSignalState::kLos;
+    }
+}
+
+void begin_tracking_loss(SignalTracker* tracker, const SimTime& current_time, SignalTrackingLossReason reason) {
+    tracker->phase = SignalTrackingPhase::kSearching;
+    tracker->acquisition_context = AcquisitionContext::kReacquisition;
+    tracker->state_since = current_time;
+    tracker->search_ready_time = current_time;
+    tracker->scheduled = false;
+    tracker->has_tracking_lock = false;
+    tracker->reacquisition_pending = true;
+    tracker->reacquisition_event = false;
+    tracker->loss_reason = reason;
+    tracker->above_acquisition_threshold_active = false;
+    tracker->below_tracking_threshold_active = false;
+    clear_measurement_validity(tracker);
+    clear_dll_continuity(tracker);
+}
+
+bool enter_tracking(SignalTracker* tracker, const SimTime& current_time, const SignalTrackingModelConfig& config,
+                    const CodeTrackingDllRoot& selected_root, std::string* error_message) {
+    SimTime psr_valid_time{};
+    SimTime doppler_valid_time{};
+    SimTime adr_valid_time{};
+    if (!add_time_ns(current_time, config.psr_valid_delay_ns, &psr_valid_time) ||
+        !add_time_ns(current_time, config.doppler_valid_delay_ns, &doppler_valid_time) ||
+        !add_time_ns(current_time, config.adr_valid_delay_ns, &adr_valid_time)) {
+        set_error(error_message, "urban signal tracking validity time overflows simulation time");
+        return false;
+    }
+
+    tracker->phase = SignalTrackingPhase::kTracking;
+    tracker->state_since = current_time;
+    tracker->tracking_start_time = current_time;
+    tracker->psr_valid_time = psr_valid_time;
+    tracker->doppler_valid_time = doppler_valid_time;
+    tracker->adr_valid_time = adr_valid_time;
+    tracker->has_tracking_lock = true;
+    tracker->lock_time_ns = 0;
+    tracker->psr_valid = false;
+    tracker->doppler_valid = false;
+    tracker->adr_valid = false;
+    tracker->observation_available = false;
+    tracker->carrier_continuity_valid = false;
+    tracker->reacquisition_event = tracker->acquisition_context == AcquisitionContext::kReacquisition;
+    tracker->reacquisition_pending = false;
+    tracker->above_acquisition_threshold_active = false;
+    tracker->below_tracking_threshold_active = false;
+    tracker->current_dll_root_valid = true;
+    tracker->previous_dll_root_valid = true;
+    tracker->current_dll_code_phase_sec = selected_root.code_phase_sec;
+    tracker->current_dll_code_phase_chips = selected_root.code_phase_chips;
+    tracker->current_dll_prompt_power = selected_root.prompt_power;
+    tracker->previous_dll_code_phase_sec = selected_root.code_phase_sec;
+    tracker->previous_dll_code_phase_chips = selected_root.code_phase_chips;
+    return true;
+}
+
+bool update_acquisition_qualification(SignalTracker* tracker, const SimTime& current_time,
+                                      const UrbanSignalTrackingInput& input, const SignalTrackingModelConfig& config,
+                                      bool* qualified, std::string* error_message) {
+    if (qualified == nullptr) {
+        set_error(error_message, "urban acquisition qualification output is null");
+        return false;
+    }
+    *qualified = false;
+    if (input.effective_cn0_dbhz < config.acquisition_cn0_threshold_dbhz) {
+        tracker->above_acquisition_threshold_active = false;
+        return true;
+    }
+    if (!tracker->above_acquisition_threshold_active) {
+        tracker->above_acquisition_threshold_active = true;
+        tracker->above_acquisition_threshold_since = current_time;
+    }
+    if (!elapsed_at_least(current_time, tracker->above_acquisition_threshold_since,
+                          config.acquisition_cn0_persistence_ns, qualified)) {
+        set_error(error_message, "cannot compute urban acquisition qualification duration");
+        return false;
+    }
+    return true;
+}
+
+bool update_tracking_validity(SignalTracker* tracker, const SimTime& current_time, std::string* error_message) {
+    std::int64_t lock_time_ns = 0;
+    if (!difference_time_ns(current_time, tracker->tracking_start_time, &lock_time_ns) || lock_time_ns < 0) {
+        set_error(error_message, "cannot compute urban signal lock time");
+        return false;
+    }
+    tracker->lock_time_ns = lock_time_ns;
+    tracker->psr_valid = compare_sim_time(current_time, tracker->psr_valid_time) >= 0;
+    tracker->doppler_valid = compare_sim_time(current_time, tracker->doppler_valid_time) >= 0;
+    tracker->adr_valid = compare_sim_time(current_time, tracker->adr_valid_time) >= 0;
+    tracker->observation_available = tracker->psr_valid;
+    tracker->carrier_continuity_valid = tracker->adr_valid;
+    return true;
+}
+
+} // namespace
+
+bool update_urban_signal_tracker(SignalTracker* tracker, const SimTime& current_time,
+                                 const UrbanSignalTrackingInput& input, const SignalTrackingModelConfig& config,
+                                 std::string* error_message) {
+    if (tracker == nullptr || !valid_time(current_time) || !std::isfinite(input.open_cn0_dbhz) ||
+        !valid_effective_cn0(input.effective_cn0_dbhz) || input.dll_root_count < 0 ||
+        (input.dll_root_count > 0 && input.dll_roots == nullptr) || find_signal_definition(tracker->signal_id) == nullptr ||
+        !validate_signal_tracking_model_config(config, nullptr)) {
+        set_error(error_message, "urban signal tracking update has invalid arguments");
+        return false;
+    }
+    if (compare_sim_time(current_time, tracker->state_since) < 0) {
+        set_error(error_message, "urban signal tracking update precedes tracker state time");
+        return false;
+    }
+
+    tracker->reacquisition_event = false;
+    tracker->cn0_dbhz = input.effective_cn0_dbhz;
+    tracker->current_dll_root_valid = false;
+
+    if (!input.signal_available) {
+        const bool had_lock = tracker->phase == SignalTrackingPhase::kTracking && tracker->has_tracking_lock;
+        tracker->phase = SignalTrackingPhase::kSignalOff;
+        tracker->state_since = current_time;
+        tracker->scheduled = false;
+        tracker->has_tracking_lock = false;
+        tracker->reacquisition_pending = false;
+        tracker->above_acquisition_threshold_active = false;
+        tracker->below_tracking_threshold_active = false;
+        if (had_lock) {
+            tracker->loss_reason = SignalTrackingLossReason::kSignalUnavailable;
+        }
+        clear_measurement_validity(tracker);
+        clear_dll_continuity(tracker);
+        update_direct_classification(tracker, input, config);
+        return true;
+    }
+
+    if (!tracker->scheduled) {
+        if (!tracker->reacquisition_pending) {
+            set_error(error_message, "urban signal is available but acquisition has not been scheduled");
+            return false;
+        }
+        tracker->phase = SignalTrackingPhase::kSearching;
+        clear_measurement_validity(tracker);
+        update_direct_classification(tracker, input, config);
+        return true;
+    }
+
+    if (tracker->phase != SignalTrackingPhase::kTracking || !tracker->has_tracking_lock) {
+        if (compare_sim_time(current_time, tracker->search_ready_time) < 0) {
+            tracker->phase = SignalTrackingPhase::kSearching;
+            tracker->above_acquisition_threshold_active = false;
+            clear_measurement_validity(tracker);
+            update_direct_classification(tracker, input, config);
+            return true;
+        }
+
+        tracker->phase = SignalTrackingPhase::kAcquiring;
+        bool qualified = false;
+        if (!update_acquisition_qualification(tracker, current_time, input, config, &qualified, error_message)) {
+            return false;
+        }
+
+        CodeTrackingDllRoot selected_root{};
+        bool root_found = false;
+        if (!select_root(input, CodeTrackingDllSelectionMode::ACQUISITION, 0.0, &selected_root, &root_found,
+                         error_message)) {
+            return false;
+        }
+        if (root_found) {
+            tracker->current_dll_root_valid = true;
+            tracker->current_dll_code_phase_sec = selected_root.code_phase_sec;
+            tracker->current_dll_code_phase_chips = selected_root.code_phase_chips;
+            tracker->current_dll_prompt_power = selected_root.prompt_power;
+        }
+
+        if (qualified && root_found && compare_sim_time(current_time, tracker->acquisition_complete_time) >= 0) {
+            if (!enter_tracking(tracker, current_time, config, selected_root, error_message)) {
+                return false;
+            }
+        } else {
+            clear_measurement_validity(tracker);
+        }
+        update_direct_classification(tracker, input, config);
+        return true;
+    }
+
+    CodeTrackingDllRoot selected_root{};
+    bool root_found = false;
+    if (!select_root(input, CodeTrackingDllSelectionMode::TRACKED, tracker->previous_dll_code_phase_sec,
+                     &selected_root, &root_found, error_message)) {
+        return false;
+    }
+    if (!root_found) {
+        begin_tracking_loss(tracker, current_time, SignalTrackingLossReason::kNoStableDllRoot);
+        update_direct_classification(tracker, input, config);
+        return true;
+    }
+
+    tracker->current_dll_root_valid = true;
+    tracker->current_dll_code_phase_sec = selected_root.code_phase_sec;
+    tracker->current_dll_code_phase_chips = selected_root.code_phase_chips;
+    tracker->current_dll_prompt_power = selected_root.prompt_power;
+
+    if (tracker->previous_dll_root_valid &&
+        std::abs(selected_root.code_phase_chips - tracker->previous_dll_code_phase_chips) >
+            config.dll_root_jump_threshold_chips) {
+        begin_tracking_loss(tracker, current_time, SignalTrackingLossReason::kAbruptDllRootSwitch);
+        update_direct_classification(tracker, input, config);
+        return true;
+    }
+
+    if (input.effective_cn0_dbhz < config.minimum_tracking_cn0_dbhz) {
+        if (!tracker->below_tracking_threshold_active) {
+            tracker->below_tracking_threshold_active = true;
+            tracker->below_tracking_threshold_since = current_time;
+        }
+        bool loss_qualified = false;
+        if (!elapsed_at_least(current_time, tracker->below_tracking_threshold_since,
+                              config.tracking_loss_cn0_persistence_ns, &loss_qualified)) {
+            set_error(error_message, "cannot compute urban tracking-loss qualification duration");
+            return false;
+        }
+        if (loss_qualified) {
+            begin_tracking_loss(tracker, current_time, SignalTrackingLossReason::kLowCn0);
+            update_direct_classification(tracker, input, config);
+            return true;
+        }
+    } else {
+        tracker->below_tracking_threshold_active = false;
+    }
+
+    tracker->previous_dll_root_valid = true;
+    tracker->previous_dll_code_phase_sec = selected_root.code_phase_sec;
+    tracker->previous_dll_code_phase_chips = selected_root.code_phase_chips;
+    if (!update_tracking_validity(tracker, current_time, error_message)) {
+        return false;
+    }
+    update_direct_classification(tracker, input, config);
+    return true;
+}
+
+const char* urban_signal_state_name(UrbanSignalState state) {
+    switch (state) {
+        case UrbanSignalState::kLos:
+            return "LOS";
+        case UrbanSignalState::kLosMultipath:
+            return "LOS_MULTIPATH";
+        case UrbanSignalState::kNlosTracked:
+            return "NLOS_TRACKED";
+        case UrbanSignalState::kBlocked:
+            return "BLOCKED";
+    }
+    return "UNKNOWN";
+}
+
+const char* signal_tracking_loss_reason_name(SignalTrackingLossReason reason) {
+    switch (reason) {
+        case SignalTrackingLossReason::kNone:
+            return "NONE";
+        case SignalTrackingLossReason::kSignalUnavailable:
+            return "SIGNAL_UNAVAILABLE";
+        case SignalTrackingLossReason::kLowCn0:
+            return "LOW_CN0";
+        case SignalTrackingLossReason::kNoStableDllRoot:
+            return "NO_STABLE_DLL_ROOT";
+        case SignalTrackingLossReason::kAbruptDllRootSwitch:
+            return "ABRUPT_DLL_ROOT_SWITCH";
+    }
+    return "UNKNOWN";
+}
+
+} // namespace gnss_sim

--- a/tests/unit/test_urban_signal_tracking.cpp
+++ b/tests/unit/test_urban_signal_tracking.cpp
@@ -88,9 +88,8 @@ void schedule_existing(gnss_sim::SignalTracker* tracker, const gnss_sim::SimTime
         << error_message;
 }
 
-void acquire_immediately(gnss_sim::SignalTracker* tracker, gnss_sim::SignalId signal_id,
-                         const gnss_sim::SimTime& start, gnss_sim::SignalTrackingModelConfig* config,
-                         bool direct_line_of_sight = true) {
+void acquire_immediately(gnss_sim::SignalTracker* tracker, gnss_sim::SignalId signal_id, const gnss_sim::SimTime& start,
+                         gnss_sim::SignalTrackingModelConfig* config, bool direct_line_of_sight = true) {
     ASSERT_NE(config, nullptr);
     config->acquisition_cn0_persistence_ns = 0;
     schedule(tracker, signal_id, start, gnss_sim::AcquisitionContext::kHot, *config);
@@ -323,8 +322,8 @@ TEST(UrbanSignalTrackingClassification, UsesCommonCn0AndDllResultRatherThanRefle
 
     const gnss_sim::CodeTrackingDllRoot code_biased = root_for(gps_l1, 0.02);
     ASSERT_TRUE(add_ms(start, 3, &current));
-    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&tracker, current, input(45.0, 45.0, true, &code_biased, 1), config,
-                                                      &error_message));
+    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&tracker, current, input(45.0, 45.0, true, &code_biased, 1),
+                                                      config, &error_message));
     EXPECT_EQ(tracker.urban_state, gnss_sim::UrbanSignalState::kLosMultipath);
 
     ASSERT_TRUE(add_ms(start, 4, &current));

--- a/tests/unit/test_urban_signal_tracking.cpp
+++ b/tests/unit/test_urban_signal_tracking.cpp
@@ -1,0 +1,412 @@
+#include "gnss/signal_definitions.h"
+#include "gnss_sim/sim_time.h"
+#include "model/signal_tracking.h"
+
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <string>
+
+namespace {
+
+constexpr std::int64_t kMs = 1000000LL;
+
+bool add_ms(const gnss_sim::SimTime& time, std::int64_t milliseconds, gnss_sim::SimTime* result) {
+    return gnss_sim::add_time_ns(time, milliseconds * kMs, result);
+}
+
+gnss_sim::DelayDistribution fixed_delay(std::int64_t delay_ns) {
+    return {delay_ns, delay_ns, delay_ns, delay_ns};
+}
+
+gnss_sim::SignalTrackingModelConfig urban_test_config() {
+    gnss_sim::SignalTrackingModelConfig config = gnss_sim::default_signal_tracking_model_config();
+    config.hot_common_startup = fixed_delay(0);
+    config.warm_common_startup = fixed_delay(0);
+    config.warm_search_uncertainty = fixed_delay(0);
+    for (int index = 0; index < 4; ++index) {
+        config.hot_signal_acquisition[index] = fixed_delay(0);
+        config.reacquisition[index] = fixed_delay(0);
+    }
+    config.psr_valid_delay_ns = 100 * kMs;
+    config.doppler_valid_delay_ns = 150 * kMs;
+    config.adr_valid_delay_ns = 500 * kMs;
+    return config;
+}
+
+const gnss_sim::SignalDefinition& signal(gnss_sim::SignalId signal_id) {
+    const gnss_sim::SignalDefinition* definition = gnss_sim::find_signal_definition(signal_id);
+    EXPECT_NE(definition, nullptr);
+    return *definition;
+}
+
+gnss_sim::CodeTrackingDllRoot root_for(const gnss_sim::SignalDefinition& definition, double code_phase_chips,
+                                       double prompt_power = 1.0, bool stable = true) {
+    gnss_sim::CodeTrackingDllRoot root{};
+    root.code_phase_chips = code_phase_chips;
+    root.code_phase_sec = code_phase_chips / definition.code_correlation.chip_rate_hz;
+    root.discriminator = 0.0;
+    root.discriminator_slope_per_chip = stable ? 1.0 : -1.0;
+    root.prompt_power = prompt_power;
+    root.stable = stable;
+    return root;
+}
+
+gnss_sim::UrbanSignalTrackingInput input(double open_cn0_dbhz, double effective_cn0_dbhz, bool direct_line_of_sight,
+                                         const gnss_sim::CodeTrackingDllRoot* roots, int root_count) {
+    gnss_sim::UrbanSignalTrackingInput value{};
+    value.signal_available = true;
+    value.direct_line_of_sight = direct_line_of_sight;
+    value.open_cn0_dbhz = open_cn0_dbhz;
+    value.effective_cn0_dbhz = effective_cn0_dbhz;
+    value.dll_roots = roots;
+    value.dll_root_count = root_count;
+    return value;
+}
+
+void schedule(gnss_sim::SignalTracker* tracker, gnss_sim::SignalId signal_id, const gnss_sim::SimTime& start,
+              gnss_sim::AcquisitionContext context, const gnss_sim::SignalTrackingModelConfig& config,
+              std::uint64_t seed = 1U) {
+    gnss_sim::reset_signal_tracker(tracker, signal_id, start);
+    gnss_sim::DeterministicRng rng{};
+    gnss_sim::seed_rng(&rng, seed);
+    const gnss_sim::Cn0Model cn0_model = gnss_sim::make_builtin_cn0_model(seed);
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::schedule_signal_acquisition(tracker, context, start, start, 60.0, cn0_model, config, &rng,
+                                                      &error_message))
+        << error_message;
+}
+
+void schedule_existing(gnss_sim::SignalTracker* tracker, const gnss_sim::SimTime& start,
+                       gnss_sim::AcquisitionContext context, const gnss_sim::SignalTrackingModelConfig& config,
+                       std::uint64_t seed = 1U) {
+    gnss_sim::DeterministicRng rng{};
+    gnss_sim::seed_rng(&rng, seed);
+    const gnss_sim::Cn0Model cn0_model = gnss_sim::make_builtin_cn0_model(seed);
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::schedule_signal_acquisition(tracker, context, start, start, 60.0, cn0_model, config, &rng,
+                                                      &error_message))
+        << error_message;
+}
+
+void acquire_immediately(gnss_sim::SignalTracker* tracker, gnss_sim::SignalId signal_id,
+                         const gnss_sim::SimTime& start, gnss_sim::SignalTrackingModelConfig* config,
+                         bool direct_line_of_sight = true) {
+    ASSERT_NE(config, nullptr);
+    config->acquisition_cn0_persistence_ns = 0;
+    schedule(tracker, signal_id, start, gnss_sim::AcquisitionContext::kHot, *config);
+    const gnss_sim::SignalDefinition& definition = signal(signal_id);
+    const gnss_sim::CodeTrackingDllRoot root = root_for(definition, 0.0);
+    const gnss_sim::UrbanSignalTrackingInput update = input(45.0, 45.0, direct_line_of_sight, &root, 1);
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(tracker, start, update, *config, &error_message))
+        << error_message;
+    ASSERT_EQ(tracker->phase, gnss_sim::SignalTrackingPhase::kTracking);
+}
+
+TEST(UrbanSignalTrackingConfig, FrozenDefaultsAndHysteresisAreExplicit) {
+    gnss_sim::SignalTrackingModelConfig config = gnss_sim::default_signal_tracking_model_config();
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::validate_signal_tracking_model_config(config, &error_message));
+    EXPECT_DOUBLE_EQ(config.minimum_tracking_cn0_dbhz, 10.0);
+    EXPECT_DOUBLE_EQ(config.acquisition_cn0_threshold_dbhz, 18.0);
+    EXPECT_EQ(config.acquisition_cn0_persistence_ns, 200 * kMs);
+    EXPECT_EQ(config.tracking_loss_cn0_persistence_ns, 500 * kMs);
+    EXPECT_DOUBLE_EQ(config.dll_root_jump_threshold_chips, 0.25);
+    EXPECT_DOUBLE_EQ(config.los_multipath_cn0_delta_db, 0.5);
+    EXPECT_DOUBLE_EQ(config.los_multipath_code_bias_chips, 0.02);
+
+    config.acquisition_cn0_threshold_dbhz = config.minimum_tracking_cn0_dbhz;
+    EXPECT_FALSE(gnss_sim::validate_signal_tracking_model_config(config, &error_message));
+}
+
+TEST(UrbanSignalTrackingAcquisition, ThresholdQualificationMustBeContinuousForTwoHundredMilliseconds) {
+    const gnss_sim::SignalTrackingModelConfig config = urban_test_config();
+    gnss_sim::SimTime start{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2400, 100000.0, &start));
+    gnss_sim::SignalTracker tracker{};
+    schedule(&tracker, gnss_sim::SignalId::kGpsL1Ca, start, gnss_sim::AcquisitionContext::kHot, config);
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    const gnss_sim::CodeTrackingDllRoot root = root_for(gps_l1, 0.0);
+    std::string error_message;
+
+    gnss_sim::SimTime current = start;
+    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&tracker, current, input(18.0, 18.0, true, &root, 1), config,
+                                                      &error_message));
+    EXPECT_EQ(tracker.phase, gnss_sim::SignalTrackingPhase::kAcquiring);
+
+    ASSERT_TRUE(add_ms(start, 150, &current));
+    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&tracker, current, input(18.0, 18.0, true, &root, 1), config,
+                                                      &error_message));
+    EXPECT_EQ(tracker.phase, gnss_sim::SignalTrackingPhase::kAcquiring);
+
+    ASSERT_TRUE(add_ms(start, 175, &current));
+    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&tracker, current, input(18.0, 17.9, true, &root, 1), config,
+                                                      &error_message));
+    EXPECT_FALSE(tracker.above_acquisition_threshold_active);
+
+    ASSERT_TRUE(add_ms(start, 200, &current));
+    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&tracker, current, input(18.0, 18.0, true, &root, 1), config,
+                                                      &error_message));
+    ASSERT_TRUE(add_ms(start, 399, &current));
+    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&tracker, current, input(18.0, 18.0, true, &root, 1), config,
+                                                      &error_message));
+    EXPECT_EQ(tracker.phase, gnss_sim::SignalTrackingPhase::kAcquiring);
+
+    ASSERT_TRUE(add_ms(start, 400, &current));
+    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&tracker, current, input(18.0, 18.0, true, &root, 1), config,
+                                                      &error_message));
+    EXPECT_EQ(tracker.phase, gnss_sim::SignalTrackingPhase::kTracking);
+    EXPECT_EQ(tracker.lock_time_ns, 0);
+}
+
+TEST(UrbanSignalTrackingCn0, WeakTrackedSignalUsesFiveHundredMillisecondLossPersistence) {
+    gnss_sim::SignalTrackingModelConfig config = urban_test_config();
+    gnss_sim::SimTime start{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2400, 110000.0, &start));
+    gnss_sim::SignalTracker tracker{};
+    acquire_immediately(&tracker, gnss_sim::SignalId::kGpsL1Ca, start, &config, false);
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    const gnss_sim::CodeTrackingDllRoot root = root_for(gps_l1, 0.0);
+    std::string error_message;
+    gnss_sim::SimTime current{};
+
+    ASSERT_TRUE(add_ms(start, 50, &current));
+    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&tracker, current, input(12.0, 12.0, false, &root, 1), config,
+                                                      &error_message));
+    EXPECT_EQ(tracker.phase, gnss_sim::SignalTrackingPhase::kTracking);
+    EXPECT_EQ(tracker.urban_state, gnss_sim::UrbanSignalState::kNlosTracked);
+
+    ASSERT_TRUE(add_ms(start, 100, &current));
+    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&tracker, current, input(9.0, 9.0, false, &root, 1), config,
+                                                      &error_message));
+    ASSERT_TRUE(add_ms(start, 599, &current));
+    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&tracker, current, input(9.0, 9.0, false, &root, 1), config,
+                                                      &error_message));
+    EXPECT_EQ(tracker.phase, gnss_sim::SignalTrackingPhase::kTracking);
+    EXPECT_TRUE(tracker.has_tracking_lock);
+
+    ASSERT_TRUE(add_ms(start, 600, &current));
+    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&tracker, current, input(9.0, 9.0, false, &root, 1), config,
+                                                      &error_message));
+    EXPECT_EQ(tracker.phase, gnss_sim::SignalTrackingPhase::kSearching);
+    EXPECT_FALSE(tracker.has_tracking_lock);
+    EXPECT_TRUE(tracker.reacquisition_pending);
+    EXPECT_EQ(tracker.loss_reason, gnss_sim::SignalTrackingLossReason::kLowCn0);
+    EXPECT_EQ(tracker.urban_state, gnss_sim::UrbanSignalState::kBlocked);
+    EXPECT_EQ(tracker.lock_time_ns, 0);
+    EXPECT_FALSE(tracker.psr_valid);
+    EXPECT_FALSE(tracker.doppler_valid);
+    EXPECT_FALSE(tracker.adr_valid);
+    EXPECT_FALSE(tracker.carrier_continuity_valid);
+}
+
+TEST(UrbanSignalTrackingReacquisition, RequiresCn0PersistenceAndExistingReacquisitionDelay) {
+    gnss_sim::SignalTrackingModelConfig config = urban_test_config();
+    for (int index = 0; index < 4; ++index) {
+        config.reacquisition[index] = fixed_delay(300 * kMs);
+    }
+    config.acquisition_cn0_persistence_ns = 0;
+    gnss_sim::SimTime start{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2400, 120000.0, &start));
+    gnss_sim::SignalTracker tracker{};
+    acquire_immediately(&tracker, gnss_sim::SignalId::kGpsL1Ca, start, &config, false);
+    config.acquisition_cn0_persistence_ns = 200 * kMs;
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    const gnss_sim::CodeTrackingDllRoot root = root_for(gps_l1, 0.0);
+    std::string error_message;
+    gnss_sim::SimTime loss_start{};
+    gnss_sim::SimTime current{};
+
+    ASSERT_TRUE(add_ms(start, 100, &loss_start));
+    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&tracker, loss_start, input(9.0, 9.0, false, &root, 1), config,
+                                                      &error_message));
+    ASSERT_TRUE(add_ms(start, 600, &current));
+    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&tracker, current, input(9.0, 9.0, false, &root, 1), config,
+                                                      &error_message));
+    ASSERT_TRUE(tracker.reacquisition_pending);
+
+    schedule_existing(&tracker, current, gnss_sim::AcquisitionContext::kReacquisition, config, 22U);
+    const gnss_sim::SimTime reacquisition_start = current;
+
+    ASSERT_TRUE(add_ms(reacquisition_start, 300, &current));
+    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&tracker, current, input(15.0, 15.0, false, &root, 1), config,
+                                                      &error_message));
+    EXPECT_EQ(tracker.phase, gnss_sim::SignalTrackingPhase::kAcquiring);
+
+    ASSERT_TRUE(add_ms(reacquisition_start, 400, &current));
+    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&tracker, current, input(18.0, 18.0, false, &root, 1), config,
+                                                      &error_message));
+    ASSERT_TRUE(add_ms(reacquisition_start, 599, &current));
+    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&tracker, current, input(18.0, 18.0, false, &root, 1), config,
+                                                      &error_message));
+    EXPECT_EQ(tracker.phase, gnss_sim::SignalTrackingPhase::kAcquiring);
+
+    ASSERT_TRUE(add_ms(reacquisition_start, 600, &current));
+    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&tracker, current, input(18.0, 18.0, false, &root, 1), config,
+                                                      &error_message));
+    EXPECT_EQ(tracker.phase, gnss_sim::SignalTrackingPhase::kTracking);
+    EXPECT_TRUE(tracker.reacquisition_event);
+    EXPECT_EQ(tracker.lock_time_ns, 0);
+    EXPECT_FALSE(tracker.adr_valid);
+    EXPECT_FALSE(tracker.carrier_continuity_valid);
+    EXPECT_EQ(tracker.loss_reason, gnss_sim::SignalTrackingLossReason::kLowCn0);
+
+    ASSERT_TRUE(add_ms(reacquisition_start, 601, &current));
+    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&tracker, current, input(18.0, 18.0, false, &root, 1), config,
+                                                      &error_message));
+    EXPECT_FALSE(tracker.reacquisition_event);
+}
+
+TEST(UrbanSignalTrackingDll, SmoothRootMotionPreservesLockButAbruptSwitchDoesNot) {
+    gnss_sim::SignalTrackingModelConfig config = urban_test_config();
+    gnss_sim::SimTime start{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2400, 130000.0, &start));
+    gnss_sim::SignalTracker tracker{};
+    acquire_immediately(&tracker, gnss_sim::SignalId::kGpsL1Ca, start, &config);
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    std::string error_message;
+    gnss_sim::SimTime current{};
+
+    const gnss_sim::CodeTrackingDllRoot smooth = root_for(gps_l1, 0.20);
+    ASSERT_TRUE(add_ms(start, 100, &current));
+    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&tracker, current, input(45.0, 45.0, true, &smooth, 1), config,
+                                                      &error_message));
+    EXPECT_EQ(tracker.phase, gnss_sim::SignalTrackingPhase::kTracking);
+    EXPECT_NEAR(tracker.current_dll_code_phase_chips, 0.20, 1.0e-15);
+
+    const gnss_sim::CodeTrackingDllRoot abrupt = root_for(gps_l1, 0.46);
+    ASSERT_TRUE(add_ms(start, 200, &current));
+    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&tracker, current, input(45.0, 45.0, true, &abrupt, 1), config,
+                                                      &error_message));
+    EXPECT_EQ(tracker.phase, gnss_sim::SignalTrackingPhase::kSearching);
+    EXPECT_EQ(tracker.loss_reason, gnss_sim::SignalTrackingLossReason::kAbruptDllRootSwitch);
+    EXPECT_TRUE(tracker.reacquisition_pending);
+}
+
+TEST(UrbanSignalTrackingDll, MissingStableRootCausesImmediateLoss) {
+    gnss_sim::SignalTrackingModelConfig config = urban_test_config();
+    gnss_sim::SimTime start{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2400, 140000.0, &start));
+    gnss_sim::SignalTracker tracker{};
+    acquire_immediately(&tracker, gnss_sim::SignalId::kGpsL1Ca, start, &config);
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    const gnss_sim::CodeTrackingDllRoot unstable = root_for(gps_l1, 0.0, 1.0, false);
+    gnss_sim::SimTime current{};
+    ASSERT_TRUE(add_ms(start, 1, &current));
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&tracker, current, input(45.0, 45.0, true, &unstable, 1), config,
+                                                      &error_message));
+    EXPECT_EQ(tracker.phase, gnss_sim::SignalTrackingPhase::kSearching);
+    EXPECT_EQ(tracker.loss_reason, gnss_sim::SignalTrackingLossReason::kNoStableDllRoot);
+}
+
+TEST(UrbanSignalTrackingClassification, UsesCommonCn0AndDllResultRatherThanReflectionPresence) {
+    gnss_sim::SignalTrackingModelConfig config = urban_test_config();
+    gnss_sim::SimTime start{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2400, 150000.0, &start));
+    gnss_sim::SignalTracker tracker{};
+    acquire_immediately(&tracker, gnss_sim::SignalId::kGpsL1Ca, start, &config, true);
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    std::string error_message;
+    gnss_sim::SimTime current{};
+
+    const gnss_sim::CodeTrackingDllRoot zero_bias = root_for(gps_l1, 0.0);
+    ASSERT_TRUE(add_ms(start, 1, &current));
+    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&tracker, current, input(45.0, 45.0, true, &zero_bias, 1), config,
+                                                      &error_message));
+    EXPECT_EQ(tracker.urban_state, gnss_sim::UrbanSignalState::kLos);
+
+    ASSERT_TRUE(add_ms(start, 2, &current));
+    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&tracker, current, input(45.0, 44.5, true, &zero_bias, 1), config,
+                                                      &error_message));
+    EXPECT_EQ(tracker.urban_state, gnss_sim::UrbanSignalState::kLosMultipath);
+
+    const gnss_sim::CodeTrackingDllRoot code_biased = root_for(gps_l1, 0.02);
+    ASSERT_TRUE(add_ms(start, 3, &current));
+    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&tracker, current, input(45.0, 45.0, true, &code_biased, 1), config,
+                                                      &error_message));
+    EXPECT_EQ(tracker.urban_state, gnss_sim::UrbanSignalState::kLosMultipath);
+
+    ASSERT_TRUE(add_ms(start, 4, &current));
+    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&tracker, current, input(45.0, 45.0, false, &code_biased, 1),
+                                                      config, &error_message));
+    EXPECT_EQ(tracker.urban_state, gnss_sim::UrbanSignalState::kNlosTracked);
+
+    gnss_sim::SignalTrackingModelConfig acquiring_config = urban_test_config();
+    acquiring_config.acquisition_cn0_persistence_ns = 200 * kMs;
+    gnss_sim::SignalTracker acquiring{};
+    schedule(&acquiring, gnss_sim::SignalId::kGpsL1Ca, start, gnss_sim::AcquisitionContext::kHot, acquiring_config);
+    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&acquiring, start, input(45.0, 45.0, false, &zero_bias, 1),
+                                                      acquiring_config, &error_message));
+    EXPECT_EQ(acquiring.urban_state, gnss_sim::UrbanSignalState::kBlocked);
+}
+
+TEST(UrbanSignalTrackingDll, ChipDomainJumpThresholdWorksAcrossDifferentCodeRates) {
+    gnss_sim::SignalTrackingModelConfig config = urban_test_config();
+    gnss_sim::SimTime start{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2400, 160000.0, &start));
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    const gnss_sim::SignalDefinition& gps_l5 = signal(gnss_sim::SignalId::kGpsL5Q);
+    ASSERT_NE(gps_l1.code_correlation.chip_rate_hz, gps_l5.code_correlation.chip_rate_hz);
+
+    gnss_sim::SignalTracker l1{};
+    gnss_sim::SignalTracker l5{};
+    acquire_immediately(&l1, gps_l1.signal_id, start, &config);
+    acquire_immediately(&l5, gps_l5.signal_id, start, &config);
+
+    const gnss_sim::CodeTrackingDllRoot l1_smooth = root_for(gps_l1, 0.20);
+    const gnss_sim::CodeTrackingDllRoot l5_smooth = root_for(gps_l5, 0.20);
+    EXPECT_NE(l1_smooth.code_phase_sec, l5_smooth.code_phase_sec);
+    gnss_sim::SimTime current{};
+    ASSERT_TRUE(add_ms(start, 10, &current));
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&l1, current, input(45.0, 45.0, true, &l1_smooth, 1), config,
+                                                      &error_message));
+    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&l5, current, input(45.0, 45.0, true, &l5_smooth, 1), config,
+                                                      &error_message));
+    EXPECT_EQ(l1.phase, gnss_sim::SignalTrackingPhase::kTracking);
+    EXPECT_EQ(l5.phase, gnss_sim::SignalTrackingPhase::kTracking);
+
+    const gnss_sim::CodeTrackingDllRoot l1_abrupt = root_for(gps_l1, 0.46);
+    const gnss_sim::CodeTrackingDllRoot l5_abrupt = root_for(gps_l5, 0.46);
+    ASSERT_TRUE(add_ms(start, 20, &current));
+    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&l1, current, input(45.0, 45.0, true, &l1_abrupt, 1), config,
+                                                      &error_message));
+    ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&l5, current, input(45.0, 45.0, true, &l5_abrupt, 1), config,
+                                                      &error_message));
+    EXPECT_EQ(l1.loss_reason, gnss_sim::SignalTrackingLossReason::kAbruptDllRootSwitch);
+    EXPECT_EQ(l5.loss_reason, gnss_sim::SignalTrackingLossReason::kAbruptDllRootSwitch);
+}
+
+TEST(UrbanSignalTrackingDeterminism, IdenticalInputsProduceIdenticalStateSequence) {
+    gnss_sim::SignalTrackingModelConfig config = urban_test_config();
+    config.acquisition_cn0_persistence_ns = 0;
+    gnss_sim::SimTime start{};
+    ASSERT_TRUE(gnss_sim::sim_time_from_week_sow(2400, 170000.0, &start));
+    gnss_sim::SignalTracker first{};
+    gnss_sim::SignalTracker second{};
+    schedule(&first, gnss_sim::SignalId::kGalileoE1, start, gnss_sim::AcquisitionContext::kHot, config, 99U);
+    schedule(&second, gnss_sim::SignalId::kGalileoE1, start, gnss_sim::AcquisitionContext::kHot, config, 99U);
+    const gnss_sim::SignalDefinition& gal_e1 = signal(gnss_sim::SignalId::kGalileoE1);
+    const gnss_sim::CodeTrackingDllRoot root = root_for(gal_e1, 0.0);
+    const std::int64_t offsets_ms[] = {0, 100, 300, 600};
+    const double cn0_dbhz[] = {45.0, 9.0, 9.0, 9.0};
+    std::string first_error;
+    std::string second_error;
+
+    for (int index = 0; index < 4; ++index) {
+        gnss_sim::SimTime current{};
+        ASSERT_TRUE(add_ms(start, offsets_ms[index], &current));
+        const gnss_sim::UrbanSignalTrackingInput update = input(cn0_dbhz[index], cn0_dbhz[index], false, &root, 1);
+        ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&first, current, update, config, &first_error));
+        ASSERT_TRUE(gnss_sim::update_urban_signal_tracker(&second, current, update, config, &second_error));
+        EXPECT_EQ(first.phase, second.phase);
+        EXPECT_EQ(first.urban_state, second.urban_state);
+        EXPECT_EQ(first.loss_reason, second.loss_reason);
+        EXPECT_EQ(first.lock_time_ns, second.lock_time_ns);
+        EXPECT_EQ(first.reacquisition_pending, second.reacquisition_pending);
+        EXPECT_EQ(first.previous_dll_code_phase_chips, second.previous_dll_code_phase_chips);
+    }
+}
+
+} // namespace


### PR DESCRIPTION
Closes #121

## Summary
- extend the existing per-signal `SignalTracker`; no parallel acquisition/tracking state machine
- add the four urban propagation/tracking states: LOS / LOS_MULTIPATH / NLOS_TRACKED / BLOCKED
- add configurable V1 defaults: 10 dB-Hz tracking, 18 dB-Hz acquisition/reacquisition, 200 ms qualification, 500 ms loss persistence, >0.25-chip abrupt DLL-root loss
- consume #119 stable roots directly for acquisition/tracked selection and continuity
- consume #120 open/effective C/N0 values for physical eligibility and LOS_MULTIPATH significance
- retain the existing seeded startup/reacquisition delay distributions
- reset observation/lock/ADR/carrier continuity on physical loss and restart validity timing on fresh acquisition/reacquisition
- add deterministic focused sequence tests, including two code rates
- document state ownership and frozen V1 engineering assumptions

## Important physical constraints
- no random NLOS/BLOCKED percentages
- no `v=-0.78` production boundary
- LOS_MULTIPATH does not require a retained reflection
- no final pseudorange/Doppler/carrier/ADR synthesis in this PR
- no NAV/EPH/ION modification or target-PVT tuning

## Validation
GitHub Actions will be used for clang-format, tooling, Ubuntu full tests + RANGEA/serialized-NAV regressions, and Windows build/test.