### PR TITLE
Build unified urban per-signal epoch result

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,7 @@ add_library(gnss_sim_core STATIC
     src/model/urban_rooftop_diffraction.cpp
     src/model/urban_rf_model.cpp
     src/model/urban_scene_geometry.cpp
+    src/model/urban_signal_epoch.cpp
     src/model/urban_signal_tracking.cpp
     src/output/novatel_nav_writer.cpp
     src/output/novatel_range_writer.cpp
@@ -271,6 +272,7 @@ if(BUILD_TESTING)
         tests/unit/test_urban_rooftop_diffraction.cpp
         tests/unit/test_urban_rf_model.cpp
         tests/unit/test_urban_scene_geometry.cpp
+        tests/unit/test_urban_signal_epoch.cpp
         tests/unit/test_urban_signal_tracking.cpp
     )
     target_include_directories(gnss_sim_unit_tests PRIVATE

--- a/src/model/urban_signal_epoch.cpp
+++ b/src/model/urban_signal_epoch.cpp
@@ -64,17 +64,16 @@ bool update_urban_signal_epoch_from_paths(const SignalDefinition& signal, const 
                                 ? CodeTrackingDllSelectionMode::TRACKED
                                 : CodeTrackingDllSelectionMode::ACQUISITION;
 
-    if (!find_code_tracking_dll_roots_with_status(
-            signal, received_paths.paths, received_paths.path_count, dll_config, output.dll_roots,
-            kMaxCodeTrackingDllRoots, &output.dll_root_count, &output.root_search_status, error_message)) {
+    if (!find_code_tracking_dll_roots_with_status(signal, received_paths.paths, received_paths.path_count, dll_config,
+                                                  output.dll_roots, kMaxCodeTrackingDllRoots, &output.dll_root_count,
+                                                  &output.root_search_status, error_message)) {
         return false;
     }
 
     output.stable_root_available = has_stable_root(output.dll_roots, output.dll_root_count);
     if (output.stable_root_available) {
-        const double previous_code_phase_sec = output.selection_mode == CodeTrackingDllSelectionMode::TRACKED
-                                                   ? tracker->previous_dll_code_phase_sec
-                                                   : 0.0;
+        const double previous_code_phase_sec =
+            output.selection_mode == CodeTrackingDllSelectionMode::TRACKED ? tracker->previous_dll_code_phase_sec : 0.0;
         if (!select_code_tracking_dll_root(output.dll_roots, output.dll_root_count, output.selection_mode,
                                            previous_code_phase_sec, &output.preselected_root_index, error_message) ||
             output.preselected_root_index < 0 || output.preselected_root_index >= output.dll_root_count ||
@@ -140,8 +139,8 @@ bool compute_urban_signal_epoch(const Cn0Model& cn0_model, const UrbanSceneGeome
                                 const SatelliteGeometry& satellite_geometry, SignalTracker* tracker,
                                 UrbanSignalEpochResult* result, std::string* error_message) {
     UrbanReceivedPathSet received_paths{};
-    if (!compute_urban_received_path_set(cn0_model, scene_config, rf_config, signal, glonass_fcn, current_time, receiver,
-                                         satellite_geometry, &received_paths, error_message)) {
+    if (!compute_urban_received_path_set(cn0_model, scene_config, rf_config, signal, glonass_fcn, current_time,
+                                         receiver, satellite_geometry, &received_paths, error_message)) {
         return false;
     }
     return update_urban_signal_epoch_from_paths(signal, current_time, received_paths, dll_config, tracking_config,

--- a/src/model/urban_signal_epoch.cpp
+++ b/src/model/urban_signal_epoch.cpp
@@ -1,0 +1,151 @@
+#include "model/urban_signal_epoch.h"
+
+#include <cmath>
+#include <limits>
+
+namespace gnss_sim {
+namespace {
+
+constexpr double kSpeedOfLightMps = 299792458.0;
+
+void set_error(std::string* error_message, const char* message) {
+    if (error_message != nullptr) {
+        *error_message = message;
+    }
+}
+
+bool has_stable_root(const CodeTrackingDllRoot* roots, int root_count) {
+    if (roots == nullptr || root_count <= 0) {
+        return false;
+    }
+    for (int index = 0; index < root_count; ++index) {
+        if (roots[index].stable) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void set_no_trackable_root_cn0(double open_cn0_dbhz, UrbanEffectiveCn0* effective_cn0) {
+    *effective_cn0 = {};
+    effective_cn0->open_cn0_dbhz = open_cn0_dbhz;
+    effective_cn0->composite_correlation = {0.0, 0.0};
+    effective_cn0->composite_power_ratio = 0.0;
+    effective_cn0->carrier_to_noise_density_hz = 0.0;
+    effective_cn0->effective_cn0_dbhz = -std::numeric_limits<double>::infinity();
+    effective_cn0->finite_effective_cn0 = false;
+}
+
+bool same_selected_root(const SignalTracker& tracker, const CodeTrackingDllRoot& root) {
+    return tracker.current_dll_root_valid && tracker.current_dll_code_phase_sec == root.code_phase_sec &&
+           tracker.current_dll_code_phase_chips == root.code_phase_chips &&
+           tracker.current_dll_prompt_power == root.prompt_power;
+}
+
+} // namespace
+
+bool update_urban_signal_epoch_from_paths(const SignalDefinition& signal, const SimTime& current_time,
+                                          const UrbanReceivedPathSet& received_paths,
+                                          const CodeTrackingDllConfig& dll_config,
+                                          const SignalTrackingModelConfig& tracking_config, SignalTracker* tracker,
+                                          UrbanSignalEpochResult* result, std::string* error_message) {
+    if (tracker == nullptr || result == nullptr || tracker->signal_id != signal.signal_id ||
+        received_paths.path_count <= 0 || received_paths.path_count > kMaxUrbanReceivedPaths ||
+        !std::isfinite(received_paths.open_cn0_dbhz) || !validate_code_tracking_dll_config(dll_config, nullptr) ||
+        !validate_signal_tracking_model_config(tracking_config, nullptr)) {
+        set_error(error_message, "urban signal epoch request is invalid");
+        return false;
+    }
+
+    UrbanSignalEpochResult output{};
+    output.received_paths = received_paths;
+    output.preselected_root_index = -1;
+    output.selection_mode = tracker->phase == SignalTrackingPhase::kTracking && tracker->has_tracking_lock
+                                ? CodeTrackingDllSelectionMode::TRACKED
+                                : CodeTrackingDllSelectionMode::ACQUISITION;
+
+    if (!find_code_tracking_dll_roots_with_status(
+            signal, received_paths.paths, received_paths.path_count, dll_config, output.dll_roots,
+            kMaxCodeTrackingDllRoots, &output.dll_root_count, &output.root_search_status, error_message)) {
+        return false;
+    }
+
+    output.stable_root_available = has_stable_root(output.dll_roots, output.dll_root_count);
+    if (output.stable_root_available) {
+        const double previous_code_phase_sec = output.selection_mode == CodeTrackingDllSelectionMode::TRACKED
+                                                   ? tracker->previous_dll_code_phase_sec
+                                                   : 0.0;
+        if (!select_code_tracking_dll_root(output.dll_roots, output.dll_root_count, output.selection_mode,
+                                           previous_code_phase_sec, &output.preselected_root_index, error_message) ||
+            output.preselected_root_index < 0 || output.preselected_root_index >= output.dll_root_count ||
+            !output.dll_roots[output.preselected_root_index].stable) {
+            return false;
+        }
+        output.preselected_root = output.dll_roots[output.preselected_root_index];
+        if (!compute_urban_effective_cn0(signal, received_paths, output.preselected_root.code_phase_sec,
+                                         &output.effective_cn0, error_message)) {
+            return false;
+        }
+    } else {
+        set_no_trackable_root_cn0(received_paths.open_cn0_dbhz, &output.effective_cn0);
+    }
+
+    UrbanSignalTrackingInput tracking_input{};
+    tracking_input.signal_available = true;
+    tracking_input.direct_line_of_sight = received_paths.direct_geometry.line_of_sight;
+    tracking_input.open_cn0_dbhz = received_paths.open_cn0_dbhz;
+    tracking_input.effective_cn0_dbhz = output.effective_cn0.effective_cn0_dbhz;
+    tracking_input.dll_roots = output.dll_roots;
+    tracking_input.dll_root_count = output.dll_root_count;
+    if (!update_urban_signal_tracker(tracker, current_time, tracking_input, tracking_config, error_message)) {
+        return false;
+    }
+
+    if (tracker->phase == SignalTrackingPhase::kTracking && tracker->has_tracking_lock) {
+        if (!output.stable_root_available || !same_selected_root(*tracker, output.preselected_root)) {
+            set_error(error_message, "urban signal epoch root selection diverged from tracking state");
+            return false;
+        }
+    }
+
+    output.selected_root_valid = tracker->current_dll_root_valid;
+    if (output.selected_root_valid) {
+        output.code_bias_m = kSpeedOfLightMps * tracker->current_dll_code_phase_sec;
+    }
+    output.tracked_composite_correlation_valid =
+        tracker->phase == SignalTrackingPhase::kTracking && tracker->has_tracking_lock && output.selected_root_valid;
+    if (output.tracked_composite_correlation_valid) {
+        output.tracked_composite_correlation = output.effective_cn0.composite_correlation;
+    }
+    output.urban_state = tracker->urban_state;
+    output.tracking_phase = tracker->phase;
+    output.loss_reason = tracker->loss_reason;
+    output.effective_cn0_dbhz = output.effective_cn0.effective_cn0_dbhz;
+    output.lock_time_ns = tracker->lock_time_ns;
+    output.observation_available = tracker->observation_available;
+    output.psr_valid = tracker->psr_valid;
+    output.doppler_valid = tracker->doppler_valid;
+    output.adr_valid = tracker->adr_valid;
+    output.reacquisition_event = tracker->reacquisition_event;
+    output.carrier_continuity_valid = tracker->carrier_continuity_valid;
+
+    *result = output;
+    return true;
+}
+
+bool compute_urban_signal_epoch(const Cn0Model& cn0_model, const UrbanSceneGeometryConfig& scene_config,
+                                const UrbanRfConfig& rf_config, const CodeTrackingDllConfig& dll_config,
+                                const SignalTrackingModelConfig& tracking_config, const SignalDefinition& signal,
+                                int glonass_fcn, const SimTime& current_time, const ReceiverTruth& receiver,
+                                const SatelliteGeometry& satellite_geometry, SignalTracker* tracker,
+                                UrbanSignalEpochResult* result, std::string* error_message) {
+    UrbanReceivedPathSet received_paths{};
+    if (!compute_urban_received_path_set(cn0_model, scene_config, rf_config, signal, glonass_fcn, current_time, receiver,
+                                         satellite_geometry, &received_paths, error_message)) {
+        return false;
+    }
+    return update_urban_signal_epoch_from_paths(signal, current_time, received_paths, dll_config, tracking_config,
+                                                tracker, result, error_message);
+}
+
+} // namespace gnss_sim

--- a/src/model/urban_signal_epoch.h
+++ b/src/model/urban_signal_epoch.h
@@ -1,0 +1,62 @@
+#ifndef GNSS_SIM_SRC_MODEL_URBAN_SIGNAL_EPOCH_H_
+#define GNSS_SIM_SRC_MODEL_URBAN_SIGNAL_EPOCH_H_
+
+#include "model/code_tracking_dll.h"
+#include "model/signal_tracking.h"
+#include "model/urban_received_power.h"
+
+#include <complex>
+#include <string>
+
+namespace gnss_sim {
+
+struct UrbanSignalEpochResult {
+    UrbanReceivedPathSet received_paths;
+    CodeTrackingDllRoot dll_roots[kMaxCodeTrackingDllRoots];
+    int dll_root_count;
+    CodeTrackingDllRootSearchStatus root_search_status;
+    CodeTrackingDllSelectionMode selection_mode;
+    int preselected_root_index;
+    CodeTrackingDllRoot preselected_root;
+    UrbanEffectiveCn0 effective_cn0;
+    double code_bias_m;
+    std::complex<double> tracked_composite_correlation;
+    UrbanSignalState urban_state;
+    SignalTrackingPhase tracking_phase;
+    SignalTrackingLossReason loss_reason;
+    double effective_cn0_dbhz;
+    std::int64_t lock_time_ns;
+    bool stable_root_available;
+    bool selected_root_valid;
+    bool tracked_composite_correlation_valid;
+    bool observation_available;
+    bool psr_valid;
+    bool doppler_valid;
+    bool adr_valid;
+    bool reacquisition_event;
+    bool carrier_continuity_valid;
+};
+
+// Core single-epoch orchestration over one already-built #120 path set. This
+// function does not schedule acquisition delays; the caller must use the
+// existing SignalTracker scheduling API before invoking it when acquisition is
+// required. The same roots and effective CN0 are then consumed by #121.
+bool update_urban_signal_epoch_from_paths(const SignalDefinition& signal, const SimTime& current_time,
+                                          const UrbanReceivedPathSet& received_paths,
+                                          const CodeTrackingDllConfig& dll_config,
+                                          const SignalTrackingModelConfig& tracking_config, SignalTracker* tracker,
+                                          UrbanSignalEpochResult* result, std::string* error_message);
+
+// Production #140 entry: build the common #120 propagation path set from the
+// already-converged authentic-NAV SatelliteGeometry, then run the core
+// DLL/CN0/tracking orchestration above. Simulator runtime wiring remains #143.
+bool compute_urban_signal_epoch(const Cn0Model& cn0_model, const UrbanSceneGeometryConfig& scene_config,
+                                const UrbanRfConfig& rf_config, const CodeTrackingDllConfig& dll_config,
+                                const SignalTrackingModelConfig& tracking_config, const SignalDefinition& signal,
+                                int glonass_fcn, const SimTime& current_time, const ReceiverTruth& receiver,
+                                const SatelliteGeometry& satellite_geometry, SignalTracker* tracker,
+                                UrbanSignalEpochResult* result, std::string* error_message);
+
+} // namespace gnss_sim
+
+#endif // GNSS_SIM_SRC_MODEL_URBAN_SIGNAL_EPOCH_H_

--- a/src/model/urban_signal_epoch.h
+++ b/src/model/urban_signal_epoch.h
@@ -6,6 +6,7 @@
 #include "model/urban_received_power.h"
 
 #include <complex>
+#include <cstdint>
 #include <string>
 
 namespace gnss_sim {

--- a/tests/unit/test_urban_signal_epoch.cpp
+++ b/tests/unit/test_urban_signal_epoch.cpp
@@ -1,0 +1,292 @@
+#include "gnss/signal_definitions.h"
+#include "gnss_sim/sim_config.h"
+#include "gnss_sim/sim_time.h"
+#include "model/urban_signal_epoch.h"
+
+#include <cmath>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <string>
+
+namespace {
+
+constexpr double kPi = 3.141592653589793238462643383279502884;
+constexpr double kDegreesToRadians = kPi / 180.0;
+constexpr double kSyntheticSatelliteDistanceM = 20000000.0;
+constexpr double kSpeedOfLightMps = 299792458.0;
+
+const gnss_sim::SignalDefinition& signal(gnss_sim::SignalId signal_id) {
+    const gnss_sim::SignalDefinition* definition = gnss_sim::find_signal_definition(signal_id);
+    EXPECT_NE(definition, nullptr);
+    return *definition;
+}
+
+gnss_sim::DelayDistribution fixed_delay(std::int64_t delay_ns) {
+    return {delay_ns, delay_ns, delay_ns, delay_ns};
+}
+
+gnss_sim::SignalTrackingModelConfig immediate_tracking_config() {
+    gnss_sim::SignalTrackingModelConfig config = gnss_sim::default_signal_tracking_model_config();
+    config.hot_common_startup = fixed_delay(0);
+    config.warm_common_startup = fixed_delay(0);
+    config.warm_search_uncertainty = fixed_delay(0);
+    for (int index = 0; index < 4; ++index) {
+        config.hot_signal_acquisition[index] = fixed_delay(0);
+        config.reacquisition[index] = fixed_delay(0);
+    }
+    config.acquisition_cn0_persistence_ns = 0;
+    config.psr_valid_delay_ns = 0;
+    config.doppler_valid_delay_ns = 0;
+    config.adr_valid_delay_ns = 0;
+    return config;
+}
+
+gnss_sim::Cn0Model normalized_model(gnss_sim::SignalId signal_id, double high_cn0_dbhz) {
+    gnss_sim::Cn0Model model{};
+    model.source = gnss_sim::Cn0ModelSource::kCalibratedCsv;
+    model.semantic = gnss_sim::Cn0ModelSemantic::kNormalizedElevationShape;
+    model.seed = 23;
+    gnss_sim::Cn0CalibratedBin bin{};
+    bin.signal_id = signal_id;
+    bin.elevation_min_deg = 0.0;
+    bin.elevation_max_deg = 90.0;
+    bin.elevation_center_deg = 45.0;
+    bin.delta_p50_db = -2.0;
+    bin.support_count = 8;
+    bin.upper_edge_inclusive = true;
+    bin.ready = true;
+    model.calibrated_bins.push_back(bin);
+    model.high_baselines.push_back({signal_id, high_cn0_dbhz});
+    return model;
+}
+
+gnss_sim::SimTime time_at(double sow_sec) {
+    gnss_sim::SimTime time{};
+    EXPECT_TRUE(gnss_sim::sim_time_from_week_sow(2400, sow_sec, &time));
+    return time;
+}
+
+void schedule_tracker(gnss_sim::SignalTracker* tracker, const gnss_sim::SignalDefinition& definition,
+                      const gnss_sim::SimTime& time, double elevation_deg, const gnss_sim::Cn0Model& cn0_model,
+                      const gnss_sim::SignalTrackingModelConfig& config, std::uint64_t seed = 1U) {
+    ASSERT_NE(tracker, nullptr);
+    gnss_sim::reset_signal_tracker(tracker, definition.signal_id, time);
+    gnss_sim::DeterministicRng rng{};
+    gnss_sim::seed_rng(&rng, seed);
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::schedule_signal_acquisition(tracker, gnss_sim::AcquisitionContext::kHot, time, time,
+                                                      elevation_deg, cn0_model, config, &rng, &error_message))
+        << error_message;
+}
+
+gnss_sim::UrbanReceivedPathSet path_set(double open_cn0_dbhz, bool direct_line_of_sight,
+                                        const gnss_sim::CodeTrackingDllPath* paths, int path_count) {
+    gnss_sim::UrbanReceivedPathSet result{};
+    result.open_cn0_dbhz = open_cn0_dbhz;
+    result.direct_geometry.line_of_sight = direct_line_of_sight;
+    result.path_count = path_count;
+    for (int index = 0; index < path_count; ++index) {
+        result.paths[index] = paths[index];
+    }
+    return result;
+}
+
+void make_synthetic_geometry(double azimuth_deg, double elevation_deg, gnss_sim::ReceiverTruth* receiver,
+                             gnss_sim::SatelliteGeometry* geometry) {
+    ASSERT_NE(receiver, nullptr);
+    ASSERT_NE(geometry, nullptr);
+    *receiver = {};
+    *geometry = {};
+    geometry->satellite_state.position_ecef_m[0] = kSyntheticSatelliteDistanceM;
+    geometry->azimuth_rad = azimuth_deg * kDegreesToRadians;
+    geometry->elevation_rad = elevation_deg * kDegreesToRadians;
+    geometry->geometric_range_m = kSyntheticSatelliteDistanceM;
+    geometry->healthy = true;
+    geometry->above_elevation_mask = true;
+    geometry->visible = true;
+}
+
+TEST(UrbanSignalEpoch, SingleDirectPathUnifiesRootCn0AndLosTracking) {
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    const gnss_sim::CodeTrackingDllPath paths[] = {{0.0, {1.0, 0.0}}};
+    const gnss_sim::UrbanReceivedPathSet received = path_set(45.0, true, paths, 1);
+    const gnss_sim::SignalTrackingModelConfig tracking = immediate_tracking_config();
+    const gnss_sim::Cn0Model cn0 = normalized_model(gps_l1.signal_id, 47.0);
+    const gnss_sim::SimTime time = time_at(100000.0);
+    gnss_sim::SignalTracker tracker{};
+    schedule_tracker(&tracker, gps_l1, time, 60.0, cn0, tracking);
+
+    gnss_sim::UrbanSignalEpochResult result{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::update_urban_signal_epoch_from_paths(
+        gps_l1, time, received, gnss_sim::default_code_tracking_dll_config(), tracking, &tracker, &result,
+        &error_message))
+        << error_message;
+    EXPECT_EQ(result.root_search_status, gnss_sim::CodeTrackingDllRootSearchStatus::kRootsFound);
+    EXPECT_TRUE(result.stable_root_available);
+    EXPECT_TRUE(result.selected_root_valid);
+    EXPECT_EQ(result.tracking_phase, gnss_sim::SignalTrackingPhase::kTracking);
+    EXPECT_EQ(result.urban_state, gnss_sim::UrbanSignalState::kLos);
+    EXPECT_NEAR(result.preselected_root.code_phase_chips, 0.0, 1.0e-8);
+    EXPECT_NEAR(result.code_bias_m, 0.0, 1.0e-8);
+    EXPECT_NEAR(result.effective_cn0_dbhz, 45.0, 1.0e-12);
+    EXPECT_TRUE(result.tracked_composite_correlation_valid);
+    EXPECT_NEAR(result.tracked_composite_correlation.real(), 1.0, 1.0e-14);
+    EXPECT_NEAR(result.tracked_composite_correlation.imag(), 0.0, 1.0e-14);
+}
+
+TEST(UrbanSignalEpoch, DllCodeBiasComesOnlyFromSelectedCompositeRoot) {
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    const double chip_duration_sec = 1.0 / gps_l1.code_correlation.chip_rate_hz;
+    const gnss_sim::CodeTrackingDllPath paths[] = {
+        {0.0, {1.0, 0.0}},
+        {0.3 * chip_duration_sec, {0.5, 0.0}},
+    };
+    const gnss_sim::UrbanReceivedPathSet received = path_set(45.0, true, paths, 2);
+    const gnss_sim::SignalTrackingModelConfig tracking = immediate_tracking_config();
+    const gnss_sim::Cn0Model cn0 = normalized_model(gps_l1.signal_id, 47.0);
+    const gnss_sim::SimTime time = time_at(110000.0);
+    gnss_sim::SignalTracker tracker{};
+    schedule_tracker(&tracker, gps_l1, time, 60.0, cn0, tracking);
+
+    gnss_sim::UrbanSignalEpochResult result{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::update_urban_signal_epoch_from_paths(
+        gps_l1, time, received, gnss_sim::default_code_tracking_dll_config(), tracking, &tracker, &result,
+        &error_message))
+        << error_message;
+    EXPECT_NEAR(result.preselected_root.code_phase_chips, 0.05, 1.0e-6);
+    EXPECT_NEAR(result.code_bias_m, kSpeedOfLightMps * result.preselected_root.code_phase_sec, 1.0e-9);
+    EXPECT_EQ(result.urban_state, gnss_sim::UrbanSignalState::kLosMultipath);
+}
+
+TEST(UrbanSignalEpoch, ExactCoherentNullBecomesBlockedWithoutFabricatedRootOrCn0Floor) {
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    const gnss_sim::SignalTrackingModelConfig tracking = immediate_tracking_config();
+    const gnss_sim::Cn0Model cn0 = normalized_model(gps_l1.signal_id, 60.0);
+    const gnss_sim::SimTime first_time = time_at(120000.0);
+    gnss_sim::SignalTracker tracker{};
+    schedule_tracker(&tracker, gps_l1, first_time, 20.0, cn0, tracking);
+
+    const gnss_sim::CodeTrackingDllPath initial_path[] = {{0.0, {1.0, 0.0}}};
+    const gnss_sim::UrbanReceivedPathSet initial = path_set(55.0, false, initial_path, 1);
+    gnss_sim::UrbanSignalEpochResult acquired{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::update_urban_signal_epoch_from_paths(
+        gps_l1, first_time, initial, gnss_sim::default_code_tracking_dll_config(), tracking, &tracker, &acquired,
+        &error_message))
+        << error_message;
+    ASSERT_EQ(acquired.tracking_phase, gnss_sim::SignalTrackingPhase::kTracking);
+    ASSERT_EQ(acquired.urban_state, gnss_sim::UrbanSignalState::kNlosTracked);
+
+    const gnss_sim::CodeTrackingDllPath cancelled_paths[] = {
+        {0.0, {1.0, 0.25}},
+        {0.0, {-1.0, -0.25}},
+    };
+    const gnss_sim::UrbanReceivedPathSet cancelled = path_set(55.0, false, cancelled_paths, 2);
+    const gnss_sim::SimTime second_time = time_at(120000.1);
+    gnss_sim::UrbanSignalEpochResult lost{};
+    ASSERT_TRUE(gnss_sim::update_urban_signal_epoch_from_paths(
+        gps_l1, second_time, cancelled, gnss_sim::default_code_tracking_dll_config(), tracking, &tracker, &lost,
+        &error_message))
+        << error_message;
+    EXPECT_EQ(lost.root_search_status, gnss_sim::CodeTrackingDllRootSearchStatus::kNoRoots);
+    EXPECT_EQ(lost.dll_root_count, 0);
+    EXPECT_FALSE(lost.stable_root_available);
+    EXPECT_FALSE(lost.selected_root_valid);
+    EXPECT_TRUE(std::isinf(lost.effective_cn0_dbhz));
+    EXPECT_LT(lost.effective_cn0_dbhz, 0.0);
+    EXPECT_EQ(lost.tracking_phase, gnss_sim::SignalTrackingPhase::kSearching);
+    EXPECT_EQ(lost.loss_reason, gnss_sim::SignalTrackingLossReason::kNoStableDllRoot);
+    EXPECT_EQ(lost.urban_state, gnss_sim::UrbanSignalState::kBlocked);
+}
+
+TEST(UrbanSignalEpoch, DifferentCodeRateUsesSignalSpecificChipMetadata) {
+    const gnss_sim::SignalDefinition& gps_l5 = signal(gnss_sim::SignalId::kGpsL5Q);
+    const double chip_duration_sec = 1.0 / gps_l5.code_correlation.chip_rate_hz;
+    const gnss_sim::CodeTrackingDllPath paths[] = {
+        {0.0, {1.0, 0.0}},
+        {0.3 * chip_duration_sec, {0.5, 0.0}},
+    };
+    const gnss_sim::UrbanReceivedPathSet received = path_set(45.0, true, paths, 2);
+    const gnss_sim::SignalTrackingModelConfig tracking = immediate_tracking_config();
+    const gnss_sim::Cn0Model cn0 = normalized_model(gps_l5.signal_id, 47.0);
+    const gnss_sim::SimTime time = time_at(130000.0);
+    gnss_sim::SignalTracker tracker{};
+    schedule_tracker(&tracker, gps_l5, time, 60.0, cn0, tracking);
+
+    gnss_sim::UrbanSignalEpochResult result{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::update_urban_signal_epoch_from_paths(
+        gps_l5, time, received, gnss_sim::default_code_tracking_dll_config(), tracking, &tracker, &result,
+        &error_message))
+        << error_message;
+    EXPECT_NEAR(result.preselected_root.code_phase_chips, 0.05, 1.0e-6);
+    EXPECT_NEAR(result.preselected_root.code_phase_sec, 0.05 / gps_l5.code_correlation.chip_rate_hz, 1.0e-15);
+    EXPECT_NEAR(result.code_bias_m, kSpeedOfLightMps * result.preselected_root.code_phase_sec, 1.0e-9);
+}
+
+TEST(UrbanSignalEpoch, ProductionRoofTransitionCanReachLosMultipath) {
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    const gnss_sim::UrbanSceneGeometryConfig scene = gnss_sim::default_urban_scene_geometry_config();
+    const gnss_sim::SimConfig sim_config = gnss_sim::default_sim_config();
+    const gnss_sim::SignalTrackingModelConfig tracking = immediate_tracking_config();
+    const gnss_sim::Cn0Model cn0 = normalized_model(gps_l1.signal_id, 55.0);
+    double skyline_rad = 0.0;
+    double wall_distance_m = 0.0;
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::compute_urban_skyline_elevation(scene, 0.0, &skyline_rad, &wall_distance_m, &error_message));
+
+    gnss_sim::ReceiverTruth receiver{};
+    gnss_sim::SatelliteGeometry geometry{};
+    const double elevation_deg = skyline_rad / kDegreesToRadians + 0.001;
+    make_synthetic_geometry(0.0, elevation_deg, &receiver, &geometry);
+    const gnss_sim::SimTime time = time_at(140000.0);
+    gnss_sim::SignalTracker tracker{};
+    schedule_tracker(&tracker, gps_l1, time, elevation_deg, cn0, tracking);
+
+    gnss_sim::UrbanSignalEpochResult result{};
+    ASSERT_TRUE(gnss_sim::compute_urban_signal_epoch(
+        cn0, scene, sim_config.urban_rf, gnss_sim::default_code_tracking_dll_config(), tracking, gps_l1, 0, time,
+        receiver, geometry, &tracker, &result, &error_message))
+        << error_message;
+    EXPECT_TRUE(result.received_paths.direct_geometry.line_of_sight);
+    EXPECT_EQ(result.tracking_phase, gnss_sim::SignalTrackingPhase::kTracking);
+    EXPECT_EQ(result.urban_state, gnss_sim::UrbanSignalState::kLosMultipath);
+    EXPECT_LT(result.effective_cn0_dbhz, result.received_paths.open_cn0_dbhz - 0.5);
+}
+
+TEST(UrbanSignalEpoch, IdenticalInputsProduceIdenticalUnifiedResults) {
+    const gnss_sim::SignalDefinition& gal_e1 = signal(gnss_sim::SignalId::kGalileoE1);
+    const gnss_sim::CodeTrackingDllPath paths[] = {{0.0, {0.8, 0.1}}};
+    const gnss_sim::UrbanReceivedPathSet received = path_set(46.0, true, paths, 1);
+    const gnss_sim::SignalTrackingModelConfig tracking = immediate_tracking_config();
+    const gnss_sim::Cn0Model cn0 = normalized_model(gal_e1.signal_id, 48.0);
+    const gnss_sim::SimTime time = time_at(150000.0);
+    gnss_sim::SignalTracker first_tracker{};
+    gnss_sim::SignalTracker second_tracker{};
+    schedule_tracker(&first_tracker, gal_e1, time, 60.0, cn0, tracking, 77U);
+    schedule_tracker(&second_tracker, gal_e1, time, 60.0, cn0, tracking, 77U);
+
+    gnss_sim::UrbanSignalEpochResult first{};
+    gnss_sim::UrbanSignalEpochResult second{};
+    std::string first_error;
+    std::string second_error;
+    ASSERT_TRUE(gnss_sim::update_urban_signal_epoch_from_paths(
+        gal_e1, time, received, gnss_sim::default_code_tracking_dll_config(), tracking, &first_tracker, &first,
+        &first_error));
+    ASSERT_TRUE(gnss_sim::update_urban_signal_epoch_from_paths(
+        gal_e1, time, received, gnss_sim::default_code_tracking_dll_config(), tracking, &second_tracker, &second,
+        &second_error));
+    EXPECT_EQ(first.dll_root_count, second.dll_root_count);
+    EXPECT_EQ(first.root_search_status, second.root_search_status);
+    EXPECT_EQ(first.preselected_root_index, second.preselected_root_index);
+    EXPECT_DOUBLE_EQ(first.preselected_root.code_phase_sec, second.preselected_root.code_phase_sec);
+    EXPECT_DOUBLE_EQ(first.effective_cn0_dbhz, second.effective_cn0_dbhz);
+    EXPECT_DOUBLE_EQ(first.code_bias_m, second.code_bias_m);
+    EXPECT_EQ(first.tracked_composite_correlation, second.tracked_composite_correlation);
+    EXPECT_EQ(first.urban_state, second.urban_state);
+    EXPECT_EQ(first.tracking_phase, second.tracking_phase);
+}
+
+} // namespace

--- a/tests/unit/test_urban_signal_epoch.cpp
+++ b/tests/unit/test_urban_signal_epoch.cpp
@@ -118,9 +118,9 @@ TEST(UrbanSignalEpoch, SingleDirectPathUnifiesRootCn0AndLosTracking) {
 
     gnss_sim::UrbanSignalEpochResult result{};
     std::string error_message;
-    ASSERT_TRUE(gnss_sim::update_urban_signal_epoch_from_paths(
-        gps_l1, time, received, gnss_sim::default_code_tracking_dll_config(), tracking, &tracker, &result,
-        &error_message))
+    ASSERT_TRUE(gnss_sim::update_urban_signal_epoch_from_paths(gps_l1, time, received,
+                                                               gnss_sim::default_code_tracking_dll_config(), tracking,
+                                                               &tracker, &result, &error_message))
         << error_message;
     EXPECT_EQ(result.root_search_status, gnss_sim::CodeTrackingDllRootSearchStatus::kRootsFound);
     EXPECT_TRUE(result.stable_root_available);
@@ -151,9 +151,9 @@ TEST(UrbanSignalEpoch, DllCodeBiasComesOnlyFromSelectedCompositeRoot) {
 
     gnss_sim::UrbanSignalEpochResult result{};
     std::string error_message;
-    ASSERT_TRUE(gnss_sim::update_urban_signal_epoch_from_paths(
-        gps_l1, time, received, gnss_sim::default_code_tracking_dll_config(), tracking, &tracker, &result,
-        &error_message))
+    ASSERT_TRUE(gnss_sim::update_urban_signal_epoch_from_paths(gps_l1, time, received,
+                                                               gnss_sim::default_code_tracking_dll_config(), tracking,
+                                                               &tracker, &result, &error_message))
         << error_message;
     EXPECT_NEAR(result.preselected_root.code_phase_chips, 0.05, 1.0e-6);
     EXPECT_NEAR(result.code_bias_m, kSpeedOfLightMps * result.preselected_root.code_phase_sec, 1.0e-9);
@@ -172,9 +172,9 @@ TEST(UrbanSignalEpoch, ExactCoherentNullBecomesBlockedWithoutFabricatedRootOrCn0
     const gnss_sim::UrbanReceivedPathSet initial = path_set(55.0, false, initial_path, 1);
     gnss_sim::UrbanSignalEpochResult acquired{};
     std::string error_message;
-    ASSERT_TRUE(gnss_sim::update_urban_signal_epoch_from_paths(
-        gps_l1, first_time, initial, gnss_sim::default_code_tracking_dll_config(), tracking, &tracker, &acquired,
-        &error_message))
+    ASSERT_TRUE(gnss_sim::update_urban_signal_epoch_from_paths(gps_l1, first_time, initial,
+                                                               gnss_sim::default_code_tracking_dll_config(), tracking,
+                                                               &tracker, &acquired, &error_message))
         << error_message;
     ASSERT_EQ(acquired.tracking_phase, gnss_sim::SignalTrackingPhase::kTracking);
     ASSERT_EQ(acquired.urban_state, gnss_sim::UrbanSignalState::kNlosTracked);
@@ -186,9 +186,9 @@ TEST(UrbanSignalEpoch, ExactCoherentNullBecomesBlockedWithoutFabricatedRootOrCn0
     const gnss_sim::UrbanReceivedPathSet cancelled = path_set(55.0, false, cancelled_paths, 2);
     const gnss_sim::SimTime second_time = time_at(120000.1);
     gnss_sim::UrbanSignalEpochResult lost{};
-    ASSERT_TRUE(gnss_sim::update_urban_signal_epoch_from_paths(
-        gps_l1, second_time, cancelled, gnss_sim::default_code_tracking_dll_config(), tracking, &tracker, &lost,
-        &error_message))
+    ASSERT_TRUE(gnss_sim::update_urban_signal_epoch_from_paths(gps_l1, second_time, cancelled,
+                                                               gnss_sim::default_code_tracking_dll_config(), tracking,
+                                                               &tracker, &lost, &error_message))
         << error_message;
     EXPECT_EQ(lost.root_search_status, gnss_sim::CodeTrackingDllRootSearchStatus::kNoRoots);
     EXPECT_EQ(lost.dll_root_count, 0);
@@ -217,9 +217,9 @@ TEST(UrbanSignalEpoch, DifferentCodeRateUsesSignalSpecificChipMetadata) {
 
     gnss_sim::UrbanSignalEpochResult result{};
     std::string error_message;
-    ASSERT_TRUE(gnss_sim::update_urban_signal_epoch_from_paths(
-        gps_l5, time, received, gnss_sim::default_code_tracking_dll_config(), tracking, &tracker, &result,
-        &error_message))
+    ASSERT_TRUE(gnss_sim::update_urban_signal_epoch_from_paths(gps_l5, time, received,
+                                                               gnss_sim::default_code_tracking_dll_config(), tracking,
+                                                               &tracker, &result, &error_message))
         << error_message;
     EXPECT_NEAR(result.preselected_root.code_phase_chips, 0.05, 1.0e-6);
     EXPECT_NEAR(result.preselected_root.code_phase_sec, 0.05 / gps_l5.code_correlation.chip_rate_hz, 1.0e-15);
@@ -246,9 +246,9 @@ TEST(UrbanSignalEpoch, ProductionRoofTransitionCanReachLosMultipath) {
     schedule_tracker(&tracker, gps_l1, time, elevation_deg, cn0, tracking);
 
     gnss_sim::UrbanSignalEpochResult result{};
-    ASSERT_TRUE(gnss_sim::compute_urban_signal_epoch(
-        cn0, scene, sim_config.urban_rf, gnss_sim::default_code_tracking_dll_config(), tracking, gps_l1, 0, time,
-        receiver, geometry, &tracker, &result, &error_message))
+    ASSERT_TRUE(gnss_sim::compute_urban_signal_epoch(cn0, scene, sim_config.urban_rf,
+                                                     gnss_sim::default_code_tracking_dll_config(), tracking, gps_l1, 0,
+                                                     time, receiver, geometry, &tracker, &result, &error_message))
         << error_message;
     EXPECT_TRUE(result.received_paths.direct_geometry.line_of_sight);
     EXPECT_EQ(result.tracking_phase, gnss_sim::SignalTrackingPhase::kTracking);
@@ -272,12 +272,12 @@ TEST(UrbanSignalEpoch, IdenticalInputsProduceIdenticalUnifiedResults) {
     gnss_sim::UrbanSignalEpochResult second{};
     std::string first_error;
     std::string second_error;
-    ASSERT_TRUE(gnss_sim::update_urban_signal_epoch_from_paths(
-        gal_e1, time, received, gnss_sim::default_code_tracking_dll_config(), tracking, &first_tracker, &first,
-        &first_error));
-    ASSERT_TRUE(gnss_sim::update_urban_signal_epoch_from_paths(
-        gal_e1, time, received, gnss_sim::default_code_tracking_dll_config(), tracking, &second_tracker, &second,
-        &second_error));
+    ASSERT_TRUE(gnss_sim::update_urban_signal_epoch_from_paths(gal_e1, time, received,
+                                                               gnss_sim::default_code_tracking_dll_config(), tracking,
+                                                               &first_tracker, &first, &first_error));
+    ASSERT_TRUE(gnss_sim::update_urban_signal_epoch_from_paths(gal_e1, time, received,
+                                                               gnss_sim::default_code_tracking_dll_config(), tracking,
+                                                               &second_tracker, &second, &second_error));
     EXPECT_EQ(first.dll_root_count, second.dll_root_count);
     EXPECT_EQ(first.root_search_status, second.root_search_status);
     EXPECT_EQ(first.preselected_root_index, second.preselected_root_index);


### PR DESCRIPTION
Closes #140.

## Summary
Create one deterministic per-satellite/per-signal urban epoch result that orchestrates the completed #117–#121 layers without yet modifying simulator runtime or `MeasurementObservation`.

Sequence:
`#120 path set -> #119 roots/status -> #121-policy root preselection -> #120 effective CN0 -> #121 update -> selected-root consistency check`

## Implementation Notes
- production entry consumes the already-converged `SatelliteGeometry`; it does not perform a second satellite/transmit-time solve;
- the exact same #120 `UrbanReceivedPathSet` feeds DLL roots and effective CN0;
- root preselection uses #119 `TRACKED` when an existing #121 lock is present, otherwise `ACQUISITION`;
- #121 receives the same roots and effective CN0; if it remains/acquires tracking but accepts a different root, the epoch update fails explicitly;
- environmental pseudorange bias is exposed only as `c * selected_dll_code_phase_sec`;
- exact coherent null uses #144 `kNoRoots`, `-inf` effective CN0, and drives the existing #121 loss/BLOCKED behavior without a fabricated floor/root;
- the accepted-root composite correlator is preserved for #141 carrier/path-rate temporal state.

## Focused coverage
- clean single-path LOS;
- constructive delayed-path DLL bias;
- exact coherent-null -> no root/BLOCKED;
- GPS L5 different code rate;
- frozen-scene clear-side rooftop LOS_MULTIPATH reachability;
- deterministic repeated result.

## Scope exclusions
No Doppler temporal differentiation, carrier phase unwrapping, `MeasurementObservation` changes, simulator runtime wiring, NAV/EPH/ION changes, or PVT tuning.