### PR TITLE
Implement time-correlated urban carrier and path-rate state

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ add_library(gnss_sim_core STATIC
     src/model/measurement_model.cpp
     src/model/receiver_truth.cpp
     src/model/signal_tracking.cpp
+    src/model/urban_carrier_temporal.cpp
     src/model/urban_received_power.cpp
     src/model/urban_reflection_paths.cpp
     src/model/urban_rooftop_diffraction.cpp
@@ -267,6 +268,7 @@ if(BUILD_TESTING)
         tests/unit/test_sim_time.cpp
         tests/unit/test_solution_engine.cpp
         tests/unit/test_solution_signal_policy.cpp
+        tests/unit/test_urban_carrier_temporal.cpp
         tests/unit/test_urban_received_power.cpp
         tests/unit/test_urban_reflection_paths.cpp
         tests/unit/test_urban_rooftop_diffraction.cpp

--- a/src/model/urban_carrier_temporal.cpp
+++ b/src/model/urban_carrier_temporal.cpp
@@ -73,10 +73,9 @@ void reset_urban_carrier_temporal_state(UrbanCarrierTemporalState* state) {
     }
 }
 
-bool update_urban_carrier_temporal_state(const SignalDefinition& signal, int glonass_fcn,
-                                         const SimTime& current_time, const UrbanSignalEpochResult& epoch,
-                                         UrbanCarrierTemporalState* state, UrbanCarrierTemporalResult* result,
-                                         std::string* error_message) {
+bool update_urban_carrier_temporal_state(const SignalDefinition& signal, int glonass_fcn, const SimTime& current_time,
+                                         const UrbanSignalEpochResult& epoch, UrbanCarrierTemporalState* state,
+                                         UrbanCarrierTemporalResult* result, std::string* error_message) {
     if (state == nullptr || result == nullptr || current_time.gps_week < 0 || current_time.tow_ns < 0 ||
         current_time.tow_ns >= GPS_WEEK_NANOSECONDS) {
         set_error(error_message, "urban carrier temporal update has invalid arguments");

--- a/src/model/urban_carrier_temporal.cpp
+++ b/src/model/urban_carrier_temporal.cpp
@@ -1,0 +1,175 @@
+#include "model/urban_carrier_temporal.h"
+
+#include <cmath>
+#include <cstdint>
+
+namespace gnss_sim {
+namespace {
+
+constexpr double kPi = 3.141592653589793238462643383279502884;
+constexpr double kTwoPi = 2.0 * kPi;
+constexpr double kNanosecondsPerSecond = 1000000000.0;
+
+void set_error(std::string* error_message, const char* message) {
+    if (error_message != nullptr) {
+        *error_message = message;
+    }
+}
+
+bool finite_complex(const std::complex<double>& value) {
+    return std::isfinite(value.real()) && std::isfinite(value.imag());
+}
+
+bool tracking_phasor_available(const UrbanSignalEpochResult& epoch) {
+    return epoch.tracking_phase == SignalTrackingPhase::kTracking && epoch.selected_root_valid &&
+           epoch.tracked_composite_correlation_valid;
+}
+
+bool start_new_segment(const SignalDefinition& signal, int glonass_fcn, const SimTime& current_time,
+                       const UrbanSignalEpochResult& epoch, double wavelength_m, UrbanCarrierTemporalState* state,
+                       UrbanCarrierTemporalResult* result, std::string* error_message) {
+    const std::complex<double> phasor = epoch.tracked_composite_correlation;
+    if (!finite_complex(phasor) || !(std::norm(phasor) > 0.0)) {
+        set_error(error_message, "urban carrier temporal state requires a finite non-zero tracked phasor");
+        return false;
+    }
+
+    const double wrapped_phase_rad = std::arg(phasor);
+    const double carrier_range_bias_m = -wrapped_phase_rad * wavelength_m / kTwoPi;
+    if (!std::isfinite(wrapped_phase_rad) || !std::isfinite(carrier_range_bias_m)) {
+        set_error(error_message, "urban carrier temporal fresh-lock phase is not finite");
+        return false;
+    }
+
+    const bool prior_lock_segment = state->ever_had_lock;
+    state->signal_id = signal.signal_id;
+    state->glonass_fcn = glonass_fcn;
+    state->previous_time = current_time;
+    state->previous_wrapped_phase_rad = wrapped_phase_rad;
+    state->unwrapped_phase_rad = wrapped_phase_rad;
+    state->previous_carrier_range_bias_m = carrier_range_bias_m;
+    state->configured = true;
+    state->continuity_active = true;
+    state->ever_had_lock = true;
+
+    result->wavelength_m = wavelength_m;
+    result->wrapped_phase_rad = wrapped_phase_rad;
+    result->unwrapped_phase_rad = wrapped_phase_rad;
+    result->carrier_range_bias_m = carrier_range_bias_m;
+    result->environmental_range_rate_mps = 0.0;
+    result->tracking_lock_valid = true;
+    result->carrier_adr_valid = epoch.adr_valid && epoch.carrier_continuity_valid;
+    result->phase_continuity_valid = true;
+    result->environmental_range_rate_valid = false;
+    result->cycle_slip_event = epoch.reacquisition_event || prior_lock_segment;
+    return true;
+}
+
+} // namespace
+
+void reset_urban_carrier_temporal_state(UrbanCarrierTemporalState* state) {
+    if (state != nullptr) {
+        *state = {};
+    }
+}
+
+bool update_urban_carrier_temporal_state(const SignalDefinition& signal, int glonass_fcn,
+                                         const SimTime& current_time, const UrbanSignalEpochResult& epoch,
+                                         UrbanCarrierTemporalState* state, UrbanCarrierTemporalResult* result,
+                                         std::string* error_message) {
+    if (state == nullptr || result == nullptr || current_time.gps_week < 0 || current_time.tow_ns < 0 ||
+        current_time.tow_ns >= GPS_WEEK_NANOSECONDS) {
+        set_error(error_message, "urban carrier temporal update has invalid arguments");
+        return false;
+    }
+
+    double wavelength_m = 0.0;
+    if (!signal_wavelength_m(signal, glonass_fcn, &wavelength_m) || !std::isfinite(wavelength_m) ||
+        !(wavelength_m > 0.0)) {
+        set_error(error_message, "urban carrier temporal update cannot determine signal wavelength");
+        return false;
+    }
+    if (state->configured && (state->signal_id != signal.signal_id || state->glonass_fcn != glonass_fcn)) {
+        set_error(error_message, "urban carrier temporal state was configured for a different signal or GLONASS FCN");
+        return false;
+    }
+
+    UrbanCarrierTemporalResult output{};
+    output.wavelength_m = wavelength_m;
+    if (!tracking_phasor_available(epoch)) {
+        output.tracking_lock_valid = false;
+        output.carrier_adr_valid = false;
+        output.phase_continuity_valid = false;
+        output.environmental_range_rate_valid = false;
+        output.cycle_slip_event = state->continuity_active;
+        state->continuity_active = false;
+        *result = output;
+        return true;
+    }
+
+    if (!state->continuity_active || epoch.reacquisition_event) {
+        if (!start_new_segment(signal, glonass_fcn, current_time, epoch, wavelength_m, state, &output, error_message)) {
+            return false;
+        }
+        *result = output;
+        return true;
+    }
+
+    std::int64_t elapsed_ns = 0;
+    if (!difference_time_ns(current_time, state->previous_time, &elapsed_ns) || elapsed_ns <= 0) {
+        set_error(error_message, "urban carrier temporal tracking epochs must be strictly increasing");
+        return false;
+    }
+
+    // A current lock younger than the elapsed time since our previous sample
+    // proves a new lock started in the gap. Never differentiate across it even
+    // if the explicit loss epoch was not supplied to this state object.
+    if (epoch.lock_time_ns >= 0 && epoch.lock_time_ns < elapsed_ns) {
+        state->continuity_active = false;
+        if (!start_new_segment(signal, glonass_fcn, current_time, epoch, wavelength_m, state, &output, error_message)) {
+            return false;
+        }
+        output.cycle_slip_event = true;
+        *result = output;
+        return true;
+    }
+
+    const std::complex<double> phasor = epoch.tracked_composite_correlation;
+    if (!finite_complex(phasor) || !(std::norm(phasor) > 0.0)) {
+        set_error(error_message, "urban carrier temporal state requires a finite non-zero tracked phasor");
+        return false;
+    }
+
+    const double wrapped_phase_rad = std::arg(phasor);
+    const double wrapped_delta_rad = std::remainder(wrapped_phase_rad - state->previous_wrapped_phase_rad, kTwoPi);
+    const double unwrapped_phase_rad = state->unwrapped_phase_rad + wrapped_delta_rad;
+    const double carrier_range_bias_m = -unwrapped_phase_rad * wavelength_m / kTwoPi;
+    const double elapsed_sec = static_cast<double>(elapsed_ns) / kNanosecondsPerSecond;
+    const double environmental_range_rate_mps =
+        (carrier_range_bias_m - state->previous_carrier_range_bias_m) / elapsed_sec;
+    if (!std::isfinite(wrapped_phase_rad) || !std::isfinite(wrapped_delta_rad) || !std::isfinite(unwrapped_phase_rad) ||
+        !std::isfinite(carrier_range_bias_m) || !std::isfinite(environmental_range_rate_mps)) {
+        set_error(error_message, "urban carrier temporal phase/range-rate result is not finite");
+        return false;
+    }
+
+    state->previous_time = current_time;
+    state->previous_wrapped_phase_rad = wrapped_phase_rad;
+    state->unwrapped_phase_rad = unwrapped_phase_rad;
+    state->previous_carrier_range_bias_m = carrier_range_bias_m;
+
+    output.wavelength_m = wavelength_m;
+    output.wrapped_phase_rad = wrapped_phase_rad;
+    output.unwrapped_phase_rad = unwrapped_phase_rad;
+    output.carrier_range_bias_m = carrier_range_bias_m;
+    output.environmental_range_rate_mps = environmental_range_rate_mps;
+    output.tracking_lock_valid = true;
+    output.carrier_adr_valid = epoch.adr_valid && epoch.carrier_continuity_valid;
+    output.phase_continuity_valid = true;
+    output.environmental_range_rate_valid = true;
+    output.cycle_slip_event = false;
+    *result = output;
+    return true;
+}
+
+} // namespace gnss_sim

--- a/src/model/urban_carrier_temporal.h
+++ b/src/model/urban_carrier_temporal.h
@@ -1,0 +1,50 @@
+#ifndef GNSS_SIM_SRC_MODEL_URBAN_CARRIER_TEMPORAL_H_
+#define GNSS_SIM_SRC_MODEL_URBAN_CARRIER_TEMPORAL_H_
+
+#include "gnss/signal_definitions.h"
+#include "gnss_sim/sim_time.h"
+#include "model/urban_signal_epoch.h"
+
+#include <string>
+
+namespace gnss_sim {
+
+struct UrbanCarrierTemporalState {
+    SignalId signal_id;
+    int glonass_fcn;
+    SimTime previous_time;
+    double previous_wrapped_phase_rad;
+    double unwrapped_phase_rad;
+    double previous_carrier_range_bias_m;
+    bool configured;
+    bool continuity_active;
+    bool ever_had_lock;
+};
+
+struct UrbanCarrierTemporalResult {
+    double wavelength_m;
+    double wrapped_phase_rad;
+    double unwrapped_phase_rad;
+    double carrier_range_bias_m;
+    double environmental_range_rate_mps;
+    bool tracking_lock_valid;
+    bool carrier_adr_valid;
+    bool phase_continuity_valid;
+    bool environmental_range_rate_valid;
+    bool cycle_slip_event;
+};
+
+void reset_urban_carrier_temporal_state(UrbanCarrierTemporalState* state);
+
+// Consume the accepted #140 receiver-domain composite phasor. With the project
+// exp(+jwt)/exp(-jkL) convention, equivalent environmental carrier range is
+// -phase_unwrapped*lambda/(2*pi). Range rate is only formed between consecutive
+// samples in one uninterrupted tracking segment.
+bool update_urban_carrier_temporal_state(const SignalDefinition& signal, int glonass_fcn,
+                                         const SimTime& current_time, const UrbanSignalEpochResult& epoch,
+                                         UrbanCarrierTemporalState* state, UrbanCarrierTemporalResult* result,
+                                         std::string* error_message);
+
+} // namespace gnss_sim
+
+#endif // GNSS_SIM_SRC_MODEL_URBAN_CARRIER_TEMPORAL_H_

--- a/src/model/urban_carrier_temporal.h
+++ b/src/model/urban_carrier_temporal.h
@@ -40,10 +40,9 @@ void reset_urban_carrier_temporal_state(UrbanCarrierTemporalState* state);
 // exp(+jwt)/exp(-jkL) convention, equivalent environmental carrier range is
 // -phase_unwrapped*lambda/(2*pi). Range rate is only formed between consecutive
 // samples in one uninterrupted tracking segment.
-bool update_urban_carrier_temporal_state(const SignalDefinition& signal, int glonass_fcn,
-                                         const SimTime& current_time, const UrbanSignalEpochResult& epoch,
-                                         UrbanCarrierTemporalState* state, UrbanCarrierTemporalResult* result,
-                                         std::string* error_message);
+bool update_urban_carrier_temporal_state(const SignalDefinition& signal, int glonass_fcn, const SimTime& current_time,
+                                         const UrbanSignalEpochResult& epoch, UrbanCarrierTemporalState* state,
+                                         UrbanCarrierTemporalResult* result, std::string* error_message);
 
 } // namespace gnss_sim
 

--- a/tests/unit/test_urban_carrier_temporal.cpp
+++ b/tests/unit/test_urban_carrier_temporal.cpp
@@ -1,0 +1,349 @@
+#include "gnss/signal_definitions.h"
+#include "gnss_sim/sim_config.h"
+#include "gnss_sim/sim_time.h"
+#include "model/urban_carrier_temporal.h"
+
+#include <cmath>
+#include <complex>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <string>
+
+namespace {
+
+constexpr double kPi = 3.141592653589793238462643383279502884;
+constexpr double kTwoPi = 2.0 * kPi;
+constexpr double kDegreesToRadians = kPi / 180.0;
+constexpr double kSyntheticSatelliteDistanceM = 20000000.0;
+constexpr std::int64_t kMilliseconds = 1000000LL;
+
+const gnss_sim::SignalDefinition& signal(gnss_sim::SignalId signal_id) {
+    const gnss_sim::SignalDefinition* definition = gnss_sim::find_signal_definition(signal_id);
+    EXPECT_NE(definition, nullptr);
+    return *definition;
+}
+
+gnss_sim::SimTime time_at(double sow_sec) {
+    gnss_sim::SimTime time{};
+    EXPECT_TRUE(gnss_sim::sim_time_from_week_sow(2400, sow_sec, &time));
+    return time;
+}
+
+std::complex<double> phasor_for_range_bias(double range_bias_m, double wavelength_m) {
+    return std::polar(1.0, -kTwoPi * range_bias_m / wavelength_m);
+}
+
+gnss_sim::UrbanSignalEpochResult tracked_epoch(const std::complex<double>& phasor, std::int64_t lock_time_ns,
+                                               bool reacquisition_event = false, double code_bias_m = 0.0) {
+    gnss_sim::UrbanSignalEpochResult epoch{};
+    epoch.tracking_phase = gnss_sim::SignalTrackingPhase::kTracking;
+    epoch.selected_root_valid = true;
+    epoch.tracked_composite_correlation_valid = true;
+    epoch.tracked_composite_correlation = phasor;
+    epoch.code_bias_m = code_bias_m;
+    epoch.lock_time_ns = lock_time_ns;
+    epoch.adr_valid = true;
+    epoch.carrier_continuity_valid = true;
+    epoch.reacquisition_event = reacquisition_event;
+    return epoch;
+}
+
+gnss_sim::UrbanSignalEpochResult lost_epoch() {
+    gnss_sim::UrbanSignalEpochResult epoch{};
+    epoch.tracking_phase = gnss_sim::SignalTrackingPhase::kSearching;
+    epoch.selected_root_valid = false;
+    epoch.tracked_composite_correlation_valid = false;
+    epoch.lock_time_ns = 0;
+    return epoch;
+}
+
+gnss_sim::DelayDistribution fixed_delay(std::int64_t delay_ns) {
+    return {delay_ns, delay_ns, delay_ns, delay_ns};
+}
+
+gnss_sim::SignalTrackingModelConfig immediate_tracking_config() {
+    gnss_sim::SignalTrackingModelConfig config = gnss_sim::default_signal_tracking_model_config();
+    config.hot_common_startup = fixed_delay(0);
+    config.warm_common_startup = fixed_delay(0);
+    config.warm_search_uncertainty = fixed_delay(0);
+    for (int index = 0; index < 4; ++index) {
+        config.hot_signal_acquisition[index] = fixed_delay(0);
+        config.reacquisition[index] = fixed_delay(0);
+    }
+    config.acquisition_cn0_persistence_ns = 0;
+    config.psr_valid_delay_ns = 0;
+    config.doppler_valid_delay_ns = 0;
+    config.adr_valid_delay_ns = 0;
+    return config;
+}
+
+gnss_sim::Cn0Model normalized_model(gnss_sim::SignalId signal_id, double high_cn0_dbhz) {
+    gnss_sim::Cn0Model model{};
+    model.source = gnss_sim::Cn0ModelSource::kCalibratedCsv;
+    model.semantic = gnss_sim::Cn0ModelSemantic::kNormalizedElevationShape;
+    model.seed = 41;
+    gnss_sim::Cn0CalibratedBin bin{};
+    bin.signal_id = signal_id;
+    bin.elevation_min_deg = 0.0;
+    bin.elevation_max_deg = 90.0;
+    bin.elevation_center_deg = 45.0;
+    bin.delta_p50_db = -2.0;
+    bin.support_count = 8;
+    bin.upper_edge_inclusive = true;
+    bin.ready = true;
+    model.calibrated_bins.push_back(bin);
+    model.high_baselines.push_back({signal_id, high_cn0_dbhz});
+    return model;
+}
+
+void schedule_tracker(gnss_sim::SignalTracker* tracker, const gnss_sim::SignalDefinition& definition,
+                      const gnss_sim::SimTime& time, double elevation_deg, const gnss_sim::Cn0Model& cn0_model,
+                      const gnss_sim::SignalTrackingModelConfig& config) {
+    gnss_sim::reset_signal_tracker(tracker, definition.signal_id, time);
+    gnss_sim::DeterministicRng rng{};
+    gnss_sim::seed_rng(&rng, 41U);
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::schedule_signal_acquisition(tracker, gnss_sim::AcquisitionContext::kHot, time, time,
+                                                      elevation_deg, cn0_model, config, &rng, &error_message))
+        << error_message;
+}
+
+void make_synthetic_geometry(double azimuth_deg, double elevation_deg, gnss_sim::ReceiverTruth* receiver,
+                             gnss_sim::SatelliteGeometry* geometry) {
+    ASSERT_NE(receiver, nullptr);
+    ASSERT_NE(geometry, nullptr);
+    *receiver = {};
+    *geometry = {};
+    geometry->satellite_state.position_ecef_m[0] = kSyntheticSatelliteDistanceM;
+    geometry->azimuth_rad = azimuth_deg * kDegreesToRadians;
+    geometry->elevation_rad = elevation_deg * kDegreesToRadians;
+    geometry->geometric_range_m = kSyntheticSatelliteDistanceM;
+    geometry->healthy = true;
+    geometry->above_elevation_mask = true;
+    geometry->visible = true;
+}
+
+TEST(UrbanCarrierTemporal, SingleMovingPathRateMatchesAnalyticRangeChange) {
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    double wavelength_m = 0.0;
+    ASSERT_TRUE(gnss_sim::signal_wavelength_m(gps_l1, 0, &wavelength_m));
+    const double first_bias_m = 0.10 * wavelength_m;
+    const double second_bias_m = 0.20 * wavelength_m;
+    const double dt_sec = 0.1;
+
+    gnss_sim::UrbanCarrierTemporalState state{};
+    gnss_sim::UrbanCarrierTemporalResult first{};
+    gnss_sim::UrbanCarrierTemporalResult second{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::update_urban_carrier_temporal_state(
+        gps_l1, 0, time_at(100000.0), tracked_epoch(phasor_for_range_bias(first_bias_m, wavelength_m), 1000 * kMilliseconds),
+        &state, &first, &error_message))
+        << error_message;
+    EXPECT_TRUE(first.phase_continuity_valid);
+    EXPECT_FALSE(first.environmental_range_rate_valid);
+    EXPECT_NEAR(first.carrier_range_bias_m, first_bias_m, 1.0e-12);
+
+    ASSERT_TRUE(gnss_sim::update_urban_carrier_temporal_state(
+        gps_l1, 0, time_at(100000.1),
+        tracked_epoch(phasor_for_range_bias(second_bias_m, wavelength_m), 1100 * kMilliseconds), &state, &second,
+        &error_message))
+        << error_message;
+    EXPECT_TRUE(second.environmental_range_rate_valid);
+    EXPECT_NEAR(second.carrier_range_bias_m, second_bias_m, 1.0e-12);
+    EXPECT_NEAR(second.environmental_range_rate_mps, (second_bias_m - first_bias_m) / dt_sec, 1.0e-10);
+}
+
+TEST(UrbanCarrierTemporal, WrappedPhaseCrossingPiRemainsContinuous) {
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    double wavelength_m = 0.0;
+    ASSERT_TRUE(gnss_sim::signal_wavelength_m(gps_l1, 0, &wavelength_m));
+    const double first_bias_m = 0.49 * wavelength_m;
+    const double second_bias_m = 0.51 * wavelength_m;
+
+    gnss_sim::UrbanCarrierTemporalState state{};
+    gnss_sim::UrbanCarrierTemporalResult first{};
+    gnss_sim::UrbanCarrierTemporalResult second{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::update_urban_carrier_temporal_state(
+        gps_l1, 0, time_at(110000.0), tracked_epoch(phasor_for_range_bias(first_bias_m, wavelength_m), 1000 * kMilliseconds),
+        &state, &first, &error_message));
+    ASSERT_TRUE(gnss_sim::update_urban_carrier_temporal_state(
+        gps_l1, 0, time_at(110000.1),
+        tracked_epoch(phasor_for_range_bias(second_bias_m, wavelength_m), 1100 * kMilliseconds), &state, &second,
+        &error_message));
+
+    EXPECT_LT(first.wrapped_phase_rad, 0.0);
+    EXPECT_GT(second.wrapped_phase_rad, 0.0);
+    EXPECT_LT(second.unwrapped_phase_rad, -kPi);
+    EXPECT_NEAR(second.carrier_range_bias_m, second_bias_m, 1.0e-12);
+}
+
+TEST(UrbanCarrierTemporal, StableCodeBiasDoesNotCreateDopplerBias) {
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    double wavelength_m = 0.0;
+    ASSERT_TRUE(gnss_sim::signal_wavelength_m(gps_l1, 0, &wavelength_m));
+    const std::complex<double> phasor = phasor_for_range_bias(0.12 * wavelength_m, wavelength_m);
+
+    gnss_sim::UrbanCarrierTemporalState state{};
+    gnss_sim::UrbanCarrierTemporalResult result{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::update_urban_carrier_temporal_state(
+        gps_l1, 0, time_at(120000.0), tracked_epoch(phasor, 1000 * kMilliseconds, false, 20.0), &state, &result,
+        &error_message));
+    ASSERT_TRUE(gnss_sim::update_urban_carrier_temporal_state(
+        gps_l1, 0, time_at(120000.2), tracked_epoch(phasor, 1200 * kMilliseconds, false, 45.0), &state, &result,
+        &error_message));
+    EXPECT_TRUE(result.environmental_range_rate_valid);
+    EXPECT_NEAR(result.environmental_range_rate_mps, 0.0, 1.0e-14);
+}
+
+TEST(UrbanCarrierTemporal, LossAndReacquisitionStartNewContinuitySegment) {
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    double wavelength_m = 0.0;
+    ASSERT_TRUE(gnss_sim::signal_wavelength_m(gps_l1, 0, &wavelength_m));
+
+    gnss_sim::UrbanCarrierTemporalState state{};
+    gnss_sim::UrbanCarrierTemporalResult result{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::update_urban_carrier_temporal_state(
+        gps_l1, 0, time_at(130000.0),
+        tracked_epoch(phasor_for_range_bias(0.1 * wavelength_m, wavelength_m), 1000 * kMilliseconds), &state, &result,
+        &error_message));
+
+    ASSERT_TRUE(gnss_sim::update_urban_carrier_temporal_state(gps_l1, 0, time_at(130000.1), lost_epoch(), &state,
+                                                              &result, &error_message));
+    EXPECT_TRUE(result.cycle_slip_event);
+    EXPECT_FALSE(result.phase_continuity_valid);
+    EXPECT_FALSE(result.environmental_range_rate_valid);
+
+    ASSERT_TRUE(gnss_sim::update_urban_carrier_temporal_state(
+        gps_l1, 0, time_at(130000.2),
+        tracked_epoch(phasor_for_range_bias(0.4 * wavelength_m, wavelength_m), 0, true), &state, &result,
+        &error_message));
+    EXPECT_TRUE(result.cycle_slip_event);
+    EXPECT_TRUE(result.phase_continuity_valid);
+    EXPECT_FALSE(result.environmental_range_rate_valid);
+}
+
+TEST(UrbanCarrierTemporal, FreshLockInsideSkippedGapIsNeverDifferentiated) {
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    double wavelength_m = 0.0;
+    ASSERT_TRUE(gnss_sim::signal_wavelength_m(gps_l1, 0, &wavelength_m));
+
+    gnss_sim::UrbanCarrierTemporalState state{};
+    gnss_sim::UrbanCarrierTemporalResult result{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::update_urban_carrier_temporal_state(
+        gps_l1, 0, time_at(140000.0),
+        tracked_epoch(phasor_for_range_bias(0.1 * wavelength_m, wavelength_m), 5000 * kMilliseconds), &state, &result,
+        &error_message));
+    ASSERT_TRUE(gnss_sim::update_urban_carrier_temporal_state(
+        gps_l1, 0, time_at(140001.0),
+        tracked_epoch(phasor_for_range_bias(0.4 * wavelength_m, wavelength_m), 200 * kMilliseconds), &state, &result,
+        &error_message));
+    EXPECT_TRUE(result.cycle_slip_event);
+    EXPECT_FALSE(result.environmental_range_rate_valid);
+}
+
+TEST(UrbanCarrierTemporal, DifferentCarrierWavelengthUsesCentralSignalMetadata) {
+    const gnss_sim::SignalDefinition& gal_e5a = signal(gnss_sim::SignalId::kGalileoE5A);
+    double wavelength_m = 0.0;
+    ASSERT_TRUE(gnss_sim::signal_wavelength_m(gal_e5a, 0, &wavelength_m));
+    const double first_bias_m = 0.08 * wavelength_m;
+    const double second_bias_m = 0.18 * wavelength_m;
+
+    gnss_sim::UrbanCarrierTemporalState state{};
+    gnss_sim::UrbanCarrierTemporalResult result{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::update_urban_carrier_temporal_state(
+        gal_e5a, 0, time_at(150000.0), tracked_epoch(phasor_for_range_bias(first_bias_m, wavelength_m), 1000 * kMilliseconds),
+        &state, &result, &error_message));
+    ASSERT_TRUE(gnss_sim::update_urban_carrier_temporal_state(
+        gal_e5a, 0, time_at(150000.1),
+        tracked_epoch(phasor_for_range_bias(second_bias_m, wavelength_m), 1100 * kMilliseconds), &state, &result,
+        &error_message));
+    EXPECT_NEAR(result.wavelength_m, wavelength_m, 1.0e-15);
+    EXPECT_NEAR(result.carrier_range_bias_m, second_bias_m, 1.0e-12);
+}
+
+TEST(UrbanCarrierTemporal, ProductionRoofTransitionProducesTimeCorrelatedPathRateFromSameEpochResult) {
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    const gnss_sim::UrbanSceneGeometryConfig scene = gnss_sim::default_urban_scene_geometry_config();
+    const gnss_sim::SimConfig sim_config = gnss_sim::default_sim_config();
+    const gnss_sim::SignalTrackingModelConfig tracking_config = immediate_tracking_config();
+    const gnss_sim::Cn0Model cn0 = normalized_model(gps_l1.signal_id, 55.0);
+    const gnss_sim::CodeTrackingDllConfig dll_config = gnss_sim::default_code_tracking_dll_config();
+    double skyline_rad = 0.0;
+    double wall_distance_m = 0.0;
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::compute_urban_skyline_elevation(scene, 0.0, &skyline_rad, &wall_distance_m, &error_message));
+
+    const double first_elevation_deg = skyline_rad / kDegreesToRadians + 0.001;
+    const double second_elevation_deg = skyline_rad / kDegreesToRadians + 0.002;
+    const gnss_sim::SimTime first_time = time_at(160000.0);
+    const gnss_sim::SimTime second_time = time_at(160000.1);
+    gnss_sim::ReceiverTruth receiver{};
+    gnss_sim::SatelliteGeometry first_geometry{};
+    gnss_sim::SatelliteGeometry second_geometry{};
+    make_synthetic_geometry(0.0, first_elevation_deg, &receiver, &first_geometry);
+    make_synthetic_geometry(0.0, second_elevation_deg, &receiver, &second_geometry);
+    gnss_sim::SignalTracker tracker{};
+    schedule_tracker(&tracker, gps_l1, first_time, first_elevation_deg, cn0, tracking_config);
+
+    gnss_sim::UrbanSignalEpochResult first_epoch{};
+    gnss_sim::UrbanSignalEpochResult second_epoch{};
+    ASSERT_TRUE(gnss_sim::compute_urban_signal_epoch(cn0, scene, sim_config.urban_rf, dll_config, tracking_config,
+                                                     gps_l1, 0, first_time, receiver, first_geometry, &tracker,
+                                                     &first_epoch, &error_message))
+        << error_message;
+    ASSERT_TRUE(gnss_sim::compute_urban_signal_epoch(cn0, scene, sim_config.urban_rf, dll_config, tracking_config,
+                                                     gps_l1, 0, second_time, receiver, second_geometry, &tracker,
+                                                     &second_epoch, &error_message))
+        << error_message;
+    ASSERT_EQ(first_epoch.urban_state, gnss_sim::UrbanSignalState::kLosMultipath);
+    ASSERT_EQ(second_epoch.urban_state, gnss_sim::UrbanSignalState::kLosMultipath);
+
+    gnss_sim::UrbanCarrierTemporalState state{};
+    gnss_sim::UrbanCarrierTemporalResult first_result{};
+    gnss_sim::UrbanCarrierTemporalResult second_result{};
+    ASSERT_TRUE(gnss_sim::update_urban_carrier_temporal_state(gps_l1, 0, first_time, first_epoch, &state, &first_result,
+                                                              &error_message))
+        << error_message;
+    ASSERT_TRUE(gnss_sim::update_urban_carrier_temporal_state(gps_l1, 0, second_time, second_epoch, &state,
+                                                              &second_result, &error_message))
+        << error_message;
+    EXPECT_TRUE(second_result.environmental_range_rate_valid);
+    EXPECT_TRUE(std::isfinite(second_result.environmental_range_rate_mps));
+    EXPECT_GT(std::abs(second_result.environmental_range_rate_mps), 1.0e-12);
+}
+
+TEST(UrbanCarrierTemporal, IdenticalSequencesAreDeterministic) {
+    const gnss_sim::SignalDefinition& gps_l1 = signal(gnss_sim::SignalId::kGpsL1Ca);
+    double wavelength_m = 0.0;
+    ASSERT_TRUE(gnss_sim::signal_wavelength_m(gps_l1, 0, &wavelength_m));
+    const double biases[] = {0.10 * wavelength_m, 0.12 * wavelength_m, 0.15 * wavelength_m};
+    const double times[] = {170000.0, 170000.1, 170000.2};
+
+    gnss_sim::UrbanCarrierTemporalState first_state{};
+    gnss_sim::UrbanCarrierTemporalState second_state{};
+    std::string first_error;
+    std::string second_error;
+    for (int index = 0; index < 3; ++index) {
+        const gnss_sim::UrbanSignalEpochResult epoch =
+            tracked_epoch(phasor_for_range_bias(biases[index], wavelength_m), (1000 + index * 100) * kMilliseconds);
+        gnss_sim::UrbanCarrierTemporalResult first{};
+        gnss_sim::UrbanCarrierTemporalResult second{};
+        ASSERT_TRUE(gnss_sim::update_urban_carrier_temporal_state(gps_l1, 0, time_at(times[index]), epoch, &first_state,
+                                                                  &first, &first_error));
+        ASSERT_TRUE(gnss_sim::update_urban_carrier_temporal_state(gps_l1, 0, time_at(times[index]), epoch, &second_state,
+                                                                  &second, &second_error));
+        EXPECT_DOUBLE_EQ(first.wrapped_phase_rad, second.wrapped_phase_rad);
+        EXPECT_DOUBLE_EQ(first.unwrapped_phase_rad, second.unwrapped_phase_rad);
+        EXPECT_DOUBLE_EQ(first.carrier_range_bias_m, second.carrier_range_bias_m);
+        EXPECT_DOUBLE_EQ(first.environmental_range_rate_mps, second.environmental_range_rate_mps);
+        EXPECT_EQ(first.environmental_range_rate_valid, second.environmental_range_rate_valid);
+        EXPECT_EQ(first.cycle_slip_event, second.cycle_slip_event);
+    }
+}
+
+} // namespace

