### PR TITLE
Add deterministic urban propagation and tracking truth diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,7 @@ add_library(gnss_sim_core STATIC
     src/output/novatel_range_writer.cpp
     src/output/novatel_solution_writer.cpp
     src/output/truth_writer.cpp
+    src/output/urban_truth_writer.cpp
     src/output/unicore_nav_writer.cpp
     src/scenario/scenario_engine.cpp
     src/solution/solution_engine.cpp

--- a/docs/URBAN_TRUTH_DIAGNOSTICS.md
+++ b/docs/URBAN_TRUTH_DIAGNOSTICS.md
@@ -1,0 +1,80 @@
+# Urban truth diagnostics
+
+Issue #123 adds a deterministic, serialization-only truth extension for the V1 urban propagation/tracking model.
+
+## Scope and invariants
+
+The urban truth writer consumes the exact `UrbanSignalEpochResult` and `UrbanCarrierTemporalResult` objects already used by the simulator runtime to synthesize receiver observables. It must not recompute scene geometry, reflection paths, rooftop diffraction, DLL roots, effective CN0, tracking state, carrier phase, or environmental path rate.
+
+Normal receiver `RANGEA` output remains receiver-observable only. Simulator-only propagation/material/tracking details are written only to the dedicated truth files below.
+
+No NAV/EPH/ION record is generated, altered, interpolated, retargeted, or fabricated by this diagnostic layer.
+
+## Schema version
+
+The urban truth extension has its own schema version independent of the existing base truth bundle:
+
+```text
+URBAN_TRUTH_SCHEMA_VERSION = 1
+```
+
+Every row in both urban CSV files starts with `truth_schema_version` so a consumer can reject an unsupported extension version before interpreting later columns. Adding these files does not reinterpret or renumber the existing `observation_truth.csv` schema.
+
+When `multipath_enabled=false`, the files are still created with their versioned headers but contain no urban data rows. The legacy/open-sky observation path is unchanged.
+
+## `urban_signal_truth.csv`
+
+One row is written for every urban-enabled satellite/signal epoch for which production signal geometry is available, including states that do not emit a normal receiver observation.
+
+Important field groups:
+
+- identity/time: GPS week/TOW, satellite number, signal id/name, GLONASS FCN;
+- geometry: azimuth/elevation, whether propagation was evaluated, direct LOS, blocking wall, roof-grazing state, diffraction status;
+- path inventory: retained reflection count and common received-path count;
+- tracking: `LOS`, `LOS_MULTIPATH`, `NLOS_TRACKED`, or `BLOCKED`, tracking phase, loss reason, lock time, reacquisition and validity flags;
+- received power: open-sky CN0, effective CN0, composite power ratio;
+- DLL: root count/search status, deterministic selection mode/root, code phase and physical pseudorange code bias;
+- carrier/temporal: tracked composite complex correlation, wavelength, wrapped/unwrapped phase, carrier-range bias, environmental range rate, continuity and cycle-slip state;
+- observation consistency: whether the runtime produced a zero-noise receiver observation and, when present, the exact pseudorange/Doppler/ADR values after urban mapping but before the independent measurement-noise layer.
+
+If propagation was not evaluated because the signal was unavailable at the runtime boundary, geometry/path-dependent fields are explicitly blank or marked `NOT_EVALUATED`; the tracking/loss state is still recorded.
+
+This permits `BLOCKED` and signal-loss events to be diagnosed without inferring them only from missing `RANGEA` observations.
+
+## `urban_path_truth.csv`
+
+This file contains only already-computed propagation components from the same `UrbanSignalEpochResult`.
+
+Stable ordering per satellite/signal/epoch is:
+
+1. `path_index=0`: the roof-affected direct component (`DIRECT_ROOF`), represented exactly once;
+2. `path_index=1..N`: every retained #117 first-order reflection in the existing stable wall/path order.
+
+The roof transition therefore never appears as an unmodified full direct path plus a second full diffraction path.
+
+Per-path fields include, where applicable:
+
+- path kind and source wall/roof edge;
+- reflection/diffraction ENU point;
+- model path range, excess path and code delay;
+- normalized complex receiver-domain voltage, amplitude and phase;
+- rooftop Fresnel `v` and complex coefficient;
+- reflection incidence angle;
+- RHCP/LHCP material response and receive-antenna complex response.
+
+Fields that are not applicable to a path type are left blank rather than filled with invented values.
+
+## Relationship to other truth files
+
+`observation_truth.csv` continues to describe the zero-noise receiver observation and authentic-NAV/broadcast-bias inputs. For an emitted urban observation, `urban_signal_truth.csv` carries the same post-urban pseudorange, Doppler and ADR values, which is regression-tested against `observation_truth.csv` by matching epoch + satellite + signal.
+
+`event_truth.csv`, `solution_truth.csv`, `scenario.json`, and `run_manifest.json` retain their existing base truth semantics.
+
+## Determinism
+
+For fixed simulator commit, authentic NAV bytes, configuration, CN0 model and seed:
+
+- urban signal rows are deterministic;
+- path arrays use stable ordering;
+- the two urban CSV files are byte-repeatable;
+- the diagnostic writer has no RNG and does not alter receiver state.

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -25,6 +25,7 @@
 #include "output/novatel_range_writer.h"
 #include "output/novatel_solution_writer.h"
 #include "output/truth_writer.h"
+#include "output/urban_truth_writer.h"
 #include "scenario/scenario_engine.h"
 #include "solution/solution_engine.h"
 
@@ -746,7 +747,12 @@ bool process_receiver_nav(RuntimeState* runtime, const SimConfig& config, const 
 
 bool update_unavailable_urban_signal(RuntimeState* runtime, const SignalDefinition& definition, int glonass_fcn,
                                      const SimTime& current_time, double elevation_deg, SignalRuntime* signal,
+                                     UrbanSignalEpochResult* epoch, UrbanCarrierTemporalResult* temporal,
                                      std::string* error_message) {
+    if (epoch == nullptr || temporal == nullptr) {
+        set_error(error_message, "unavailable urban signal diagnostics output is null");
+        return false;
+    }
     double open_cn0_dbhz = 0.0;
     if (!cn0_model_estimate_dbhz(runtime->cn0_model, definition.signal_id, elevation_deg, current_time,
                                  &open_cn0_dbhz)) {
@@ -761,26 +767,30 @@ bool update_unavailable_urban_signal(RuntimeState* runtime, const SignalDefiniti
     if (!update_urban_signal_tracker(&signal->tracker, current_time, input, runtime->tracking_config, error_message)) {
         return false;
     }
-    UrbanSignalEpochResult epoch{};
-    epoch.urban_state = signal->tracker.urban_state;
-    epoch.tracking_phase = signal->tracker.phase;
-    epoch.loss_reason = signal->tracker.loss_reason;
-    epoch.lock_time_ns = signal->tracker.lock_time_ns;
-    epoch.observation_available = signal->tracker.observation_available;
-    epoch.psr_valid = signal->tracker.psr_valid;
-    epoch.doppler_valid = signal->tracker.doppler_valid;
-    epoch.adr_valid = signal->tracker.adr_valid;
-    epoch.reacquisition_event = signal->tracker.reacquisition_event;
-    epoch.carrier_continuity_valid = signal->tracker.carrier_continuity_valid;
-    UrbanCarrierTemporalResult temporal{};
-    return update_urban_carrier_temporal_state(definition, glonass_fcn, current_time, epoch,
-                                               &signal->urban_carrier_temporal, &temporal, error_message);
+    UrbanSignalEpochResult output{};
+    output.urban_state = signal->tracker.urban_state;
+    output.tracking_phase = signal->tracker.phase;
+    output.loss_reason = signal->tracker.loss_reason;
+    output.lock_time_ns = signal->tracker.lock_time_ns;
+    output.observation_available = signal->tracker.observation_available;
+    output.psr_valid = signal->tracker.psr_valid;
+    output.doppler_valid = signal->tracker.doppler_valid;
+    output.adr_valid = signal->tracker.adr_valid;
+    output.reacquisition_event = signal->tracker.reacquisition_event;
+    output.carrier_continuity_valid = signal->tracker.carrier_continuity_valid;
+    if (!update_urban_carrier_temporal_state(definition, glonass_fcn, current_time, output,
+                                             &signal->urban_carrier_temporal, temporal, error_message)) {
+        return false;
+    }
+    *epoch = output;
+    return true;
 }
 
 bool update_tracking_and_measurements(RuntimeState* runtime, const SimConfig& config,
                                       const ScenarioEpochState& scenario,
                                       std::vector<MeasurementObservation>* measurements, int* tracked_satellites,
-                                      TruthWriter* truth_writer, std::string* error_message) {
+                                      TruthWriter* truth_writer, UrbanTruthWriter* urban_truth_writer,
+                                      std::string* error_message) {
     measurements->clear();
     *tracked_satellites = 0;
     const RtklibNavStore* truth_nav = truth_navigation_store(runtime->navigation);
@@ -909,7 +919,8 @@ bool update_tracking_and_measurements(RuntimeState* runtime, const SimConfig& co
                         return false;
                     }
                 } else if (!update_unavailable_urban_signal(runtime, *definition, glonass_fcn, scenario.time,
-                                                            elevation_deg, &signal, error_message)) {
+                                                            elevation_deg, &signal, &urban_epoch, &urban_temporal,
+                                                            error_message)) {
                     return false;
                 }
             } else if (!update_signal_tracker(&signal.tracker, scenario.time, signal_available, elevation_deg,
@@ -918,6 +929,11 @@ bool update_tracking_and_measurements(RuntimeState* runtime, const SimConfig& co
             }
 
             if (signal.tracker.phase != SignalTrackingPhase::kTracking) {
+                if (config.multipath_enabled &&
+                    !urban_truth_writer_write_signal(urban_truth_writer, signal_geometry, *definition, glonass_fcn,
+                                                     urban_epoch, urban_temporal, nullptr, error_message)) {
+                    return false;
+                }
                 reset_carrier_ambiguity_state(&signal.ambiguity);
                 reset_measurement_error_state(&signal.measurement_error);
                 continue;
@@ -941,7 +957,12 @@ bool update_tracking_and_measurements(RuntimeState* runtime, const SimConfig& co
                                                       atmosphere, &signal.ambiguity, &observation, error_message);
             if (!measurement_ok ||
                 (config.multipath_enabled &&
-                 !apply_urban_measurement_effects(urban_epoch, urban_temporal, &observation, error_message)) ||
+                 !apply_urban_measurement_effects(urban_epoch, urban_temporal, &observation, error_message))) {
+                return false;
+            }
+            if ((config.multipath_enabled &&
+                 !urban_truth_writer_write_signal(urban_truth_writer, signal_geometry, *definition, glonass_fcn,
+                                                  urban_epoch, urban_temporal, &observation, error_message)) ||
                 !truth_writer_write_observation(truth_writer, runtime->receiver, signal_geometry, signal.tracker,
                                                 observation, error_message)) {
                 return false;
@@ -1083,10 +1104,18 @@ bool run_simulator(const SimConfig& config, const SimulatorRunOptions& options, 
         destroy_navigation_state(runtime.navigation);
         return false;
     }
+    UrbanTruthWriter* urban_truth_writer = create_urban_truth_writer(options.output_log_path, error_message);
+    if (urban_truth_writer == nullptr) {
+        destroy_truth_writer(truth_writer);
+        output.close();
+        destroy_navigation_state(runtime.navigation);
+        return false;
+    }
 
     std::uint64_t epoch_count = 0;
     if (!epoch_count_for_duration(config.duration_ns, config.sampling_rate_hz, &epoch_count)) {
         set_error(error_message, "cannot compute simulator epoch count");
+        destroy_urban_truth_writer(urban_truth_writer);
         destroy_truth_writer(truth_writer);
         destroy_navigation_state(runtime.navigation);
         return false;
@@ -1149,7 +1178,7 @@ bool run_simulator(const SimConfig& config, const SimulatorRunOptions& options, 
 
         int tracked_satellites = 0;
         if (!update_tracking_and_measurements(&runtime, config, scenario, &measurements, &tracked_satellites,
-                                              truth_writer, error_message) ||
+                                              truth_writer, urban_truth_writer, error_message) ||
             !process_receiver_nav(&runtime, config, current_time, &output, &result, error_message)) {
             ok = false;
             break;
@@ -1185,10 +1214,14 @@ bool run_simulator(const SimConfig& config, const SimulatorRunOptions& options, 
         ok = false;
     }
     output.close();
+    if (ok && !finalize_urban_truth_writer(urban_truth_writer, error_message)) {
+        ok = false;
+    }
     if (ok && !finalize_truth_writer(truth_writer, result, simulator_version(), simulator_commit_sha(),
                                      rtklib_commit_sha(), error_message)) {
         ok = false;
     }
+    destroy_urban_truth_writer(urban_truth_writer);
     destroy_truth_writer(truth_writer);
     destroy_navigation_state(runtime.navigation);
     if (!ok) {

--- a/src/output/urban_truth_writer.cpp
+++ b/src/output/urban_truth_writer.cpp
@@ -10,6 +10,7 @@
 #include <iomanip>
 #include <locale>
 #include <new>
+#include <string>
 
 namespace gnss_sim {
 
@@ -106,7 +107,7 @@ bool write_path_rows(UrbanTruthWriter* writer, const SatelliteGeometry& geometry
         output << ',' << std::scientific << std::setprecision(17) << received.diffraction.model_path_range_m << ','
                << received.diffraction.excess_path_length_m << ',' << received.paths[0].code_delay_sec << ',';
     } else {
-        output << ",,,," << std::scientific << std::setprecision(17) << geometry.geometric_range_m << ",0,"
+        output << ",,," << std::scientific << std::setprecision(17) << geometry.geometric_range_m << ",0,"
                << received.paths[0].code_delay_sec << ',';
     }
     write_complex(output, received.paths[0].complex_voltage);
@@ -116,7 +117,7 @@ bool write_path_rows(UrbanTruthWriter* writer, const SatelliteGeometry& geometry
         output << received.diffraction.fresnel_v << ',';
         write_complex(output, received.diffraction.fresnel_coefficient);
     } else {
-        output << ",,,";
+        output << ",,";
     }
     output << ",,,,,,,,,\n";
     if (!stream_ok(output, "urban_path_truth.csv", error_message)) {

--- a/src/output/urban_truth_writer.cpp
+++ b/src/output/urban_truth_writer.cpp
@@ -1,8 +1,8 @@
 #include "output/urban_truth_writer.h"
 
 #include "gnss_sim/sim_time.h"
-#include "model/urban_scene_geometry.h"
 #include "model/urban_rooftop_diffraction.h"
+#include "model/urban_scene_geometry.h"
 
 #include <cmath>
 #include <filesystem>
@@ -203,10 +203,8 @@ void destroy_urban_truth_writer(UrbanTruthWriter* writer) {
 
 bool urban_truth_writer_write_signal(UrbanTruthWriter* writer, const SatelliteGeometry& geometry,
                                      const SignalDefinition& signal, int glonass_fcn,
-                                     const UrbanSignalEpochResult& epoch,
-                                     const UrbanCarrierTemporalResult& temporal,
-                                     const MeasurementObservation* observation,
-                                     std::string* error_message) {
+                                     const UrbanSignalEpochResult& epoch, const UrbanCarrierTemporalResult& temporal,
+                                     const MeasurementObservation* observation, std::string* error_message) {
     if (writer == nullptr || writer->finalized || geometry.satellite_number <= 0) {
         set_error(error_message, "urban truth signal writer request is invalid");
         return false;
@@ -217,9 +215,8 @@ bool urban_truth_writer_write_signal(UrbanTruthWriter* writer, const SatelliteGe
     output << URBAN_TRUTH_SCHEMA_VERSION << ',';
     write_time(output, geometry.receive_time);
     output << ',' << geometry.satellite_number << ',' << static_cast<int>(signal.signal_id) << ',' << signal.name << ','
-           << glonass_fcn << ',' << std::scientific << std::setprecision(17)
-           << geometry.azimuth_rad * kRadiansToDegrees << ',' << geometry.elevation_rad * kRadiansToDegrees << ','
-           << (propagation_evaluated ? 1 : 0) << ',';
+           << glonass_fcn << ',' << std::scientific << std::setprecision(17) << geometry.azimuth_rad * kRadiansToDegrees
+           << ',' << geometry.elevation_rad * kRadiansToDegrees << ',' << (propagation_evaluated ? 1 : 0) << ',';
     if (propagation_evaluated) {
         output << (received.direct_geometry.line_of_sight ? 1 : 0) << ','
                << urban_wall_id_name(received.direct_geometry.primary_wall) << ','
@@ -229,14 +226,13 @@ bool urban_truth_writer_write_signal(UrbanTruthWriter* writer, const SatelliteGe
         output << ",NONE,,NOT_EVALUATED";
     }
     output << ',' << received.reflections.path_count << ',' << received.path_count << ','
-           << urban_signal_state_name(epoch.urban_state) << ',' << signal_tracking_phase_name(epoch.tracking_phase) << ','
-           << signal_tracking_loss_reason_name(epoch.loss_reason) << ',';
+           << urban_signal_state_name(epoch.urban_state) << ',' << signal_tracking_phase_name(epoch.tracking_phase)
+           << ',' << signal_tracking_loss_reason_name(epoch.loss_reason) << ',';
     if (propagation_evaluated) {
         output << received.open_cn0_dbhz << ',' << epoch.effective_cn0_dbhz << ','
-               << (epoch.effective_cn0.finite_effective_cn0 ? 1 : 0) << ','
-               << epoch.effective_cn0.composite_power_ratio << ',' << epoch.dll_root_count << ','
-               << root_search_status_name(epoch.root_search_status) << ',' << selection_mode_name(epoch.selection_mode)
-               << ',';
+               << (epoch.effective_cn0.finite_effective_cn0 ? 1 : 0) << ',' << epoch.effective_cn0.composite_power_ratio
+               << ',' << epoch.dll_root_count << ',' << root_search_status_name(epoch.root_search_status) << ','
+               << selection_mode_name(epoch.selection_mode) << ',';
     } else {
         output << ",,,,0,NOT_EVALUATED,NOT_EVALUATED,";
     }
@@ -249,8 +245,8 @@ bool urban_truth_writer_write_signal(UrbanTruthWriter* writer, const SatelliteGe
     output << ',' << epoch.code_bias_m << ',';
     write_complex(output, epoch.tracked_composite_correlation);
     output << ',' << epoch.lock_time_ns << ',' << (epoch.observation_available ? 1 : 0) << ','
-           << (epoch.psr_valid ? 1 : 0) << ',' << (epoch.doppler_valid ? 1 : 0) << ',' << (epoch.adr_valid ? 1 : 0) << ','
-           << (epoch.reacquisition_event ? 1 : 0) << ',' << (epoch.carrier_continuity_valid ? 1 : 0) << ','
+           << (epoch.psr_valid ? 1 : 0) << ',' << (epoch.doppler_valid ? 1 : 0) << ',' << (epoch.adr_valid ? 1 : 0)
+           << ',' << (epoch.reacquisition_event ? 1 : 0) << ',' << (epoch.carrier_continuity_valid ? 1 : 0) << ','
            << temporal.wavelength_m << ',' << temporal.wrapped_phase_rad << ',' << temporal.unwrapped_phase_rad << ','
            << temporal.carrier_range_bias_m << ',' << temporal.environmental_range_rate_mps << ','
            << (temporal.environmental_range_rate_valid ? 1 : 0) << ',' << (temporal.cycle_slip_event ? 1 : 0) << ','

--- a/src/output/urban_truth_writer.cpp
+++ b/src/output/urban_truth_writer.cpp
@@ -1,5 +1,6 @@
 #include "output/urban_truth_writer.h"
 
+#include "gnss_sim/sim_time.h"
 #include "model/urban_scene_geometry.h"
 #include "model/urban_rooftop_diffraction.h"
 
@@ -93,6 +94,7 @@ bool write_path_rows(UrbanTruthWriter* writer, const SatelliteGeometry& geometry
     }
 
     std::ofstream& output = writer->path_stream;
+    output << URBAN_TRUTH_SCHEMA_VERSION << ',';
     write_time(output, geometry.receive_time);
     output << ',' << geometry.satellite_number << ',' << static_cast<int>(signal.signal_id) << ",0,DIRECT_ROOF,"
            << urban_wall_id_name(received.diffraction_status == UrbanRooftopDiffractionStatus::VALID
@@ -104,7 +106,8 @@ bool write_path_rows(UrbanTruthWriter* writer, const SatelliteGeometry& geometry
         output << ',' << std::scientific << std::setprecision(17) << received.diffraction.model_path_range_m << ','
                << received.diffraction.excess_path_length_m << ',' << received.paths[0].code_delay_sec << ',';
     } else {
-        output << ",,," << ',' << geometry.geometric_range_m << ",0," << received.paths[0].code_delay_sec << ',';
+        output << ",,,," << std::scientific << std::setprecision(17) << geometry.geometric_range_m << ",0,"
+               << received.paths[0].code_delay_sec << ',';
     }
     write_complex(output, received.paths[0].complex_voltage);
     output << ',' << std::abs(received.paths[0].complex_voltage) << ',' << std::arg(received.paths[0].complex_voltage)
@@ -127,6 +130,7 @@ bool write_path_rows(UrbanTruthWriter* writer, const SatelliteGeometry& geometry
             set_error(error_message, "urban truth reflection/path ordering is inconsistent");
             return false;
         }
+        output << URBAN_TRUTH_SCHEMA_VERSION << ',';
         write_time(output, geometry.receive_time);
         output << ',' << geometry.satellite_number << ',' << static_cast<int>(signal.signal_id) << ',' << received_index
                << ",REFLECTION," << urban_wall_id_name(reflection.wall_id) << ',';
@@ -170,8 +174,8 @@ UrbanTruthWriter* create_urban_truth_writer(const char* receiver_log_path, std::
     }
     const char* signal_header =
         "truth_schema_version,gps_week,tow_ns,sow_sec,satellite_number,signal_id,signal_name,glonass_fcn,"
-        "azimuth_deg,elevation_deg,direct_los,blocking_wall,grazing_roof,diffraction_status,reflection_count,"
-        "received_path_count,urban_state,tracking_phase,loss_reason,open_cn0_dbhz,effective_cn0_dbhz,"
+        "azimuth_deg,elevation_deg,propagation_evaluated,direct_los,blocking_wall,grazing_roof,diffraction_status,"
+        "reflection_count,received_path_count,urban_state,tracking_phase,loss_reason,open_cn0_dbhz,effective_cn0_dbhz,"
         "effective_cn0_finite,composite_power_ratio,dll_root_count,root_search_status,selection_mode,"
         "selected_root_valid,dll_code_phase_sec,dll_code_phase_chips,code_bias_m,tracked_correlation_real,"
         "tracked_correlation_imag,lock_time_ns,observation_available,pseudorange_valid,doppler_valid,adr_valid,"
@@ -207,22 +211,35 @@ bool urban_truth_writer_write_signal(UrbanTruthWriter* writer, const SatelliteGe
         return false;
     }
     const UrbanReceivedPathSet& received = epoch.received_paths;
+    const bool propagation_evaluated = received.path_count > 0;
     std::ofstream& output = writer->signal_stream;
     output << URBAN_TRUTH_SCHEMA_VERSION << ',';
     write_time(output, geometry.receive_time);
     output << ',' << geometry.satellite_number << ',' << static_cast<int>(signal.signal_id) << ',' << signal.name << ','
            << glonass_fcn << ',' << std::scientific << std::setprecision(17)
            << geometry.azimuth_rad * kRadiansToDegrees << ',' << geometry.elevation_rad * kRadiansToDegrees << ','
-           << (received.direct_geometry.line_of_sight ? 1 : 0) << ','
-           << urban_wall_id_name(received.direct_geometry.primary_wall) << ','
-           << (received.direct_geometry.grazing_roof ? 1 : 0) << ','
-           << urban_rooftop_diffraction_status_name(received.diffraction_status) << ',' << received.reflections.path_count
-           << ',' << received.path_count << ',' << urban_signal_state_name(epoch.urban_state) << ','
-           << signal_tracking_phase_name(epoch.tracking_phase) << ',' << signal_tracking_loss_reason_name(epoch.loss_reason)
-           << ',' << received.open_cn0_dbhz << ',' << epoch.effective_cn0_dbhz << ','
-           << (epoch.effective_cn0.finite_effective_cn0 ? 1 : 0) << ',' << epoch.effective_cn0.composite_power_ratio << ','
-           << epoch.dll_root_count << ',' << root_search_status_name(epoch.root_search_status) << ','
-           << selection_mode_name(epoch.selection_mode) << ',' << (epoch.selected_root_valid ? 1 : 0) << ',';
+           << (propagation_evaluated ? 1 : 0) << ',';
+    if (propagation_evaluated) {
+        output << (received.direct_geometry.line_of_sight ? 1 : 0) << ','
+               << urban_wall_id_name(received.direct_geometry.primary_wall) << ','
+               << (received.direct_geometry.grazing_roof ? 1 : 0) << ','
+               << urban_rooftop_diffraction_status_name(received.diffraction_status);
+    } else {
+        output << ",NONE,,NOT_EVALUATED";
+    }
+    output << ',' << received.reflections.path_count << ',' << received.path_count << ','
+           << urban_signal_state_name(epoch.urban_state) << ',' << signal_tracking_phase_name(epoch.tracking_phase) << ','
+           << signal_tracking_loss_reason_name(epoch.loss_reason) << ',';
+    if (propagation_evaluated) {
+        output << received.open_cn0_dbhz << ',' << epoch.effective_cn0_dbhz << ','
+               << (epoch.effective_cn0.finite_effective_cn0 ? 1 : 0) << ','
+               << epoch.effective_cn0.composite_power_ratio << ',' << epoch.dll_root_count << ','
+               << root_search_status_name(epoch.root_search_status) << ',' << selection_mode_name(epoch.selection_mode)
+               << ',';
+    } else {
+        output << ",,,,0,NOT_EVALUATED,NOT_EVALUATED,";
+    }
+    output << (epoch.selected_root_valid ? 1 : 0) << ',';
     if (epoch.selected_root_valid) {
         output << epoch.preselected_root.code_phase_sec << ',' << epoch.preselected_root.code_phase_chips;
     } else {

--- a/src/output/urban_truth_writer.cpp
+++ b/src/output/urban_truth_writer.cpp
@@ -1,0 +1,269 @@
+#include "output/urban_truth_writer.h"
+
+#include "model/urban_scene_geometry.h"
+#include "model/urban_rooftop_diffraction.h"
+
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <locale>
+#include <new>
+
+namespace gnss_sim {
+
+struct UrbanTruthWriter {
+    std::ofstream signal_stream;
+    std::ofstream path_stream;
+    bool finalized;
+};
+
+namespace {
+
+constexpr double kRadiansToDegrees = 180.0 / 3.141592653589793238462643383279502884;
+
+void set_error(std::string* error_message, const std::string& message) {
+    if (error_message != nullptr) {
+        *error_message = message;
+    }
+}
+
+bool open_csv(std::ofstream* stream, const std::filesystem::path& path, const char* header,
+              std::string* error_message) {
+    stream->open(path, std::ios::binary | std::ios::trunc);
+    if (!*stream) {
+        set_error(error_message, std::string("cannot open urban truth CSV: ") + path.generic_string());
+        return false;
+    }
+    stream->imbue(std::locale::classic());
+    *stream << header << '\n';
+    if (!*stream) {
+        set_error(error_message, std::string("cannot write urban truth CSV header: ") + path.generic_string());
+        return false;
+    }
+    return true;
+}
+
+bool stream_ok(std::ofstream& stream, const char* name, std::string* error_message) {
+    if (stream) {
+        return true;
+    }
+    set_error(error_message, std::string("failed to write ") + name);
+    return false;
+}
+
+void write_time(std::ofstream& stream, const SimTime& time) {
+    stream << time.gps_week << ',' << time.tow_ns << ',' << std::fixed << std::setprecision(9)
+           << sim_time_sow_sec(time);
+}
+
+const char* root_search_status_name(CodeTrackingDllRootSearchStatus status) {
+    switch (status) {
+        case CodeTrackingDllRootSearchStatus::kRootsFound:
+            return "ROOTS_FOUND";
+        case CodeTrackingDllRootSearchStatus::kNoRoots:
+            return "NO_ROOTS";
+    }
+    return "UNKNOWN";
+}
+
+const char* selection_mode_name(CodeTrackingDllSelectionMode mode) {
+    switch (mode) {
+        case CodeTrackingDllSelectionMode::TRACKED:
+            return "TRACKED";
+        case CodeTrackingDllSelectionMode::ACQUISITION:
+            return "ACQUISITION";
+    }
+    return "UNKNOWN";
+}
+
+void write_complex(std::ofstream& stream, const std::complex<double>& value) {
+    stream << std::scientific << std::setprecision(17) << value.real() << ',' << value.imag();
+}
+
+void write_point(std::ofstream& stream, const EnuPoint& point) {
+    stream << std::scientific << std::setprecision(17) << point.east_m << ',' << point.north_m << ',' << point.up_m;
+}
+
+bool write_path_rows(UrbanTruthWriter* writer, const SatelliteGeometry& geometry, const SignalDefinition& signal,
+                     const UrbanSignalEpochResult& epoch, std::string* error_message) {
+    const UrbanReceivedPathSet& received = epoch.received_paths;
+    if (received.path_count <= 0) {
+        return true;
+    }
+
+    std::ofstream& output = writer->path_stream;
+    write_time(output, geometry.receive_time);
+    output << ',' << geometry.satellite_number << ',' << static_cast<int>(signal.signal_id) << ",0,DIRECT_ROOF,"
+           << urban_wall_id_name(received.diffraction_status == UrbanRooftopDiffractionStatus::VALID
+                                     ? received.diffraction.wall_id
+                                     : received.direct_geometry.primary_wall)
+           << ',';
+    if (received.diffraction_status == UrbanRooftopDiffractionStatus::VALID) {
+        write_point(output, received.diffraction.diffraction_point_enu_m);
+        output << ',' << std::scientific << std::setprecision(17) << received.diffraction.model_path_range_m << ','
+               << received.diffraction.excess_path_length_m << ',' << received.paths[0].code_delay_sec << ',';
+    } else {
+        output << ",,," << ',' << geometry.geometric_range_m << ",0," << received.paths[0].code_delay_sec << ',';
+    }
+    write_complex(output, received.paths[0].complex_voltage);
+    output << ',' << std::abs(received.paths[0].complex_voltage) << ',' << std::arg(received.paths[0].complex_voltage)
+           << ',';
+    if (received.diffraction_status == UrbanRooftopDiffractionStatus::VALID) {
+        output << received.diffraction.fresnel_v << ',';
+        write_complex(output, received.diffraction.fresnel_coefficient);
+    } else {
+        output << ",,,";
+    }
+    output << ",,,,,,,,,\n";
+    if (!stream_ok(output, "urban_path_truth.csv", error_message)) {
+        return false;
+    }
+
+    for (int index = 0; index < received.reflections.path_count; ++index) {
+        const UrbanFirstOrderReflectionPath& reflection = received.reflections.paths[index];
+        const int received_index = index + 1;
+        if (received_index >= received.path_count) {
+            set_error(error_message, "urban truth reflection/path ordering is inconsistent");
+            return false;
+        }
+        write_time(output, geometry.receive_time);
+        output << ',' << geometry.satellite_number << ',' << static_cast<int>(signal.signal_id) << ',' << received_index
+               << ",REFLECTION," << urban_wall_id_name(reflection.wall_id) << ',';
+        write_point(output, reflection.reflection_point_enu_m);
+        output << ',' << std::scientific << std::setprecision(17) << reflection.model_path_range_m << ','
+               << reflection.excess_path_length_m << ',' << received.paths[received_index].code_delay_sec << ',';
+        write_complex(output, received.paths[received_index].complex_voltage);
+        output << ',' << std::abs(received.paths[received_index].complex_voltage) << ','
+               << std::arg(received.paths[received_index].complex_voltage) << ",,,,"
+               << reflection.incidence_angle_rad * kRadiansToDegrees << ',';
+        write_complex(output, reflection.rf_response.gamma_rhcp_from_rhcp);
+        output << ',';
+        write_complex(output, reflection.rf_response.gamma_lhcp_from_rhcp);
+        output << ',';
+        write_complex(output, reflection.antenna_rhcp_voltage);
+        output << ',';
+        write_complex(output, reflection.antenna_lhcp_voltage);
+        output << '\n';
+        if (!stream_ok(output, "urban_path_truth.csv", error_message)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+} // namespace
+
+UrbanTruthWriter* create_urban_truth_writer(const char* receiver_log_path, std::string* error_message) {
+    if (receiver_log_path == nullptr || receiver_log_path[0] == '\0') {
+        set_error(error_message, "urban truth writer request has invalid output path");
+        return nullptr;
+    }
+    UrbanTruthWriter* writer = new (std::nothrow) UrbanTruthWriter{};
+    if (writer == nullptr) {
+        set_error(error_message, "cannot allocate urban truth writer");
+        return nullptr;
+    }
+    std::filesystem::path output_directory = std::filesystem::path(receiver_log_path).parent_path();
+    if (output_directory.empty()) {
+        output_directory = ".";
+    }
+    const char* signal_header =
+        "truth_schema_version,gps_week,tow_ns,sow_sec,satellite_number,signal_id,signal_name,glonass_fcn,"
+        "azimuth_deg,elevation_deg,direct_los,blocking_wall,grazing_roof,diffraction_status,reflection_count,"
+        "received_path_count,urban_state,tracking_phase,loss_reason,open_cn0_dbhz,effective_cn0_dbhz,"
+        "effective_cn0_finite,composite_power_ratio,dll_root_count,root_search_status,selection_mode,"
+        "selected_root_valid,dll_code_phase_sec,dll_code_phase_chips,code_bias_m,tracked_correlation_real,"
+        "tracked_correlation_imag,lock_time_ns,observation_available,pseudorange_valid,doppler_valid,adr_valid,"
+        "reacquisition_event,carrier_continuity_valid,wavelength_m,wrapped_phase_rad,unwrapped_phase_rad,"
+        "carrier_range_bias_m,environmental_range_rate_mps,environmental_range_rate_valid,cycle_slip_event,"
+        "receiver_observation_emitted,pseudorange_m,doppler_hz,adr_cycles";
+    const char* path_header =
+        "truth_schema_version,gps_week,tow_ns,sow_sec,satellite_number,signal_id,path_index,path_kind,wall_id,"
+        "point_e_m,point_n_m,point_u_m,model_path_range_m,excess_path_m,code_delay_sec,voltage_real,voltage_imag,"
+        "voltage_amplitude,voltage_phase_rad,fresnel_v,fresnel_real,fresnel_imag,incidence_angle_deg,"
+        "gamma_rhcp_real,gamma_rhcp_imag,gamma_lhcp_real,gamma_lhcp_imag,antenna_rhcp_real,antenna_rhcp_imag,"
+        "antenna_lhcp_real,antenna_lhcp_imag";
+    if (!open_csv(&writer->signal_stream, output_directory / "urban_signal_truth.csv", signal_header, error_message) ||
+        !open_csv(&writer->path_stream, output_directory / "urban_path_truth.csv", path_header, error_message)) {
+        delete writer;
+        return nullptr;
+    }
+    return writer;
+}
+
+void destroy_urban_truth_writer(UrbanTruthWriter* writer) {
+    delete writer;
+}
+
+bool urban_truth_writer_write_signal(UrbanTruthWriter* writer, const SatelliteGeometry& geometry,
+                                     const SignalDefinition& signal, int glonass_fcn,
+                                     const UrbanSignalEpochResult& epoch,
+                                     const UrbanCarrierTemporalResult& temporal,
+                                     const MeasurementObservation* observation,
+                                     std::string* error_message) {
+    if (writer == nullptr || writer->finalized || geometry.satellite_number <= 0) {
+        set_error(error_message, "urban truth signal writer request is invalid");
+        return false;
+    }
+    const UrbanReceivedPathSet& received = epoch.received_paths;
+    std::ofstream& output = writer->signal_stream;
+    output << URBAN_TRUTH_SCHEMA_VERSION << ',';
+    write_time(output, geometry.receive_time);
+    output << ',' << geometry.satellite_number << ',' << static_cast<int>(signal.signal_id) << ',' << signal.name << ','
+           << glonass_fcn << ',' << std::scientific << std::setprecision(17)
+           << geometry.azimuth_rad * kRadiansToDegrees << ',' << geometry.elevation_rad * kRadiansToDegrees << ','
+           << (received.direct_geometry.line_of_sight ? 1 : 0) << ','
+           << urban_wall_id_name(received.direct_geometry.primary_wall) << ','
+           << (received.direct_geometry.grazing_roof ? 1 : 0) << ','
+           << urban_rooftop_diffraction_status_name(received.diffraction_status) << ',' << received.reflections.path_count
+           << ',' << received.path_count << ',' << urban_signal_state_name(epoch.urban_state) << ','
+           << signal_tracking_phase_name(epoch.tracking_phase) << ',' << signal_tracking_loss_reason_name(epoch.loss_reason)
+           << ',' << received.open_cn0_dbhz << ',' << epoch.effective_cn0_dbhz << ','
+           << (epoch.effective_cn0.finite_effective_cn0 ? 1 : 0) << ',' << epoch.effective_cn0.composite_power_ratio << ','
+           << epoch.dll_root_count << ',' << root_search_status_name(epoch.root_search_status) << ','
+           << selection_mode_name(epoch.selection_mode) << ',' << (epoch.selected_root_valid ? 1 : 0) << ',';
+    if (epoch.selected_root_valid) {
+        output << epoch.preselected_root.code_phase_sec << ',' << epoch.preselected_root.code_phase_chips;
+    } else {
+        output << ',';
+    }
+    output << ',' << epoch.code_bias_m << ',';
+    write_complex(output, epoch.tracked_composite_correlation);
+    output << ',' << epoch.lock_time_ns << ',' << (epoch.observation_available ? 1 : 0) << ','
+           << (epoch.psr_valid ? 1 : 0) << ',' << (epoch.doppler_valid ? 1 : 0) << ',' << (epoch.adr_valid ? 1 : 0) << ','
+           << (epoch.reacquisition_event ? 1 : 0) << ',' << (epoch.carrier_continuity_valid ? 1 : 0) << ','
+           << temporal.wavelength_m << ',' << temporal.wrapped_phase_rad << ',' << temporal.unwrapped_phase_rad << ','
+           << temporal.carrier_range_bias_m << ',' << temporal.environmental_range_rate_mps << ','
+           << (temporal.environmental_range_rate_valid ? 1 : 0) << ',' << (temporal.cycle_slip_event ? 1 : 0) << ','
+           << (observation != nullptr ? 1 : 0) << ',';
+    if (observation != nullptr) {
+        output << observation->pseudorange_m << ',' << observation->doppler_hz << ',' << observation->adr_cycles;
+    } else {
+        output << ",,";
+    }
+    output << '\n';
+    if (!stream_ok(output, "urban_signal_truth.csv", error_message)) {
+        return false;
+    }
+    return write_path_rows(writer, geometry, signal, epoch, error_message);
+}
+
+bool finalize_urban_truth_writer(UrbanTruthWriter* writer, std::string* error_message) {
+    if (writer == nullptr || writer->finalized) {
+        set_error(error_message, "urban truth writer finalization request is invalid");
+        return false;
+    }
+    writer->signal_stream.flush();
+    writer->path_stream.flush();
+    if (!writer->signal_stream || !writer->path_stream) {
+        set_error(error_message, "failed to flush urban truth CSV output");
+        return false;
+    }
+    writer->signal_stream.close();
+    writer->path_stream.close();
+    writer->finalized = true;
+    return true;
+}
+
+} // namespace gnss_sim

--- a/src/output/urban_truth_writer.h
+++ b/src/output/urban_truth_writer.h
@@ -1,0 +1,35 @@
+#ifndef GNSS_SIM_SRC_OUTPUT_URBAN_TRUTH_WRITER_H_
+#define GNSS_SIM_SRC_OUTPUT_URBAN_TRUTH_WRITER_H_
+
+#include "gnss/satellite_engine.h"
+#include "model/measurement_model.h"
+#include "model/urban_carrier_temporal.h"
+#include "model/urban_signal_epoch.h"
+
+#include <string>
+
+namespace gnss_sim {
+
+struct UrbanTruthWriter;
+
+constexpr int URBAN_TRUTH_SCHEMA_VERSION = 1;
+
+UrbanTruthWriter* create_urban_truth_writer(const char* receiver_log_path, std::string* error_message);
+void destroy_urban_truth_writer(UrbanTruthWriter* writer);
+
+// Writes one per-signal summary plus the already-computed propagation paths.
+// observation may be null for BLOCKED/searching/lost states. This function is
+// serialization-only: it must never recompute geometry, propagation, DLL, CN0,
+// tracking, carrier phase, or path rate.
+bool urban_truth_writer_write_signal(UrbanTruthWriter* writer, const SatelliteGeometry& geometry,
+                                     const SignalDefinition& signal, int glonass_fcn,
+                                     const UrbanSignalEpochResult& epoch,
+                                     const UrbanCarrierTemporalResult& temporal,
+                                     const MeasurementObservation* observation,
+                                     std::string* error_message);
+
+bool finalize_urban_truth_writer(UrbanTruthWriter* writer, std::string* error_message);
+
+} // namespace gnss_sim
+
+#endif // GNSS_SIM_SRC_OUTPUT_URBAN_TRUTH_WRITER_H_

--- a/src/output/urban_truth_writer.h
+++ b/src/output/urban_truth_writer.h
@@ -23,10 +23,8 @@ void destroy_urban_truth_writer(UrbanTruthWriter* writer);
 // tracking, carrier phase, or path rate.
 bool urban_truth_writer_write_signal(UrbanTruthWriter* writer, const SatelliteGeometry& geometry,
                                      const SignalDefinition& signal, int glonass_fcn,
-                                     const UrbanSignalEpochResult& epoch,
-                                     const UrbanCarrierTemporalResult& temporal,
-                                     const MeasurementObservation* observation,
-                                     std::string* error_message);
+                                     const UrbanSignalEpochResult& epoch, const UrbanCarrierTemporalResult& temporal,
+                                     const MeasurementObservation* observation, std::string* error_message);
 
 bool finalize_urban_truth_writer(UrbanTruthWriter* writer, std::string* error_message);
 

--- a/tests/integration/test_truth_outputs.cpp
+++ b/tests/integration/test_truth_outputs.cpp
@@ -111,10 +111,9 @@ void expect_stable_urban_path_order(const std::filesystem::path& path) {
     int expected_path_index = 0;
     for (std::size_t row_index = 1; row_index < rows.size(); ++row_index) {
         const std::vector<std::string>& row = rows[row_index];
-        const std::string key = row[static_cast<std::size_t>(week_column)] + ":" +
-                                row[static_cast<std::size_t>(tow_column)] + ":" +
-                                row[static_cast<std::size_t>(satellite_column)] + ":" +
-                                row[static_cast<std::size_t>(signal_column)];
+        const std::string key =
+            row[static_cast<std::size_t>(week_column)] + ":" + row[static_cast<std::size_t>(tow_column)] + ":" +
+            row[static_cast<std::size_t>(satellite_column)] + ":" + row[static_cast<std::size_t>(signal_column)];
         if (key != previous_key) {
             expected_path_index = 0;
             previous_key = key;
@@ -180,16 +179,17 @@ TEST(TruthOutputs, HeadersAreVersionedAndExplicit) {
               "velocity_valid,velocity_status,velocity_type,velocity_x_mps,velocity_y_mps,velocity_z_mps,"
               "horizontal_speed_mps,track_over_ground_deg,vertical_speed_mps,receiver_clock_drift_mps,"
               "velocity_used_satellites,velocity_diagnostic");
-    EXPECT_EQ(first_line(directory / "urban_signal_truth.csv"),
-              "truth_schema_version,gps_week,tow_ns,sow_sec,satellite_number,signal_id,signal_name,glonass_fcn,"
-              "azimuth_deg,elevation_deg,propagation_evaluated,direct_los,blocking_wall,grazing_roof,diffraction_status,"
-              "reflection_count,received_path_count,urban_state,tracking_phase,loss_reason,open_cn0_dbhz,effective_cn0_dbhz,"
-              "effective_cn0_finite,composite_power_ratio,dll_root_count,root_search_status,selection_mode,"
-              "selected_root_valid,dll_code_phase_sec,dll_code_phase_chips,code_bias_m,tracked_correlation_real,"
-              "tracked_correlation_imag,lock_time_ns,observation_available,pseudorange_valid,doppler_valid,adr_valid,"
-              "reacquisition_event,carrier_continuity_valid,wavelength_m,wrapped_phase_rad,unwrapped_phase_rad,"
-              "carrier_range_bias_m,environmental_range_rate_mps,environmental_range_rate_valid,cycle_slip_event,"
-              "receiver_observation_emitted,pseudorange_m,doppler_hz,adr_cycles");
+    EXPECT_EQ(
+        first_line(directory / "urban_signal_truth.csv"),
+        "truth_schema_version,gps_week,tow_ns,sow_sec,satellite_number,signal_id,signal_name,glonass_fcn,"
+        "azimuth_deg,elevation_deg,propagation_evaluated,direct_los,blocking_wall,grazing_roof,diffraction_status,"
+        "reflection_count,received_path_count,urban_state,tracking_phase,loss_reason,open_cn0_dbhz,effective_cn0_dbhz,"
+        "effective_cn0_finite,composite_power_ratio,dll_root_count,root_search_status,selection_mode,"
+        "selected_root_valid,dll_code_phase_sec,dll_code_phase_chips,code_bias_m,tracked_correlation_real,"
+        "tracked_correlation_imag,lock_time_ns,observation_available,pseudorange_valid,doppler_valid,adr_valid,"
+        "reacquisition_event,carrier_continuity_valid,wavelength_m,wrapped_phase_rad,unwrapped_phase_rad,"
+        "carrier_range_bias_m,environmental_range_rate_mps,environmental_range_rate_valid,cycle_slip_event,"
+        "receiver_observation_emitted,pseudorange_m,doppler_hz,adr_cycles");
     EXPECT_EQ(first_line(directory / "urban_path_truth.csv"),
               "truth_schema_version,gps_week,tow_ns,sow_sec,satellite_number,signal_id,path_index,path_kind,wall_id,"
               "point_e_m,point_n_m,point_u_m,model_path_range_m,excess_path_m,code_delay_sec,voltage_real,voltage_imag,"
@@ -326,10 +326,8 @@ TEST(TruthOutputs, UrbanTruthIsDeterministicOrderedAndMatchesSynthesizedObservat
     const std::vector<std::string>* matching_observation = nullptr;
     for (std::size_t row_index = 1; row_index < observation_rows.size(); ++row_index) {
         const std::vector<std::string>& row = observation_rows[row_index];
-        if (row[static_cast<std::size_t>(observation_week)] ==
-                (*emitted_row)[static_cast<std::size_t>(urban_week)] &&
-            row[static_cast<std::size_t>(observation_tow)] ==
-                (*emitted_row)[static_cast<std::size_t>(urban_tow)] &&
+        if (row[static_cast<std::size_t>(observation_week)] == (*emitted_row)[static_cast<std::size_t>(urban_week)] &&
+            row[static_cast<std::size_t>(observation_tow)] == (*emitted_row)[static_cast<std::size_t>(urban_tow)] &&
             row[static_cast<std::size_t>(observation_satellite)] ==
                 (*emitted_row)[static_cast<std::size_t>(urban_satellite)] &&
             row[static_cast<std::size_t>(observation_signal)] ==
@@ -367,15 +365,14 @@ TEST(TruthOutputs, UrbanTruthSerializerCoversAllFourPropagationStates) {
     double wavelength_m = 0.0;
     ASSERT_TRUE(gnss_sim::signal_wavelength_m(*signal, 0, &wavelength_m));
 
-    const gnss_sim::UrbanSignalState states[] = {gnss_sim::UrbanSignalState::kLos,
-                                                 gnss_sim::UrbanSignalState::kLosMultipath,
-                                                 gnss_sim::UrbanSignalState::kNlosTracked,
-                                                 gnss_sim::UrbanSignalState::kBlocked};
+    const gnss_sim::UrbanSignalState states[] = {
+        gnss_sim::UrbanSignalState::kLos, gnss_sim::UrbanSignalState::kLosMultipath,
+        gnss_sim::UrbanSignalState::kNlosTracked, gnss_sim::UrbanSignalState::kBlocked};
     const gnss_sim::SimTime base_time = start_time();
     for (int state_index = 0; state_index < 4; ++state_index) {
         gnss_sim::SatelliteGeometry geometry{};
-        ASSERT_TRUE(gnss_sim::add_time_ns(base_time, state_index * gnss_sim::NANOSECONDS_PER_SECOND,
-                                          &geometry.receive_time));
+        ASSERT_TRUE(
+            gnss_sim::add_time_ns(base_time, state_index * gnss_sim::NANOSECONDS_PER_SECOND, &geometry.receive_time));
         geometry.satellite_number = 1;
         geometry.geometric_range_m = 21000000.0 + state_index;
         geometry.azimuth_rad = 0.4 + 0.1 * state_index;
@@ -383,10 +380,10 @@ TEST(TruthOutputs, UrbanTruthSerializerCoversAllFourPropagationStates) {
 
         gnss_sim::UrbanSignalEpochResult epoch{};
         epoch.urban_state = states[state_index];
-        epoch.tracking_phase = state_index == 3 ? gnss_sim::SignalTrackingPhase::kSearching
-                                                : gnss_sim::SignalTrackingPhase::kTracking;
-        epoch.loss_reason = state_index == 3 ? gnss_sim::SignalTrackingLossReason::kLowCn0
-                                             : gnss_sim::SignalTrackingLossReason::kNone;
+        epoch.tracking_phase =
+            state_index == 3 ? gnss_sim::SignalTrackingPhase::kSearching : gnss_sim::SignalTrackingPhase::kTracking;
+        epoch.loss_reason =
+            state_index == 3 ? gnss_sim::SignalTrackingLossReason::kLowCn0 : gnss_sim::SignalTrackingLossReason::kNone;
         epoch.lock_time_ns = state_index == 3 ? 0 : state_index * gnss_sim::NANOSECONDS_PER_SECOND;
         epoch.observation_available = state_index != 3;
         epoch.psr_valid = state_index != 3;
@@ -438,14 +435,14 @@ TEST(TruthOutputs, UrbanTruthSerializerCoversAllFourPropagationStates) {
             epoch.tracked_composite_correlation = received.paths[0].complex_voltage;
             temporal.wrapped_phase_rad = 0.1 * state_index;
             temporal.unwrapped_phase_rad = 0.1 * state_index;
-            temporal.carrier_range_bias_m = -temporal.unwrapped_phase_rad * wavelength_m /
-                                            (2.0 * 3.141592653589793238462643383279502884);
+            temporal.carrier_range_bias_m =
+                -temporal.unwrapped_phase_rad * wavelength_m / (2.0 * 3.141592653589793238462643383279502884);
             temporal.environmental_range_rate_mps = 0.01 * state_index;
             temporal.environmental_range_rate_valid = state_index > 0;
         }
 
         ASSERT_TRUE(gnss_sim::urban_truth_writer_write_signal(writer, geometry, *signal, 0, epoch, temporal, nullptr,
-                                                               &error_message))
+                                                              &error_message))
             << error_message;
     }
     ASSERT_TRUE(gnss_sim::finalize_urban_truth_writer(writer, &error_message)) << error_message;
@@ -488,9 +485,9 @@ TEST(TruthOutputs, ExternalCn0ModelIsManifestedAndByteRepeatable) {
         << error_message;
     ASSERT_TRUE(run_in_directory(builtin_directory, &builtin_summary, &error_message)) << error_message;
 
-    for (const char* file_name : {"simulated.log", "scenario.json", "event_truth.csv", "observation_truth.csv",
-                                  "solution_truth.csv", "urban_signal_truth.csv", "urban_path_truth.csv",
-                                  "run_manifest.json"}) {
+    for (const char* file_name :
+         {"simulated.log", "scenario.json", "event_truth.csv", "observation_truth.csv", "solution_truth.csv",
+          "urban_signal_truth.csv", "urban_path_truth.csv", "run_manifest.json"}) {
         EXPECT_EQ(read_file(first_directory / file_name), read_file(second_directory / file_name)) << file_name;
     }
     const std::string manifest = read_file(first_directory / "run_manifest.json");

--- a/tests/integration/test_truth_outputs.cpp
+++ b/tests/integration/test_truth_outputs.cpp
@@ -1,6 +1,8 @@
+#include "gnss/signal_definitions.h"
 #include "gnss_sim/sim_config.h"
 #include "gnss_sim/sim_time.h"
 #include "gnss_sim/simulator.h"
+#include "output/urban_truth_writer.h"
 
 #include <cstdio>
 #include <filesystem>
@@ -346,6 +348,130 @@ TEST(TruthOutputs, UrbanTruthIsDeterministicOrderedAndMatchesSynthesizedObservat
 
     cleanup(first_directory);
     cleanup(second_directory);
+}
+
+TEST(TruthOutputs, UrbanTruthSerializerCoversAllFourPropagationStates) {
+    const std::filesystem::path directory = "gnss_sim_truth_urban_states";
+    cleanup(directory);
+    std::error_code filesystem_error;
+    ASSERT_TRUE(std::filesystem::create_directories(directory, filesystem_error));
+    ASSERT_FALSE(filesystem_error);
+
+    const std::filesystem::path receiver_log_path = directory / "simulated.log";
+    std::string error_message;
+    gnss_sim::UrbanTruthWriter* writer =
+        gnss_sim::create_urban_truth_writer(receiver_log_path.string().c_str(), &error_message);
+    ASSERT_NE(writer, nullptr) << error_message;
+    const gnss_sim::SignalDefinition* signal = gnss_sim::find_signal_definition(gnss_sim::SignalId::kGpsL1Ca);
+    ASSERT_NE(signal, nullptr);
+    double wavelength_m = 0.0;
+    ASSERT_TRUE(gnss_sim::signal_wavelength_m(*signal, 0, &wavelength_m));
+
+    const gnss_sim::UrbanSignalState states[] = {gnss_sim::UrbanSignalState::kLos,
+                                                 gnss_sim::UrbanSignalState::kLosMultipath,
+                                                 gnss_sim::UrbanSignalState::kNlosTracked,
+                                                 gnss_sim::UrbanSignalState::kBlocked};
+    const gnss_sim::SimTime base_time = start_time();
+    for (int state_index = 0; state_index < 4; ++state_index) {
+        gnss_sim::SatelliteGeometry geometry{};
+        ASSERT_TRUE(gnss_sim::add_time_ns(base_time, state_index * gnss_sim::NANOSECONDS_PER_SECOND,
+                                          &geometry.receive_time));
+        geometry.satellite_number = 1;
+        geometry.geometric_range_m = 21000000.0 + state_index;
+        geometry.azimuth_rad = 0.4 + 0.1 * state_index;
+        geometry.elevation_rad = 0.6;
+
+        gnss_sim::UrbanSignalEpochResult epoch{};
+        epoch.urban_state = states[state_index];
+        epoch.tracking_phase = state_index == 3 ? gnss_sim::SignalTrackingPhase::kSearching
+                                                : gnss_sim::SignalTrackingPhase::kTracking;
+        epoch.loss_reason = state_index == 3 ? gnss_sim::SignalTrackingLossReason::kLowCn0
+                                             : gnss_sim::SignalTrackingLossReason::kNone;
+        epoch.lock_time_ns = state_index == 3 ? 0 : state_index * gnss_sim::NANOSECONDS_PER_SECOND;
+        epoch.observation_available = state_index != 3;
+        epoch.psr_valid = state_index != 3;
+        epoch.doppler_valid = state_index != 3;
+        epoch.adr_valid = state_index != 3;
+        epoch.reacquisition_event = state_index == 2;
+        epoch.carrier_continuity_valid = state_index != 3;
+
+        gnss_sim::UrbanCarrierTemporalResult temporal{};
+        temporal.wavelength_m = wavelength_m;
+        temporal.tracking_lock_valid = state_index != 3;
+        temporal.carrier_adr_valid = state_index != 3;
+        temporal.phase_continuity_valid = state_index != 3;
+        temporal.cycle_slip_event = state_index == 2;
+
+        if (state_index != 3) {
+            gnss_sim::UrbanReceivedPathSet& received = epoch.received_paths;
+            received.path_count = 1;
+            received.open_cn0_dbhz = 45.0;
+            received.direct_geometry.line_of_sight = state_index < 2;
+            received.direct_geometry.primary_wall = gnss_sim::UrbanWallId::NORTH;
+            received.direct_geometry.grazing_roof = state_index == 1;
+            received.paths[0].code_delay_sec = state_index == 0 ? 0.0 : 1.0e-8 * state_index;
+            received.paths[0].complex_voltage = {1.0 - 0.1 * state_index, 0.05 * state_index};
+            if (state_index == 0) {
+                received.diffraction_status = gnss_sim::UrbanRooftopDiffractionStatus::NO_BLOCKING_ROOF_EDGE;
+            } else {
+                received.diffraction_status = gnss_sim::UrbanRooftopDiffractionStatus::VALID;
+                received.diffraction.wall_id = gnss_sim::UrbanWallId::NORTH;
+                received.diffraction.diffraction_point_enu_m = {0.0, 10.0, 10.0};
+                received.diffraction.model_path_range_m = geometry.geometric_range_m + 1.0 + state_index;
+                received.diffraction.excess_path_length_m = 1.0 + state_index;
+                received.diffraction.fresnel_v = state_index == 1 ? -0.1 : 0.8;
+                received.diffraction.fresnel_coefficient = received.paths[0].complex_voltage;
+            }
+            epoch.effective_cn0.open_cn0_dbhz = received.open_cn0_dbhz;
+            epoch.effective_cn0.composite_correlation = received.paths[0].complex_voltage;
+            epoch.effective_cn0.composite_power_ratio = std::norm(received.paths[0].complex_voltage);
+            epoch.effective_cn0.effective_cn0_dbhz = 44.0 - state_index;
+            epoch.effective_cn0.finite_effective_cn0 = true;
+            epoch.effective_cn0_dbhz = epoch.effective_cn0.effective_cn0_dbhz;
+            epoch.dll_root_count = 1;
+            epoch.root_search_status = gnss_sim::CodeTrackingDllRootSearchStatus::kRootsFound;
+            epoch.selection_mode = gnss_sim::CodeTrackingDllSelectionMode::TRACKED;
+            epoch.selected_root_valid = true;
+            epoch.preselected_root.code_phase_sec = received.paths[0].code_delay_sec;
+            epoch.preselected_root.code_phase_chips = 0.01 * state_index;
+            epoch.code_bias_m = 299792458.0 * epoch.preselected_root.code_phase_sec;
+            epoch.tracked_composite_correlation = received.paths[0].complex_voltage;
+            temporal.wrapped_phase_rad = 0.1 * state_index;
+            temporal.unwrapped_phase_rad = 0.1 * state_index;
+            temporal.carrier_range_bias_m = -temporal.unwrapped_phase_rad * wavelength_m /
+                                            (2.0 * 3.141592653589793238462643383279502884);
+            temporal.environmental_range_rate_mps = 0.01 * state_index;
+            temporal.environmental_range_rate_valid = state_index > 0;
+        }
+
+        ASSERT_TRUE(gnss_sim::urban_truth_writer_write_signal(writer, geometry, *signal, 0, epoch, temporal, nullptr,
+                                                               &error_message))
+            << error_message;
+    }
+    ASSERT_TRUE(gnss_sim::finalize_urban_truth_writer(writer, &error_message)) << error_message;
+    gnss_sim::destroy_urban_truth_writer(writer);
+
+    expect_consistent_simple_csv_columns(directory / "urban_signal_truth.csv");
+    expect_consistent_simple_csv_columns(directory / "urban_path_truth.csv");
+    const std::vector<std::vector<std::string>> rows = read_simple_csv(directory / "urban_signal_truth.csv");
+    ASSERT_EQ(rows.size(), 5U);
+    const int state_column = column_index(rows.front(), "urban_state");
+    const int loss_column = column_index(rows.front(), "loss_reason");
+    const int reacquisition_column = column_index(rows.front(), "reacquisition_event");
+    const int slip_column = column_index(rows.front(), "cycle_slip_event");
+    ASSERT_GE(state_column, 0);
+    ASSERT_GE(loss_column, 0);
+    ASSERT_GE(reacquisition_column, 0);
+    ASSERT_GE(slip_column, 0);
+    EXPECT_EQ(rows[1][static_cast<std::size_t>(state_column)], "LOS");
+    EXPECT_EQ(rows[2][static_cast<std::size_t>(state_column)], "LOS_MULTIPATH");
+    EXPECT_EQ(rows[3][static_cast<std::size_t>(state_column)], "NLOS_TRACKED");
+    EXPECT_EQ(rows[4][static_cast<std::size_t>(state_column)], "BLOCKED");
+    EXPECT_EQ(rows[3][static_cast<std::size_t>(reacquisition_column)], "1");
+    EXPECT_EQ(rows[3][static_cast<std::size_t>(slip_column)], "1");
+    EXPECT_EQ(rows[4][static_cast<std::size_t>(loss_column)], "LOW_CN0");
+    EXPECT_EQ(read_simple_csv(directory / "urban_path_truth.csv").size(), 4U);
+    cleanup(directory);
 }
 
 TEST(TruthOutputs, ExternalCn0ModelIsManifestedAndByteRepeatable) {

--- a/tests/integration/test_truth_outputs.cpp
+++ b/tests/integration/test_truth_outputs.cpp
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <gtest/gtest.h>
 #include <string>
+#include <vector>
 
 namespace {
 
@@ -45,6 +46,81 @@ std::string first_line(const std::filesystem::path& path) {
     std::string line;
     std::getline(input, line);
     return line;
+}
+
+std::vector<std::string> split_csv_line(const std::string& line) {
+    std::vector<std::string> fields;
+    std::size_t start = 0;
+    while (true) {
+        const std::size_t separator = line.find(',', start);
+        if (separator == std::string::npos) {
+            fields.push_back(line.substr(start));
+            return fields;
+        }
+        fields.push_back(line.substr(start, separator - start));
+        start = separator + 1U;
+    }
+}
+
+std::vector<std::vector<std::string>> read_simple_csv(const std::filesystem::path& path) {
+    std::vector<std::vector<std::string>> rows;
+    std::ifstream input(path, std::ios::binary);
+    std::string line;
+    while (std::getline(input, line)) {
+        rows.push_back(split_csv_line(line));
+    }
+    return rows;
+}
+
+int column_index(const std::vector<std::string>& header, const char* name) {
+    for (std::size_t index = 0; index < header.size(); ++index) {
+        if (header[index] == name) {
+            return static_cast<int>(index);
+        }
+    }
+    return -1;
+}
+
+void expect_consistent_simple_csv_columns(const std::filesystem::path& path) {
+    const std::vector<std::vector<std::string>> rows = read_simple_csv(path);
+    ASSERT_FALSE(rows.empty()) << path.string();
+    const std::size_t expected_columns = rows.front().size();
+    ASSERT_GT(expected_columns, 0U) << path.string();
+    for (std::size_t row = 1; row < rows.size(); ++row) {
+        EXPECT_EQ(rows[row].size(), expected_columns) << path.string() << " row " << row + 1U;
+    }
+}
+
+void expect_stable_urban_path_order(const std::filesystem::path& path) {
+    const std::vector<std::vector<std::string>> rows = read_simple_csv(path);
+    ASSERT_GT(rows.size(), 1U);
+    const int week_column = column_index(rows.front(), "gps_week");
+    const int tow_column = column_index(rows.front(), "tow_ns");
+    const int satellite_column = column_index(rows.front(), "satellite_number");
+    const int signal_column = column_index(rows.front(), "signal_id");
+    const int path_index_column = column_index(rows.front(), "path_index");
+    ASSERT_GE(week_column, 0);
+    ASSERT_GE(tow_column, 0);
+    ASSERT_GE(satellite_column, 0);
+    ASSERT_GE(signal_column, 0);
+    ASSERT_GE(path_index_column, 0);
+
+    std::string previous_key;
+    int expected_path_index = 0;
+    for (std::size_t row_index = 1; row_index < rows.size(); ++row_index) {
+        const std::vector<std::string>& row = rows[row_index];
+        const std::string key = row[static_cast<std::size_t>(week_column)] + ":" +
+                                row[static_cast<std::size_t>(tow_column)] + ":" +
+                                row[static_cast<std::size_t>(satellite_column)] + ":" +
+                                row[static_cast<std::size_t>(signal_column)];
+        if (key != previous_key) {
+            expected_path_index = 0;
+            previous_key = key;
+        }
+        ASSERT_FALSE(row[static_cast<std::size_t>(path_index_column)].empty());
+        EXPECT_EQ(std::stoi(row[static_cast<std::size_t>(path_index_column)]), expected_path_index) << key;
+        ++expected_path_index;
+    }
 }
 
 bool run_config_in_directory(const std::filesystem::path& directory, const gnss_sim::SimConfig& config,
@@ -102,6 +178,22 @@ TEST(TruthOutputs, HeadersAreVersionedAndExplicit) {
               "velocity_valid,velocity_status,velocity_type,velocity_x_mps,velocity_y_mps,velocity_z_mps,"
               "horizontal_speed_mps,track_over_ground_deg,vertical_speed_mps,receiver_clock_drift_mps,"
               "velocity_used_satellites,velocity_diagnostic");
+    EXPECT_EQ(first_line(directory / "urban_signal_truth.csv"),
+              "truth_schema_version,gps_week,tow_ns,sow_sec,satellite_number,signal_id,signal_name,glonass_fcn,"
+              "azimuth_deg,elevation_deg,propagation_evaluated,direct_los,blocking_wall,grazing_roof,diffraction_status,"
+              "reflection_count,received_path_count,urban_state,tracking_phase,loss_reason,open_cn0_dbhz,effective_cn0_dbhz,"
+              "effective_cn0_finite,composite_power_ratio,dll_root_count,root_search_status,selection_mode,"
+              "selected_root_valid,dll_code_phase_sec,dll_code_phase_chips,code_bias_m,tracked_correlation_real,"
+              "tracked_correlation_imag,lock_time_ns,observation_available,pseudorange_valid,doppler_valid,adr_valid,"
+              "reacquisition_event,carrier_continuity_valid,wavelength_m,wrapped_phase_rad,unwrapped_phase_rad,"
+              "carrier_range_bias_m,environmental_range_rate_mps,environmental_range_rate_valid,cycle_slip_event,"
+              "receiver_observation_emitted,pseudorange_m,doppler_hz,adr_cycles");
+    EXPECT_EQ(first_line(directory / "urban_path_truth.csv"),
+              "truth_schema_version,gps_week,tow_ns,sow_sec,satellite_number,signal_id,path_index,path_kind,wall_id,"
+              "point_e_m,point_n_m,point_u_m,model_path_range_m,excess_path_m,code_delay_sec,voltage_real,voltage_imag,"
+              "voltage_amplitude,voltage_phase_rad,fresnel_v,fresnel_real,fresnel_imag,incidence_angle_deg,"
+              "gamma_rhcp_real,gamma_rhcp_imag,gamma_lhcp_real,gamma_lhcp_imag,antenna_rhcp_real,antenna_rhcp_imag,"
+              "antenna_lhcp_real,antenna_lhcp_imag");
 
     const std::string scenario = read_file(directory / "scenario.json");
     const std::string manifest = read_file(directory / "run_manifest.json");
@@ -128,6 +220,8 @@ TEST(TruthOutputs, HeadersAreVersionedAndExplicit) {
     EXPECT_NE(observations.find(",LEGACY,"), std::string::npos);
     EXPECT_GT(observations.size(), first_line(directory / "observation_truth.csv").size());
     EXPECT_GT(read_file(directory / "solution_truth.csv").size(), first_line(directory / "solution_truth.csv").size());
+    EXPECT_EQ(read_file(directory / "urban_signal_truth.csv"), first_line(directory / "urban_signal_truth.csv") + "\n");
+    EXPECT_EQ(read_file(directory / "urban_path_truth.csv"), first_line(directory / "urban_path_truth.csv") + "\n");
     cleanup(directory);
 }
 
@@ -140,12 +234,116 @@ TEST(TruthOutputs, SameInputConfigAndSeedAreByteIdenticalAcrossOutputDirectories
     ASSERT_TRUE(run_in_directory(first_directory, &first_summary, &error_message)) << error_message;
     ASSERT_TRUE(run_in_directory(second_directory, &second_summary, &error_message)) << error_message;
 
-    for (const char* file_name :
-         {"scenario.json", "event_truth.csv", "observation_truth.csv", "solution_truth.csv", "run_manifest.json"}) {
+    for (const char* file_name : {"scenario.json", "event_truth.csv", "observation_truth.csv", "solution_truth.csv",
+                                  "urban_signal_truth.csv", "urban_path_truth.csv", "run_manifest.json"}) {
         EXPECT_EQ(read_file(first_directory / file_name), read_file(second_directory / file_name)) << file_name;
     }
     EXPECT_EQ(first_summary.scheduled_epochs, second_summary.scheduled_epochs);
     EXPECT_EQ(first_summary.max_observations_per_epoch, second_summary.max_observations_per_epoch);
+    cleanup(first_directory);
+    cleanup(second_directory);
+}
+
+TEST(TruthOutputs, UrbanTruthIsDeterministicOrderedAndMatchesSynthesizedObservation) {
+    const std::filesystem::path first_directory = "gnss_sim_truth_urban_a";
+    const std::filesystem::path second_directory = "gnss_sim_truth_urban_b";
+    gnss_sim::SimConfig config = truth_config();
+    config.sampling_rate_hz = 10;
+    config.duration_ns = 6LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    config.measurement_noise_enabled = false;
+    config.multipath_enabled = true;
+
+    gnss_sim::SimulatorRunSummary first_summary{};
+    gnss_sim::SimulatorRunSummary second_summary{};
+    std::string error_message;
+    ASSERT_TRUE(run_config_in_directory(first_directory, config, &first_summary, &error_message)) << error_message;
+    ASSERT_TRUE(run_config_in_directory(second_directory, config, &second_summary, &error_message)) << error_message;
+
+    for (const char* file_name : {"simulated.log", "urban_signal_truth.csv", "urban_path_truth.csv"}) {
+        EXPECT_EQ(read_file(first_directory / file_name), read_file(second_directory / file_name)) << file_name;
+    }
+    expect_consistent_simple_csv_columns(first_directory / "urban_signal_truth.csv");
+    expect_consistent_simple_csv_columns(first_directory / "urban_path_truth.csv");
+    expect_stable_urban_path_order(first_directory / "urban_path_truth.csv");
+
+    const std::vector<std::vector<std::string>> urban_rows =
+        read_simple_csv(first_directory / "urban_signal_truth.csv");
+    const std::vector<std::vector<std::string>> observation_rows =
+        read_simple_csv(first_directory / "observation_truth.csv");
+    ASSERT_GT(urban_rows.size(), 1U);
+    ASSERT_GT(observation_rows.size(), 1U);
+
+    const int urban_week = column_index(urban_rows.front(), "gps_week");
+    const int urban_tow = column_index(urban_rows.front(), "tow_ns");
+    const int urban_satellite = column_index(urban_rows.front(), "satellite_number");
+    const int urban_signal = column_index(urban_rows.front(), "signal_id");
+    const int urban_state = column_index(urban_rows.front(), "urban_state");
+    const int urban_emitted = column_index(urban_rows.front(), "receiver_observation_emitted");
+    const int urban_pseudorange = column_index(urban_rows.front(), "pseudorange_m");
+    const int urban_doppler = column_index(urban_rows.front(), "doppler_hz");
+    const int urban_adr = column_index(urban_rows.front(), "adr_cycles");
+    const int observation_week = column_index(observation_rows.front(), "gps_week");
+    const int observation_tow = column_index(observation_rows.front(), "tow_ns");
+    const int observation_satellite = column_index(observation_rows.front(), "satellite_number");
+    const int observation_signal = column_index(observation_rows.front(), "signal_id");
+    const int observation_pseudorange = column_index(observation_rows.front(), "pseudorange_m");
+    const int observation_doppler = column_index(observation_rows.front(), "doppler_hz");
+    const int observation_adr = column_index(observation_rows.front(), "adr_cycles");
+    ASSERT_GE(urban_week, 0);
+    ASSERT_GE(urban_tow, 0);
+    ASSERT_GE(urban_satellite, 0);
+    ASSERT_GE(urban_signal, 0);
+    ASSERT_GE(urban_state, 0);
+    ASSERT_GE(urban_emitted, 0);
+    ASSERT_GE(urban_pseudorange, 0);
+    ASSERT_GE(urban_doppler, 0);
+    ASSERT_GE(urban_adr, 0);
+    ASSERT_GE(observation_week, 0);
+    ASSERT_GE(observation_tow, 0);
+    ASSERT_GE(observation_satellite, 0);
+    ASSERT_GE(observation_signal, 0);
+    ASSERT_GE(observation_pseudorange, 0);
+    ASSERT_GE(observation_doppler, 0);
+    ASSERT_GE(observation_adr, 0);
+
+    bool found_blocked_without_observation = false;
+    const std::vector<std::string>* emitted_row = nullptr;
+    for (std::size_t row_index = 1; row_index < urban_rows.size(); ++row_index) {
+        const std::vector<std::string>& row = urban_rows[row_index];
+        if (row[static_cast<std::size_t>(urban_state)] == "BLOCKED" &&
+            row[static_cast<std::size_t>(urban_emitted)] == "0") {
+            found_blocked_without_observation = true;
+        }
+        if (emitted_row == nullptr && row[static_cast<std::size_t>(urban_emitted)] == "1") {
+            emitted_row = &row;
+        }
+    }
+    EXPECT_TRUE(found_blocked_without_observation);
+    ASSERT_NE(emitted_row, nullptr);
+
+    const std::vector<std::string>* matching_observation = nullptr;
+    for (std::size_t row_index = 1; row_index < observation_rows.size(); ++row_index) {
+        const std::vector<std::string>& row = observation_rows[row_index];
+        if (row[static_cast<std::size_t>(observation_week)] ==
+                (*emitted_row)[static_cast<std::size_t>(urban_week)] &&
+            row[static_cast<std::size_t>(observation_tow)] ==
+                (*emitted_row)[static_cast<std::size_t>(urban_tow)] &&
+            row[static_cast<std::size_t>(observation_satellite)] ==
+                (*emitted_row)[static_cast<std::size_t>(urban_satellite)] &&
+            row[static_cast<std::size_t>(observation_signal)] ==
+                (*emitted_row)[static_cast<std::size_t>(urban_signal)]) {
+            matching_observation = &row;
+            break;
+        }
+    }
+    ASSERT_NE(matching_observation, nullptr);
+    EXPECT_EQ((*emitted_row)[static_cast<std::size_t>(urban_pseudorange)],
+              (*matching_observation)[static_cast<std::size_t>(observation_pseudorange)]);
+    EXPECT_EQ((*emitted_row)[static_cast<std::size_t>(urban_doppler)],
+              (*matching_observation)[static_cast<std::size_t>(observation_doppler)]);
+    EXPECT_EQ((*emitted_row)[static_cast<std::size_t>(urban_adr)],
+              (*matching_observation)[static_cast<std::size_t>(observation_adr)]);
+
     cleanup(first_directory);
     cleanup(second_directory);
 }
@@ -165,7 +363,8 @@ TEST(TruthOutputs, ExternalCn0ModelIsManifestedAndByteRepeatable) {
     ASSERT_TRUE(run_in_directory(builtin_directory, &builtin_summary, &error_message)) << error_message;
 
     for (const char* file_name : {"simulated.log", "scenario.json", "event_truth.csv", "observation_truth.csv",
-                                  "solution_truth.csv", "run_manifest.json"}) {
+                                  "solution_truth.csv", "urban_signal_truth.csv", "urban_path_truth.csv",
+                                  "run_manifest.json"}) {
         EXPECT_EQ(read_file(first_directory / file_name), read_file(second_directory / file_name)) << file_name;
     }
     const std::string manifest = read_file(first_directory / "run_manifest.json");


### PR DESCRIPTION
Closes #123

## Summary
- add a serialization-only urban truth extension with `URBAN_TRUTH_SCHEMA_VERSION=1`
- write `urban_signal_truth.csv` for per-signal propagation/tracking/DLL/CN0/carrier/rate/lock diagnostics, including BLOCKED/no-observation states
- write `urban_path_truth.csv` for the already-computed roof-affected direct component and every retained first-order reflection in stable path order
- wire the writer directly to the same `UrbanSignalEpochResult` and `UrbanCarrierTemporalResult` used by #143/#142; no truth-only physics recomputation
- keep `multipath_enabled=false` on the legacy path; urban CSV files are header-only in that mode
- document schema semantics and the direct-vs-diffraction no-double-counting rule

## Consistency contract
- urban observation fields are serialized after #142 applies deterministic urban effects and before the independent measurement-noise layer
- emitted urban pseudorange/Doppler/ADR are regression-matched against the existing `observation_truth.csv` row for the same epoch/satellite/signal
- BLOCKED/search/loss states remain diagnosable even when no normal receiver observation is emitted
- path ordering is deterministic: index 0 is the roof-affected direct component, followed by retained #117 reflections in production order

## Tests
- scenario-off urban files are header-only and existing truth/receiver outputs remain on the legacy path
- fixed authentic NAV/config/seed gives byte-identical urban signal/path truth across repeated runs
- every urban CSV row has the declared column count
- path indices are stable and contiguous per epoch/satellite/signal
- runtime BLOCKED-without-observation truth is present
- emitted urban observation values exactly match the same zero-noise observation recorded by the existing truth writer
- serializer fixture covers LOS, LOS_MULTIPATH, NLOS_TRACKED, BLOCKED, reacquisition, cycle-slip, and loss-reason fields without manufacturing NAV

## Invariants
- no NAV/EPH/ION fabrication, modification, interpolation, or retargeting
- no target-PVT tuning or arbitrary NLOS offsets
- normal RANGE remains receiver-observable only
- truth writer has no RNG and does not alter receiver/tracking state

## Validation target
Full GitHub Actions: format, tooling, Ubuntu build/test + RANGEA/serialized-NAV regressions, and Windows build/test.