### PR TITLE
Wire urban observable synthesis into simulator runtime

### DIFF
--- a/src/core/sim_config.cpp
+++ b/src/core/sim_config.cpp
@@ -661,10 +661,6 @@ bool validate_sim_config(const SimConfig& config, std::string* error_message) {
         set_error(error_message, "cn0_high_dbhz configuration is invalid");
         return false;
     }
-    if (config.multipath_enabled) {
-        set_error(error_message, "multipath is not supported in V1");
-        return false;
-    }
     if (config.receiver_clock_bias_m != 0.0 || config.receiver_clock_drift_mps != 0.0) {
         set_error(error_message, "receiver clock bias and drift must be zero in V1");
         return false;

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -904,8 +904,8 @@ bool update_tracking_and_measurements(RuntimeState* runtime, const SimConfig& co
                                                     glonass_fcn, scenario.time, runtime->receiver, signal_geometry,
                                                     &signal.tracker, &urban_epoch, error_message) ||
                         !update_urban_carrier_temporal_state(*definition, glonass_fcn, scenario.time, urban_epoch,
-                                                            &signal.urban_carrier_temporal, &urban_temporal,
-                                                            error_message)) {
+                                                             &signal.urban_carrier_temporal, &urban_temporal,
+                                                             error_message)) {
                         return false;
                     }
                 } else if (!update_unavailable_urban_signal(runtime, *definition, glonass_fcn, scenario.time,

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -12,10 +12,14 @@
 #include "model/atmosphere_model.h"
 #include "model/bestpos_rtk_model.h"
 #include "model/cn0_model.h"
+#include "model/code_tracking_dll.h"
 #include "model/measurement_error_model.h"
 #include "model/measurement_model.h"
 #include "model/receiver_truth.h"
 #include "model/signal_tracking.h"
+#include "model/urban_carrier_temporal.h"
+#include "model/urban_scene_geometry.h"
+#include "model/urban_signal_epoch.h"
 #include "output/device_marker.h"
 #include "output/novatel_nav_writer.h"
 #include "output/novatel_range_writer.h"
@@ -48,6 +52,7 @@ struct SignalRuntime {
     SignalTracker tracker;
     CarrierAmbiguityState ambiguity;
     MeasurementErrorState measurement_error;
+    UrbanCarrierTemporalState urban_carrier_temporal;
     bool ever_scheduled;
 };
 
@@ -81,6 +86,8 @@ struct RuntimeState {
     DeterministicRng rng;
     Cn0Model cn0_model;
     SignalTrackingModelConfig tracking_config;
+    UrbanSceneGeometryConfig urban_scene_config;
+    CodeTrackingDllConfig urban_dll_config;
     SolutionEngineState solution_state;
     BestposRtkState bestpos_rtk_state;
     StartupMode startup_mode;
@@ -332,6 +339,7 @@ bool build_satellite_runtimes(const std::vector<TruthScheduleEntry>& schedule, c
             SignalRuntime signal{};
             reset_signal_tracker(&signal.tracker, definitions[index].signal_id, reset_time);
             reset_carrier_ambiguity_state(&signal.ambiguity);
+            reset_urban_carrier_temporal_state(&signal.urban_carrier_temporal);
             satellite.signals.push_back(signal);
         }
         for (const TruthScheduleEntry& entry : schedule) {
@@ -499,6 +507,7 @@ bool receiver_power_on(RuntimeState* runtime, const SimConfig& config, const Sim
             reset_signal_tracker(&signal.tracker, signal.tracker.signal_id, power_on_time);
             reset_carrier_ambiguity_state(&signal.ambiguity);
             reset_measurement_error_state(&signal.measurement_error);
+            reset_urban_carrier_temporal_state(&signal.urban_carrier_temporal);
             signal.ever_scheduled = false;
         }
         for (ColdFamilyRuntime& family : satellite.cold_families) {
@@ -523,6 +532,7 @@ void receiver_power_off(RuntimeState* runtime, const SimTime& time) {
             reset_signal_tracker(&signal.tracker, signal.tracker.signal_id, time);
             reset_carrier_ambiguity_state(&signal.ambiguity);
             reset_measurement_error_state(&signal.measurement_error);
+            reset_urban_carrier_temporal_state(&signal.urban_carrier_temporal);
         }
     }
 }
@@ -534,6 +544,7 @@ void receiver_signal_off(RuntimeState* runtime, const SimTime& time) {
             static_cast<void>(update_signal_tracker(&signal.tracker, time, false, 0.0, runtime->cn0_model, nullptr));
             reset_carrier_ambiguity_state(&signal.ambiguity);
             reset_measurement_error_state(&signal.measurement_error);
+            reset_urban_carrier_temporal_state(&signal.urban_carrier_temporal);
         }
     }
 }
@@ -733,6 +744,39 @@ bool process_receiver_nav(RuntimeState* runtime, const SimConfig& config, const 
     return process_normal_nav(runtime, config, current_time, output, summary, error_message);
 }
 
+bool update_unavailable_urban_signal(RuntimeState* runtime, const SignalDefinition& definition, int glonass_fcn,
+                                     const SimTime& current_time, double elevation_deg, SignalRuntime* signal,
+                                     std::string* error_message) {
+    double open_cn0_dbhz = 0.0;
+    if (!cn0_model_estimate_dbhz(runtime->cn0_model, definition.signal_id, elevation_deg, current_time,
+                                 &open_cn0_dbhz)) {
+        set_error(error_message, "cannot evaluate open-sky CN0 for unavailable urban signal");
+        return false;
+    }
+    UrbanSignalTrackingInput input{};
+    input.signal_available = false;
+    input.direct_line_of_sight = false;
+    input.open_cn0_dbhz = open_cn0_dbhz;
+    input.effective_cn0_dbhz = open_cn0_dbhz;
+    if (!update_urban_signal_tracker(&signal->tracker, current_time, input, runtime->tracking_config, error_message)) {
+        return false;
+    }
+    UrbanSignalEpochResult epoch{};
+    epoch.urban_state = signal->tracker.urban_state;
+    epoch.tracking_phase = signal->tracker.phase;
+    epoch.loss_reason = signal->tracker.loss_reason;
+    epoch.lock_time_ns = signal->tracker.lock_time_ns;
+    epoch.observation_available = signal->tracker.observation_available;
+    epoch.psr_valid = signal->tracker.psr_valid;
+    epoch.doppler_valid = signal->tracker.doppler_valid;
+    epoch.adr_valid = signal->tracker.adr_valid;
+    epoch.reacquisition_event = signal->tracker.reacquisition_event;
+    epoch.carrier_continuity_valid = signal->tracker.carrier_continuity_valid;
+    UrbanCarrierTemporalResult temporal{};
+    return update_urban_carrier_temporal_state(definition, glonass_fcn, current_time, epoch,
+                                               &signal->urban_carrier_temporal, &temporal, error_message);
+}
+
 bool update_tracking_and_measurements(RuntimeState* runtime, const SimConfig& config,
                                       const ScenarioEpochState& scenario,
                                       std::vector<MeasurementObservation>* measurements, int* tracked_satellites,
@@ -822,7 +866,7 @@ bool update_tracking_and_measurements(RuntimeState* runtime, const SimConfig& co
                 signal_healthy = signal_health == 0;
             }
 
-            const bool signal_available =
+            const bool legacy_signal_available =
                 scenario.signal_available &&
                 (health_family != RtklibBroadcastMessageFamily::kUnknown ? signal_geometry.above_elevation_mask
                                                                          : signal_geometry.visible);
@@ -830,6 +874,10 @@ bool update_tracking_and_measurements(RuntimeState* runtime, const SimConfig& co
                 signal_geometry.healthy = signal_healthy;
                 signal_geometry.visible = signal_geometry.above_elevation_mask && signal_healthy;
             }
+            const bool signal_available =
+                config.multipath_enabled
+                    ? scenario.signal_available && signal_geometry.above_elevation_mask && signal_healthy
+                    : legacy_signal_available;
             const double elevation_deg = signal_geometry.elevation_rad * kRadiansToDegrees;
             if (signal_available && !signal.tracker.scheduled) {
                 const AcquisitionContext context =
@@ -846,10 +894,29 @@ bool update_tracking_and_measurements(RuntimeState* runtime, const SimConfig& co
                 }
                 signal.ever_scheduled = true;
             }
-            if (!update_signal_tracker(&signal.tracker, scenario.time, signal_available, elevation_deg,
-                                       runtime->cn0_model, error_message)) {
+
+            UrbanSignalEpochResult urban_epoch{};
+            UrbanCarrierTemporalResult urban_temporal{};
+            if (config.multipath_enabled) {
+                if (signal_available) {
+                    if (!compute_urban_signal_epoch(runtime->cn0_model, runtime->urban_scene_config, config.urban_rf,
+                                                    runtime->urban_dll_config, runtime->tracking_config, *definition,
+                                                    glonass_fcn, scenario.time, runtime->receiver, signal_geometry,
+                                                    &signal.tracker, &urban_epoch, error_message) ||
+                        !update_urban_carrier_temporal_state(*definition, glonass_fcn, scenario.time, urban_epoch,
+                                                            &signal.urban_carrier_temporal, &urban_temporal,
+                                                            error_message)) {
+                        return false;
+                    }
+                } else if (!update_unavailable_urban_signal(runtime, *definition, glonass_fcn, scenario.time,
+                                                            elevation_deg, &signal, error_message)) {
+                    return false;
+                }
+            } else if (!update_signal_tracker(&signal.tracker, scenario.time, signal_available, elevation_deg,
+                                              runtime->cn0_model, error_message)) {
                 return false;
             }
+
             if (signal.tracker.phase != SignalTrackingPhase::kTracking) {
                 reset_carrier_ambiguity_state(&signal.ambiguity);
                 reset_measurement_error_state(&signal.measurement_error);
@@ -872,8 +939,11 @@ bool update_tracking_and_measurements(RuntimeState* runtime, const SimConfig& co
                           &signal.ambiguity, &observation, error_message)
                     : generate_zero_noise_measurement(truth_nav, signal_geometry, runtime->receiver, signal.tracker,
                                                       atmosphere, &signal.ambiguity, &observation, error_message);
-            if (!measurement_ok || !truth_writer_write_observation(truth_writer, runtime->receiver, signal_geometry,
-                                                                   signal.tracker, observation, error_message)) {
+            if (!measurement_ok ||
+                (config.multipath_enabled &&
+                 !apply_urban_measurement_effects(urban_epoch, urban_temporal, &observation, error_message)) ||
+                !truth_writer_write_observation(truth_writer, runtime->receiver, signal_geometry, signal.tracker,
+                                                observation, error_message)) {
                 return false;
             }
             MeasurementObservation reported_observation = observation;
@@ -990,6 +1060,8 @@ bool run_simulator(const SimConfig& config, const SimulatorRunOptions& options, 
     result.cn0_model_hash = runtime.cn0_model.identity.hash;
     result.cn0_model_size_bytes = runtime.cn0_model.identity.size_bytes;
     runtime.tracking_config = default_signal_tracking_model_config();
+    runtime.urban_scene_config = default_urban_scene_geometry_config();
+    runtime.urban_dll_config = default_code_tracking_dll_config();
 
     ScenarioEngine scenario_engine{};
     if (!initialize_scenario_engine(config, options.start_time, &scenario_engine, error_message)) {

--- a/tests/integration/test_scenarios.cpp
+++ b/tests/integration/test_scenarios.cpp
@@ -266,6 +266,39 @@ TEST(StreamingSimulator, FutureOnlyEphemerisDoesNotAbortEarlierEpochs) {
     std::remove(output_path.c_str());
 }
 
+TEST(StreamingSimulator, UrbanMultipathRuntimeIsDeterministicAndChangesReceiverObservations) {
+    gnss_sim::SimConfig urban_config = base_config(gnss_sim::ScenarioType::KS);
+    urban_config.sampling_rate_hz = 10;
+    urban_config.duration_ns = 10LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    urban_config.measurement_noise_enabled = false;
+    urban_config.multipath_enabled = true;
+
+    gnss_sim::SimulatorRunSummary first_summary{};
+    gnss_sim::SimulatorRunSummary second_summary{};
+    std::string error_message;
+    ASSERT_TRUE(run(urban_config, "urban_runtime_first", &first_summary, &error_message)) << error_message;
+    ASSERT_TRUE(run(urban_config, "urban_runtime_second", &second_summary, &error_message)) << error_message;
+    EXPECT_EQ(first_summary.scheduled_epochs, 100U);
+    EXPECT_EQ(first_summary.range_messages, 100U);
+    EXPECT_EQ(second_summary.range_messages, first_summary.range_messages);
+
+    const std::string first_log = read_file(test_output_path("urban_runtime_first"));
+    const std::string second_log = read_file(test_output_path("urban_runtime_second"));
+    EXPECT_EQ(first_log, second_log);
+    EXPECT_EQ(occurrence_count(first_log, "#RANGEA,"), 100U);
+
+    gnss_sim::SimConfig legacy_config = urban_config;
+    legacy_config.multipath_enabled = false;
+    gnss_sim::SimulatorRunSummary legacy_summary{};
+    ASSERT_TRUE(run(legacy_config, "urban_runtime_legacy", &legacy_summary, &error_message)) << error_message;
+    EXPECT_EQ(legacy_summary.range_messages, first_summary.range_messages);
+    EXPECT_NE(read_file(test_output_path("urban_runtime_legacy")), first_log);
+
+    std::remove(test_output_path("urban_runtime_first").c_str());
+    std::remove(test_output_path("urban_runtime_second").c_str());
+    std::remove(test_output_path("urban_runtime_legacy").c_str());
+}
+
 TEST(StreamingSimulator, OneSecondDurationHasExactEpochCountAtEveryFrozenRate) {
     for (const int rate : {1, 5, 10, 20, 50}) {
         std::uint64_t count = 0;


### PR DESCRIPTION
Closes #143

## Summary
- enable the existing `multipath_enabled` configuration switch without changing its default (`false`)
- preserve the legacy/open-sky runtime path when multipath is disabled
- add per-signal urban carrier temporal state with explicit power/signal reset handling
- when enabled, run the common urban epoch/tracking pipeline, update temporal carrier/range-rate state, apply urban effects to the existing clean measurement exactly once, then apply the existing measurement-noise layer
- preserve authentic-NAV geometry, atmosphere, satellite clock, broadcast TGD/ISC/BGD, Galileo HAS E6, GLONASS FCN and existing ambiguity handling
- add deterministic runtime integration coverage comparing urban-on and legacy-off output

## Invariants
- no NAV/EPH/ION fabrication or modification
- no target-PVT tuning or arbitrary NLOS offsets
- `multipath_enabled=false` remains on the existing legacy tracking/measurement branch
- truth observation is written after deterministic urban mapping but before random measurement noise

## Validation target
Full GitHub Actions on Ubuntu and Windows, including existing RANGEA and serialized-NAV positioning regressions.