--- a/tests/unit/test_urban_carrier_temporal.cpp
+++ b/tests/unit/test_urban_carrier_temporal.cpp
@@ -136,8 +136,9 @@ TEST(UrbanCarrierTemporal, SingleMovingPathRateMatchesAnalyticRangeChange) {
     gnss_sim::UrbanCarrierTemporalResult second{};
     std::string error_message;
     ASSERT_TRUE(gnss_sim::update_urban_carrier_temporal_state(
-        gps_l1, 0, time_at(100000.0), tracked_epoch(phasor_for_range_bias(first_bias_m, wavelength_m), 1000 * kMilliseconds),
-        &state, &first, &error_message))
+        gps_l1, 0, time_at(100000.0),
+        tracked_epoch(phasor_for_range_bias(first_bias_m, wavelength_m), 1000 * kMilliseconds), &state, &first,
+        &error_message))
         << error_message;
     EXPECT_TRUE(first.phase_continuity_valid);
     EXPECT_FALSE(first.environmental_range_rate_valid);
@@ -165,8 +166,9 @@ TEST(UrbanCarrierTemporal, WrappedPhaseCrossingPiRemainsContinuous) {
     gnss_sim::UrbanCarrierTemporalResult second{};
     std::string error_message;
     ASSERT_TRUE(gnss_sim::update_urban_carrier_temporal_state(
-        gps_l1, 0, time_at(110000.0), tracked_epoch(phasor_for_range_bias(first_bias_m, wavelength_m), 1000 * kMilliseconds),
-        &state, &first, &error_message));
+        gps_l1, 0, time_at(110000.0),
+        tracked_epoch(phasor_for_range_bias(first_bias_m, wavelength_m), 1000 * kMilliseconds), &state, &first,
+        &error_message));
     ASSERT_TRUE(gnss_sim::update_urban_carrier_temporal_state(
         gps_l1, 0, time_at(110000.1),
         tracked_epoch(phasor_for_range_bias(second_bias_m, wavelength_m), 1100 * kMilliseconds), &state, &second,
@@ -187,12 +189,12 @@ TEST(UrbanCarrierTemporal, StableCodeBiasDoesNotCreateDopplerBias) {
     gnss_sim::UrbanCarrierTemporalState state{};
     gnss_sim::UrbanCarrierTemporalResult result{};
     std::string error_message;
-    ASSERT_TRUE(gnss_sim::update_urban_carrier_temporal_state(
-        gps_l1, 0, time_at(120000.0), tracked_epoch(phasor, 1000 * kMilliseconds, false, 20.0), &state, &result,
-        &error_message));
-    ASSERT_TRUE(gnss_sim::update_urban_carrier_temporal_state(
-        gps_l1, 0, time_at(120000.2), tracked_epoch(phasor, 1200 * kMilliseconds, false, 45.0), &state, &result,
-        &error_message));
+    ASSERT_TRUE(gnss_sim::update_urban_carrier_temporal_state(gps_l1, 0, time_at(120000.0),
+                                                              tracked_epoch(phasor, 1000 * kMilliseconds, false, 20.0),
+                                                              &state, &result, &error_message));
+    ASSERT_TRUE(gnss_sim::update_urban_carrier_temporal_state(gps_l1, 0, time_at(120000.2),
+                                                              tracked_epoch(phasor, 1200 * kMilliseconds, false, 45.0),
+                                                              &state, &result, &error_message));
     EXPECT_TRUE(result.environmental_range_rate_valid);
     EXPECT_NEAR(result.environmental_range_rate_mps, 0.0, 1.0e-14);
 }
@@ -217,9 +219,8 @@ TEST(UrbanCarrierTemporal, LossAndReacquisitionStartNewContinuitySegment) {
     EXPECT_FALSE(result.environmental_range_rate_valid);
 
     ASSERT_TRUE(gnss_sim::update_urban_carrier_temporal_state(
-        gps_l1, 0, time_at(130000.2),
-        tracked_epoch(phasor_for_range_bias(0.4 * wavelength_m, wavelength_m), 0, true), &state, &result,
-        &error_message));
+        gps_l1, 0, time_at(130000.2), tracked_epoch(phasor_for_range_bias(0.4 * wavelength_m, wavelength_m), 0, true),
+        &state, &result, &error_message));
     EXPECT_TRUE(result.cycle_slip_event);
     EXPECT_TRUE(result.phase_continuity_valid);
     EXPECT_FALSE(result.environmental_range_rate_valid);
@@ -256,8 +257,9 @@ TEST(UrbanCarrierTemporal, DifferentCarrierWavelengthUsesCentralSignalMetadata) 
     gnss_sim::UrbanCarrierTemporalResult result{};
     std::string error_message;
     ASSERT_TRUE(gnss_sim::update_urban_carrier_temporal_state(
-        gal_e5a, 0, time_at(150000.0), tracked_epoch(phasor_for_range_bias(first_bias_m, wavelength_m), 1000 * kMilliseconds),
-        &state, &result, &error_message));
+        gal_e5a, 0, time_at(150000.0),
+        tracked_epoch(phasor_for_range_bias(first_bias_m, wavelength_m), 1000 * kMilliseconds), &state, &result,
+        &error_message));
     ASSERT_TRUE(gnss_sim::update_urban_carrier_temporal_state(
         gal_e5a, 0, time_at(150000.1),
         tracked_epoch(phasor_for_range_bias(second_bias_m, wavelength_m), 1100 * kMilliseconds), &state, &result,
@@ -335,8 +337,8 @@ TEST(UrbanCarrierTemporal, IdenticalSequencesAreDeterministic) {
         gnss_sim::UrbanCarrierTemporalResult second{};
         ASSERT_TRUE(gnss_sim::update_urban_carrier_temporal_state(gps_l1, 0, time_at(times[index]), epoch, &first_state,
                                                                   &first, &first_error));
-        ASSERT_TRUE(gnss_sim::update_urban_carrier_temporal_state(gps_l1, 0, time_at(times[index]), epoch, &second_state,
-                                                                  &second, &second_error));
+        ASSERT_TRUE(gnss_sim::update_urban_carrier_temporal_state(gps_l1, 0, time_at(times[index]), epoch,
+                                                                  &second_state, &second, &second_error));
         EXPECT_DOUBLE_EQ(first.wrapped_phase_rad, second.wrapped_phase_rad);
         EXPECT_DOUBLE_EQ(first.unwrapped_phase_rad, second.unwrapped_phase_rad);
         EXPECT_DOUBLE_EQ(first.carrier_range_bias_m, second.carrier_range_bias_m);


### PR DESCRIPTION
Closes #141.

## Summary
Add the per-signal temporal state that consumes #140's accepted receiver-domain composite phasor and produces a continuous environmental carrier-range bias plus finite-difference environmental path rate.

## Frozen conventions
- keep `exp(+jωt)` / `exp(-jkL)`;
- `ΔL_carrier = -phase_unwrapped * λ / (2π)`;
- first epoch of a fresh lock establishes the phase branch but has `environmental_range_rate_valid=false`;
- subsequent uninterrupted tracking epochs unwrap to the nearest phase branch and form range rate from the same carrier-range bias;
- no differentiation across loss/reacquisition gaps;
- a current #121 lock time younger than the sample interval is treated as proof of an intervening fresh lock even if the explicit loss epoch was skipped;
- reacquisition starts a new segment and flags a cycle-slip/discontinuity event;
- central signal metadata supplies wavelength, including future GLONASS-FCN use.

## Focused coverage
- analytic single-path range-rate finite difference;
- ±π phase wrapping continuity;
- changing code bias with constant carrier phasor produces zero Doppler/path-rate bias;
- loss + reacquisition reset;
- skipped-gap fresh-lock detection;
- Galileo E5A wavelength handling;
- two real #140 frozen-scene rooftop epochs produce a finite time-correlated path rate;
- deterministic repeated sequences.

## Scope exclusions
No `MeasurementObservation` changes, simulator runtime wiring, RANGE serialization, NAV changes, arbitrary Doppler injection, or PVT tuning.