### PR TITLE
Apply urban state to measurement observations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,7 @@ add_library(gnss_sim_core STATIC
     src/model/receiver_truth.cpp
     src/model/signal_tracking.cpp
     src/model/urban_carrier_temporal.cpp
+    src/model/urban_measurement_application.cpp
     src/model/urban_received_power.cpp
     src/model/urban_reflection_paths.cpp
     src/model/urban_rooftop_diffraction.cpp
@@ -269,6 +270,7 @@ if(BUILD_TESTING)
         tests/unit/test_solution_engine.cpp
         tests/unit/test_solution_signal_policy.cpp
         tests/unit/test_urban_carrier_temporal.cpp
+        tests/unit/test_urban_measurement_application.cpp
         tests/unit/test_urban_received_power.cpp
         tests/unit/test_urban_reflection_paths.cpp
         tests/unit/test_urban_rooftop_diffraction.cpp

--- a/src/model/measurement_model.h
+++ b/src/model/measurement_model.h
@@ -12,6 +12,9 @@
 
 namespace gnss_sim {
 
+struct UrbanCarrierTemporalResult;
+struct UrbanSignalEpochResult;
+
 enum class BroadcastCodeBiasStatus {
     kApplied,
     kNoCorrection,
@@ -69,6 +72,14 @@ bool generate_zero_noise_measurement_with_explicit_code_bias(
     const SatelliteGeometry& geometry, const ReceiverTruth& receiver, const SignalTracker& tracker,
     const AtmosphereCorrection& atmosphere, double code_bias_m, CarrierAmbiguityState* ambiguity_state,
     MeasurementObservation* observation, std::string* error_message);
+
+// Apply #140/#141 environmental terms to one already-generated clean
+// zero-noise measurement. Broadcast/explicit code bias, satellite clock,
+// atmosphere, and carrier ambiguity have already been applied exactly once by
+// the clean generator and are not recomputed here.
+bool apply_urban_measurement_effects(const UrbanSignalEpochResult& epoch,
+                                     const UrbanCarrierTemporalResult& temporal,
+                                     MeasurementObservation* observation, std::string* error_message);
 
 const char* broadcast_code_bias_status_name(BroadcastCodeBiasStatus status);
 

--- a/src/model/measurement_model.h
+++ b/src/model/measurement_model.h
@@ -77,8 +77,7 @@ bool generate_zero_noise_measurement_with_explicit_code_bias(
 // zero-noise measurement. Broadcast/explicit code bias, satellite clock,
 // atmosphere, and carrier ambiguity have already been applied exactly once by
 // the clean generator and are not recomputed here.
-bool apply_urban_measurement_effects(const UrbanSignalEpochResult& epoch,
-                                     const UrbanCarrierTemporalResult& temporal,
+bool apply_urban_measurement_effects(const UrbanSignalEpochResult& epoch, const UrbanCarrierTemporalResult& temporal,
                                      MeasurementObservation* observation, std::string* error_message);
 
 const char* broadcast_code_bias_status_name(BroadcastCodeBiasStatus status);

--- a/src/model/urban_measurement_application.cpp
+++ b/src/model/urban_measurement_application.cpp
@@ -1,0 +1,99 @@
+#include "model/measurement_model.h"
+
+#include "model/urban_carrier_temporal.h"
+#include "model/urban_signal_epoch.h"
+
+#include <cmath>
+
+namespace gnss_sim {
+namespace {
+
+void set_error(std::string* error_message, const char* message) {
+    if (error_message != nullptr) {
+        *error_message = message;
+    }
+}
+
+bool valid_effective_cn0(double cn0_dbhz) {
+    return std::isfinite(cn0_dbhz) || (std::isinf(cn0_dbhz) && cn0_dbhz < 0.0);
+}
+
+bool wavelength_matches(double clean_wavelength_m, double temporal_wavelength_m) {
+    if (!std::isfinite(clean_wavelength_m) || !std::isfinite(temporal_wavelength_m) ||
+        !(clean_wavelength_m > 0.0) || !(temporal_wavelength_m > 0.0)) {
+        return false;
+    }
+    const double tolerance_m = 1.0e-12 * clean_wavelength_m + 1.0e-15;
+    return std::abs(clean_wavelength_m - temporal_wavelength_m) <= tolerance_m;
+}
+
+} // namespace
+
+bool apply_urban_measurement_effects(const UrbanSignalEpochResult& epoch,
+                                     const UrbanCarrierTemporalResult& temporal,
+                                     MeasurementObservation* observation, std::string* error_message) {
+    if (observation == nullptr || !wavelength_matches(observation->wavelength_m, temporal.wavelength_m) ||
+        !std::isfinite(observation->pseudorange_m) || !std::isfinite(observation->range_rate_mps) ||
+        !std::isfinite(observation->doppler_hz) || !std::isfinite(observation->adr_cycles) ||
+        !std::isfinite(epoch.code_bias_m) || !valid_effective_cn0(epoch.effective_cn0_dbhz) ||
+        epoch.lock_time_ns < 0 || !std::isfinite(temporal.carrier_range_bias_m) ||
+        !std::isfinite(temporal.environmental_range_rate_mps)) {
+        set_error(error_message, "urban measurement application has invalid arguments");
+        return false;
+    }
+
+    const bool epoch_tracking_phasor = epoch.tracking_phase == SignalTrackingPhase::kTracking &&
+                                       epoch.selected_root_valid && epoch.tracked_composite_correlation_valid;
+    if (temporal.tracking_lock_valid != epoch_tracking_phasor ||
+        (temporal.phase_continuity_valid && !temporal.tracking_lock_valid) ||
+        (temporal.environmental_range_rate_valid && !temporal.phase_continuity_valid) ||
+        (temporal.carrier_adr_valid && !temporal.phase_continuity_valid)) {
+        set_error(error_message, "urban measurement epoch and temporal states are inconsistent");
+        return false;
+    }
+
+    MeasurementObservation output = *observation;
+
+    // Keep MeasurementObservation::code_bias_m as the broadcast/explicit code
+    // bias diagnostic. The environmental DLL bias is a separate physical term
+    // and therefore only shifts the final pseudorange here.
+    if (epoch.selected_root_valid) {
+        output.pseudorange_m += epoch.code_bias_m;
+    }
+
+    // The #141 environmental range rate is additive to the authentic-NAV clean
+    // range rate exactly once. Preserve a finite numeric baseline when the
+    // derivative is unavailable, but mark Doppler invalid below rather than
+    // silently assuming zero environmental rate.
+    if (temporal.environmental_range_rate_valid) {
+        output.range_rate_mps += temporal.environmental_range_rate_mps;
+        output.doppler_hz -= temporal.environmental_range_rate_mps / output.wavelength_m;
+    }
+
+    // Clean ADR already contains clock/ionosphere/troposphere and the existing
+    // deterministic ambiguity segment. Add only the continuous environmental
+    // carrier-range term from #141; never create a second ambiguity here.
+    if (temporal.phase_continuity_valid) {
+        output.adr_cycles += temporal.carrier_range_bias_m / output.wavelength_m;
+    }
+
+    output.cn0_dbhz = epoch.effective_cn0_dbhz;
+    output.lock_time_ns = epoch.lock_time_ns;
+
+    const bool urban_observation_available = epoch.observation_available && temporal.tracking_lock_valid;
+    output.observation_available = output.observation_available && urban_observation_available;
+    output.pseudorange_valid = output.pseudorange_valid && epoch.psr_valid && epoch.selected_root_valid;
+    output.doppler_valid = output.doppler_valid && epoch.doppler_valid && temporal.environmental_range_rate_valid;
+    output.adr_valid = output.adr_valid && epoch.adr_valid && temporal.carrier_adr_valid;
+
+    if (!output.observation_available) {
+        output.pseudorange_valid = false;
+        output.doppler_valid = false;
+        output.adr_valid = false;
+    }
+
+    *observation = output;
+    return true;
+}
+
+} // namespace gnss_sim

--- a/src/model/urban_measurement_application.cpp
+++ b/src/model/urban_measurement_application.cpp
@@ -1,5 +1,4 @@
 #include "model/measurement_model.h"
-
 #include "model/urban_carrier_temporal.h"
 #include "model/urban_signal_epoch.h"
 
@@ -19,8 +18,8 @@ bool valid_effective_cn0(double cn0_dbhz) {
 }
 
 bool wavelength_matches(double clean_wavelength_m, double temporal_wavelength_m) {
-    if (!std::isfinite(clean_wavelength_m) || !std::isfinite(temporal_wavelength_m) ||
-        !(clean_wavelength_m > 0.0) || !(temporal_wavelength_m > 0.0)) {
+    if (!std::isfinite(clean_wavelength_m) || !std::isfinite(temporal_wavelength_m) || !(clean_wavelength_m > 0.0) ||
+        !(temporal_wavelength_m > 0.0)) {
         return false;
     }
     const double tolerance_m = 1.0e-12 * clean_wavelength_m + 1.0e-15;
@@ -29,15 +28,13 @@ bool wavelength_matches(double clean_wavelength_m, double temporal_wavelength_m)
 
 } // namespace
 
-bool apply_urban_measurement_effects(const UrbanSignalEpochResult& epoch,
-                                     const UrbanCarrierTemporalResult& temporal,
+bool apply_urban_measurement_effects(const UrbanSignalEpochResult& epoch, const UrbanCarrierTemporalResult& temporal,
                                      MeasurementObservation* observation, std::string* error_message) {
     if (observation == nullptr || !wavelength_matches(observation->wavelength_m, temporal.wavelength_m) ||
         !std::isfinite(observation->pseudorange_m) || !std::isfinite(observation->range_rate_mps) ||
         !std::isfinite(observation->doppler_hz) || !std::isfinite(observation->adr_cycles) ||
-        !std::isfinite(epoch.code_bias_m) || !valid_effective_cn0(epoch.effective_cn0_dbhz) ||
-        epoch.lock_time_ns < 0 || !std::isfinite(temporal.carrier_range_bias_m) ||
-        !std::isfinite(temporal.environmental_range_rate_mps)) {
+        !std::isfinite(epoch.code_bias_m) || !valid_effective_cn0(epoch.effective_cn0_dbhz) || epoch.lock_time_ns < 0 ||
+        !std::isfinite(temporal.carrier_range_bias_m) || !std::isfinite(temporal.environmental_range_rate_mps)) {
         set_error(error_message, "urban measurement application has invalid arguments");
         return false;
     }

--- a/tests/unit/test_urban_measurement_application.cpp
+++ b/tests/unit/test_urban_measurement_application.cpp
@@ -85,7 +85,7 @@ TEST(UrbanMeasurementApplication, AppliesCodeCarrierRateAndCn0ExactlyOnce) {
     EXPECT_NEAR(observation.pseudorange_m - clean.pseudorange_m, 4.5, 1.0e-12);
     EXPECT_NEAR(observation.range_rate_mps - clean.range_rate_mps, 1.4, 1.0e-12);
     EXPECT_NEAR(observation.doppler_hz - clean.doppler_hz, -1.4 / kWavelengthM, 1.0e-12);
-    EXPECT_NEAR(observation.adr_cycles - clean.adr_cycles, 0.32 / kWavelengthM, 1.0e-9);
+    EXPECT_NEAR(observation.adr_cycles - clean.adr_cycles, 0.32 / kWavelengthM, 1.0e-8);
     EXPECT_DOUBLE_EQ(observation.cn0_dbhz, 34.25);
     EXPECT_EQ(observation.lock_time_ns, 8200000000LL);
     EXPECT_TRUE(observation.observation_available);
@@ -135,7 +135,7 @@ TEST(UrbanMeasurementApplication, FreshLockWithoutPathRateDoesNotInventDopplerCo
     EXPECT_DOUBLE_EQ(observation.doppler_hz, clean.doppler_hz);
     EXPECT_FALSE(observation.doppler_valid);
     EXPECT_TRUE(observation.adr_valid);
-    EXPECT_NEAR(observation.adr_cycles - clean.adr_cycles, 0.07 / kWavelengthM, 1.0e-9);
+    EXPECT_NEAR(observation.adr_cycles - clean.adr_cycles, 0.07 / kWavelengthM, 1.0e-8);
 }
 
 TEST(UrbanMeasurementApplication, BlockedStateCannotLeakValidRangeObservation) {

--- a/tests/unit/test_urban_measurement_application.cpp
+++ b/tests/unit/test_urban_measurement_application.cpp
@@ -1,0 +1,248 @@
+#include "gnss/signal_definitions.h"
+#include "model/measurement_model.h"
+#include "model/urban_carrier_temporal.h"
+#include "model/urban_signal_epoch.h"
+
+#include <cmath>
+#include <gtest/gtest.h>
+#include <limits>
+#include <string>
+
+namespace {
+
+gnss_sim::MeasurementObservation clean_observation(double wavelength_m) {
+    gnss_sim::MeasurementObservation result{};
+    result.signal_id = gnss_sim::SignalId::kGpsL1Ca;
+    result.satellite_number = 7;
+    result.glonass_fcn = 0;
+    result.wavelength_m = wavelength_m;
+    result.geometric_range_m = 22000000.0;
+    result.range_rate_mps = -512.25;
+    result.satellite_clock_bias_m = 13.5;
+    result.satellite_clock_drift_mps = -0.125;
+    result.broadcast_message_family = gnss_sim::RtklibBroadcastMessageFamily::kLegacy;
+    result.tgd_sec[0] = 5.0e-9;
+    result.isc_sec[0] = 2.0e-9;
+    result.glonass_dtaun_sec = 3.0e-9;
+    result.code_bias_m = 1.75;
+    result.ionosphere_code_delay_m = 6.25;
+    result.troposphere_delay_m = 2.1;
+    result.pseudorange_m = 22000010.6;
+    result.doppler_hz = 2692.5;
+    result.adr_cycles = 115000123.25;
+    result.cn0_dbhz = 45.0;
+    result.lock_time_ns = 5000000000LL;
+    result.ambiguity_cycles = 345678;
+    result.code_bias_status = gnss_sim::BroadcastCodeBiasStatus::kApplied;
+    result.observation_available = true;
+    result.pseudorange_valid = true;
+    result.doppler_valid = true;
+    result.adr_valid = true;
+    return result;
+}
+
+gnss_sim::UrbanSignalEpochResult tracked_epoch(double code_bias_m, double effective_cn0_dbhz,
+                                               std::int64_t lock_time_ns) {
+    gnss_sim::UrbanSignalEpochResult result{};
+    result.tracking_phase = gnss_sim::SignalTrackingPhase::kTracking;
+    result.code_bias_m = code_bias_m;
+    result.effective_cn0_dbhz = effective_cn0_dbhz;
+    result.lock_time_ns = lock_time_ns;
+    result.selected_root_valid = true;
+    result.tracked_composite_correlation_valid = true;
+    result.observation_available = true;
+    result.psr_valid = true;
+    result.doppler_valid = true;
+    result.adr_valid = true;
+    result.carrier_continuity_valid = true;
+    return result;
+}
+
+gnss_sim::UrbanCarrierTemporalResult tracked_temporal(double wavelength_m, double carrier_range_bias_m,
+                                                       double environmental_range_rate_mps) {
+    gnss_sim::UrbanCarrierTemporalResult result{};
+    result.wavelength_m = wavelength_m;
+    result.carrier_range_bias_m = carrier_range_bias_m;
+    result.environmental_range_rate_mps = environmental_range_rate_mps;
+    result.tracking_lock_valid = true;
+    result.carrier_adr_valid = true;
+    result.phase_continuity_valid = true;
+    result.environmental_range_rate_valid = true;
+    return result;
+}
+
+TEST(UrbanMeasurementApplication, AppliesCodeCarrierRateAndCn0ExactlyOnce) {
+    constexpr double kWavelengthM = 0.20;
+    gnss_sim::MeasurementObservation observation = clean_observation(kWavelengthM);
+    const gnss_sim::MeasurementObservation clean = observation;
+    const gnss_sim::UrbanSignalEpochResult epoch = tracked_epoch(4.5, 34.25, 8200000000LL);
+    const gnss_sim::UrbanCarrierTemporalResult temporal = tracked_temporal(kWavelengthM, 0.32, 1.4);
+
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::apply_urban_measurement_effects(epoch, temporal, &observation, &error_message))
+        << error_message;
+
+    EXPECT_NEAR(observation.pseudorange_m - clean.pseudorange_m, 4.5, 1.0e-12);
+    EXPECT_NEAR(observation.range_rate_mps - clean.range_rate_mps, 1.4, 1.0e-12);
+    EXPECT_NEAR(observation.doppler_hz - clean.doppler_hz, -1.4 / kWavelengthM, 1.0e-12);
+    EXPECT_NEAR(observation.adr_cycles - clean.adr_cycles, 0.32 / kWavelengthM, 1.0e-9);
+    EXPECT_DOUBLE_EQ(observation.cn0_dbhz, 34.25);
+    EXPECT_EQ(observation.lock_time_ns, 8200000000LL);
+    EXPECT_TRUE(observation.observation_available);
+    EXPECT_TRUE(observation.pseudorange_valid);
+    EXPECT_TRUE(observation.doppler_valid);
+    EXPECT_TRUE(observation.adr_valid);
+}
+
+TEST(UrbanMeasurementApplication, PreservesBroadcastAtmosphereClockAndAmbiguityDiagnostics) {
+    constexpr double kWavelengthM = 0.20;
+    gnss_sim::MeasurementObservation observation = clean_observation(kWavelengthM);
+    const gnss_sim::MeasurementObservation clean = observation;
+    const gnss_sim::UrbanSignalEpochResult epoch = tracked_epoch(3.0, 38.0, 6000000000LL);
+    const gnss_sim::UrbanCarrierTemporalResult temporal = tracked_temporal(kWavelengthM, -0.11, -0.75);
+
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::apply_urban_measurement_effects(epoch, temporal, &observation, &error_message))
+        << error_message;
+
+    EXPECT_DOUBLE_EQ(observation.geometric_range_m, clean.geometric_range_m);
+    EXPECT_DOUBLE_EQ(observation.satellite_clock_bias_m, clean.satellite_clock_bias_m);
+    EXPECT_DOUBLE_EQ(observation.satellite_clock_drift_mps, clean.satellite_clock_drift_mps);
+    EXPECT_EQ(observation.broadcast_message_family, clean.broadcast_message_family);
+    EXPECT_DOUBLE_EQ(observation.tgd_sec[0], clean.tgd_sec[0]);
+    EXPECT_DOUBLE_EQ(observation.isc_sec[0], clean.isc_sec[0]);
+    EXPECT_DOUBLE_EQ(observation.glonass_dtaun_sec, clean.glonass_dtaun_sec);
+    EXPECT_DOUBLE_EQ(observation.code_bias_m, clean.code_bias_m);
+    EXPECT_EQ(observation.code_bias_status, clean.code_bias_status);
+    EXPECT_DOUBLE_EQ(observation.ionosphere_code_delay_m, clean.ionosphere_code_delay_m);
+    EXPECT_DOUBLE_EQ(observation.troposphere_delay_m, clean.troposphere_delay_m);
+    EXPECT_EQ(observation.ambiguity_cycles, clean.ambiguity_cycles);
+}
+
+TEST(UrbanMeasurementApplication, FreshLockWithoutPathRateDoesNotInventDopplerCorrection) {
+    constexpr double kWavelengthM = 0.20;
+    gnss_sim::MeasurementObservation observation = clean_observation(kWavelengthM);
+    const gnss_sim::MeasurementObservation clean = observation;
+    const gnss_sim::UrbanSignalEpochResult epoch = tracked_epoch(0.8, 31.0, 0);
+    gnss_sim::UrbanCarrierTemporalResult temporal = tracked_temporal(kWavelengthM, 0.07, 0.0);
+    temporal.environmental_range_rate_valid = false;
+
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::apply_urban_measurement_effects(epoch, temporal, &observation, &error_message))
+        << error_message;
+
+    EXPECT_DOUBLE_EQ(observation.range_rate_mps, clean.range_rate_mps);
+    EXPECT_DOUBLE_EQ(observation.doppler_hz, clean.doppler_hz);
+    EXPECT_FALSE(observation.doppler_valid);
+    EXPECT_TRUE(observation.adr_valid);
+    EXPECT_NEAR(observation.adr_cycles - clean.adr_cycles, 0.07 / kWavelengthM, 1.0e-9);
+}
+
+TEST(UrbanMeasurementApplication, BlockedStateCannotLeakValidRangeObservation) {
+    constexpr double kWavelengthM = 0.20;
+    gnss_sim::MeasurementObservation observation = clean_observation(kWavelengthM);
+    const gnss_sim::MeasurementObservation clean = observation;
+    gnss_sim::UrbanSignalEpochResult epoch{};
+    epoch.tracking_phase = gnss_sim::SignalTrackingPhase::kSearching;
+    epoch.effective_cn0_dbhz = -std::numeric_limits<double>::infinity();
+    epoch.lock_time_ns = 0;
+    epoch.observation_available = false;
+    epoch.psr_valid = false;
+    epoch.doppler_valid = false;
+    epoch.adr_valid = false;
+
+    gnss_sim::UrbanCarrierTemporalResult temporal{};
+    temporal.wavelength_m = kWavelengthM;
+
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::apply_urban_measurement_effects(epoch, temporal, &observation, &error_message))
+        << error_message;
+
+    EXPECT_FALSE(observation.observation_available);
+    EXPECT_FALSE(observation.pseudorange_valid);
+    EXPECT_FALSE(observation.doppler_valid);
+    EXPECT_FALSE(observation.adr_valid);
+    EXPECT_TRUE(std::isinf(observation.cn0_dbhz));
+    EXPECT_LT(observation.cn0_dbhz, 0.0);
+    EXPECT_DOUBLE_EQ(observation.pseudorange_m, clean.pseudorange_m);
+    EXPECT_DOUBLE_EQ(observation.range_rate_mps, clean.range_rate_mps);
+    EXPECT_DOUBLE_EQ(observation.doppler_hz, clean.doppler_hz);
+    EXPECT_DOUBLE_EQ(observation.adr_cycles, clean.adr_cycles);
+}
+
+TEST(UrbanMeasurementApplication, CleanGeometryValidityRemainsAnUpperBound) {
+    constexpr double kWavelengthM = 0.20;
+    gnss_sim::MeasurementObservation observation = clean_observation(kWavelengthM);
+    observation.observation_available = false;
+    observation.pseudorange_valid = false;
+    observation.doppler_valid = false;
+    observation.adr_valid = false;
+    const gnss_sim::UrbanSignalEpochResult epoch = tracked_epoch(0.5, 40.0, 7000000000LL);
+    const gnss_sim::UrbanCarrierTemporalResult temporal = tracked_temporal(kWavelengthM, 0.02, 0.3);
+
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::apply_urban_measurement_effects(epoch, temporal, &observation, &error_message))
+        << error_message;
+
+    EXPECT_FALSE(observation.observation_available);
+    EXPECT_FALSE(observation.pseudorange_valid);
+    EXPECT_FALSE(observation.doppler_valid);
+    EXPECT_FALSE(observation.adr_valid);
+}
+
+TEST(UrbanMeasurementApplication, NeutralUrbanTermsLeaveCleanObservableValuesUnchanged) {
+    constexpr double kWavelengthM = 0.20;
+    gnss_sim::MeasurementObservation observation = clean_observation(kWavelengthM);
+    const gnss_sim::MeasurementObservation clean = observation;
+    const gnss_sim::UrbanSignalEpochResult epoch = tracked_epoch(0.0, clean.cn0_dbhz, clean.lock_time_ns);
+    const gnss_sim::UrbanCarrierTemporalResult temporal = tracked_temporal(kWavelengthM, 0.0, 0.0);
+
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::apply_urban_measurement_effects(epoch, temporal, &observation, &error_message))
+        << error_message;
+
+    EXPECT_DOUBLE_EQ(observation.pseudorange_m, clean.pseudorange_m);
+    EXPECT_DOUBLE_EQ(observation.range_rate_mps, clean.range_rate_mps);
+    EXPECT_DOUBLE_EQ(observation.doppler_hz, clean.doppler_hz);
+    EXPECT_DOUBLE_EQ(observation.adr_cycles, clean.adr_cycles);
+    EXPECT_DOUBLE_EQ(observation.cn0_dbhz, clean.cn0_dbhz);
+    EXPECT_EQ(observation.lock_time_ns, clean.lock_time_ns);
+}
+
+TEST(UrbanMeasurementApplication, SignalSpecificWavelengthControlsDopplerAndAdrMapping) {
+    const gnss_sim::SignalDefinition* gps_l5 = gnss_sim::find_signal_definition(gnss_sim::SignalId::kGpsL5Q);
+    ASSERT_NE(gps_l5, nullptr);
+    double wavelength_m = 0.0;
+    ASSERT_TRUE(gnss_sim::signal_wavelength_m(*gps_l5, 0, &wavelength_m));
+
+    gnss_sim::MeasurementObservation observation = clean_observation(wavelength_m);
+    observation.signal_id = gnss_sim::SignalId::kGpsL5Q;
+    const gnss_sim::MeasurementObservation clean = observation;
+    const gnss_sim::UrbanSignalEpochResult epoch = tracked_epoch(0.0, 42.0, 9000000000LL);
+    const gnss_sim::UrbanCarrierTemporalResult temporal = tracked_temporal(wavelength_m, 0.25 * wavelength_m, 2.0);
+
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::apply_urban_measurement_effects(epoch, temporal, &observation, &error_message))
+        << error_message;
+
+    EXPECT_NEAR(observation.doppler_hz - clean.doppler_hz, -2.0 / wavelength_m, 1.0e-12);
+    EXPECT_NEAR(observation.adr_cycles - clean.adr_cycles, 0.25, 1.0e-9);
+}
+
+TEST(UrbanMeasurementApplication, RejectsMismatchedTemporalEpochPairWithoutMutation) {
+    constexpr double kWavelengthM = 0.20;
+    gnss_sim::MeasurementObservation observation = clean_observation(kWavelengthM);
+    const gnss_sim::MeasurementObservation clean = observation;
+    const gnss_sim::UrbanSignalEpochResult epoch = tracked_epoch(1.0, 35.0, 5000000000LL);
+    gnss_sim::UrbanCarrierTemporalResult temporal = tracked_temporal(kWavelengthM, 0.1, 0.4);
+    temporal.tracking_lock_valid = false;
+
+    std::string error_message;
+    EXPECT_FALSE(gnss_sim::apply_urban_measurement_effects(epoch, temporal, &observation, &error_message));
+    EXPECT_FALSE(error_message.empty());
+    EXPECT_DOUBLE_EQ(observation.pseudorange_m, clean.pseudorange_m);
+    EXPECT_DOUBLE_EQ(observation.doppler_hz, clean.doppler_hz);
+    EXPECT_DOUBLE_EQ(observation.adr_cycles, clean.adr_cycles);
+}
+
+} // namespace

--- a/tests/unit/test_urban_measurement_application.cpp
+++ b/tests/unit/test_urban_measurement_application.cpp
@@ -59,7 +59,7 @@ gnss_sim::UrbanSignalEpochResult tracked_epoch(double code_bias_m, double effect
 }
 
 gnss_sim::UrbanCarrierTemporalResult tracked_temporal(double wavelength_m, double carrier_range_bias_m,
-                                                       double environmental_range_rate_mps) {
+                                                      double environmental_range_rate_mps) {
     gnss_sim::UrbanCarrierTemporalResult result{};
     result.wavelength_m = wavelength_m;
     result.carrier_range_bias_m = carrier_range_bias_m;


### PR DESCRIPTION
Closes #142.

## Summary
Apply the completed #140/#141 urban signal state to one already-generated clean `MeasurementObservation` in a single explicit post-processing mapper.

## Implementation Notes
- `generate_zero_noise_measurement()` and `measurement_model.cpp` are unchanged;
- the clean measurement therefore continues to own satellite clock/drift, atmosphere, broadcast TGD/ISC/BGD/dtaun, and deterministic carrier ambiguity exactly once;
- urban DLL code bias shifts only `pseudorange_m`; `MeasurementObservation::code_bias_m` retains its existing broadcast/explicit-bias diagnostic meaning;
- #141 environmental path rate is additive to `range_rate_mps` exactly once and changes Doppler by `-delta_range_rate / wavelength`;
- #141 continuous environmental carrier range shifts ADR by `delta_range / wavelength` without introducing a second ambiguity;
- #140 effective CN0 and #121 lock/validity state replace/gate the corresponding clean fields;
- on a fresh lock where #141 has no finite-difference path rate yet, numeric clean Doppler is left untouched but `doppler_valid=false` rather than inventing a zero environmental rate;
- BLOCKED/no-observation state cannot leak a valid RANGE observation;
- clean geometry/validity remains an upper bound and cannot be re-enabled by the urban mapper.

## Focused coverage
- exact pseudorange/range-rate/Doppler/ADR/CN0 deltas;
- broadcast bias, atmosphere, clock and ambiguity diagnostics remain unchanged;
- fresh-lock no-path-rate semantics;
- BLOCKED validity suppression;
- clean-invalid state cannot be re-enabled;
- neutral urban terms leave clean observable values unchanged;
- GPS L5 wavelength-dependent Doppler/ADR mapping;
- inconsistent epoch/temporal pair fails without mutating the observation.

## Scope exclusions
No simulator runtime wiring/config switch, RANGE serialization changes, truth serialization, NAV/EPH/ION changes, arbitrary offsets, or target-PVT tuning.