### PR TITLE
Validate complete urban scenario end-to-end with authentic NAV and RTKLIB

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/data/minimal/brd400dlr_rinex4_acceptance_nav.rnx text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,7 @@ jobs:
         if: runner.os == 'Linux'
         shell: bash
         run: ./build/gnss_sim_integration_tests --gtest_filter=RangeaRoundtripIntegration.SerializedRangeAndEphemerisPositionWithoutOriginalRinexNavAndParsesIon
+      - name: Report authentic-NAV urban E2E metrics
+        if: runner.os == 'Linux'
+        shell: bash
+        run: ./build/gnss_sim_integration_tests --gtest_filter=UrbanE2EValidation.*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,6 +302,7 @@ if(BUILD_TESTING)
         tests/integration/test_transient_validator.cpp
         tests/integration/test_residual_validator.cpp
         tests/integration/test_truth_outputs.cpp
+        tests/integration/test_urban_e2e_validation.cpp
         tests/integration/test_v1_acceptance.cpp
     )
     target_include_directories(gnss_sim_integration_tests PRIVATE

--- a/docs/URBAN_E2E_VALIDATION.md
+++ b/docs/URBAN_E2E_VALIDATION.md
@@ -1,0 +1,175 @@
+# Authentic-NAV urban end-to-end validation
+
+Issue: #124
+
+## Verdict
+
+PASS for the V1 urban chain within the signal-correlation scope that is explicitly modeled by the repository.
+
+The end-to-end acceptance run uses authentic BRD400DLR broadcast navigation data, production urban propagation/tracking/measurement code, production solution code, serialized NovAtel RANGEA, and pinned RTKLIB. The run reaches all four frozen urban states and the resulting position/velocity degradation is produced by the observation model rather than by editing navigation data or forcing a target PVT error.
+
+This verdict is intentionally scoped. A full mixed-GNSS BRD400DLR urban run is not yet a valid acceptance path because some frozen GPS/QZSS signal definitions deliberately have unsupported code-correlation profiles. The urban DLL fails fast for those profiles rather than silently substituting an unverified BPSK model. That limitation is preserved by this validation.
+
+## Authentic navigation provenance
+
+Source product: `BRD400DLR`
+
+Source file: `BRD400DLR_S_20250030000_01D_MN.rnx`
+
+Source URL recorded by the fixture metadata:
+
+`ftp://igs.gnsswhu.cn/pub/gps/data/daily/2025/brdc/BRD400DLR_S_20250030000_01D_MN.rnx.gz`
+
+Source compressed SHA256: `fb84d4046b06e905e8e4ec0efb82f0e9ad044bc44d664cc0209cb9b4c92b9512`
+
+Source uncompressed SHA256: `b11c638eea42978b8bd6aa8b65a5099fe6556dfe527bc037ed481d2b239afc42`
+
+Repository fixture: `tests/data/minimal/brd400dlr_rinex4_acceptance_nav.rnx`
+
+Fixture SHA256: `17c6bb00a8a0ef8f732b803925311e7b1ead658ae2e11f62635371eb915e9781`
+
+The fixture is RINEX 4.02 and its provenance is frozen in `brd400dlr_rinex4_acceptance_nav.meta.json`. `.gitattributes` pins this provenance-fixed fixture to LF line endings so that its working-tree bytes do not vary between Linux and Windows checkouts.
+
+## Validation NAV subset
+
+The #124 harness mechanically copies every BeiDou `EPH` record from the authentic BRD400DLR fixture. It does not select satellites based on desired visibility, multipath state, or PVT outcome, and it does not alter, interpolate, retarget, synthesize, or repair any ephemeris field.
+
+The generated subset therefore means:
+
+- all BeiDou EPH records in the frozen authentic fixture;
+- original record field values preserved;
+- canonical LF output from the harness;
+- at least four EPH records and at least four distinct BeiDou satellites are required, otherwise the test fails;
+- no generated ION data is used by this test (`atmosphere_mode=NONE`).
+
+The BeiDou-only scope is selected because the five frozen BeiDou V1 signal correlations required by the urban code path are explicitly modeled. It is not selected to manufacture a particular satellite geometry or error magnitude.
+
+Reference filtered-NAV FNV-1a-64 from CI: `2552251af489a9ec`.
+
+## Frozen acceptance configuration
+
+Reference metric run: GitHub Actions CI #727.
+
+- start: GPST week 2347, SOW 436500 s;
+- duration: 180 s;
+- sampling rate: 1 Hz;
+- static receiver: latitude 20 deg, longitude 120 deg, height 100 m;
+- seed: `0x124`;
+- measurement noise: disabled;
+- urban multipath: enabled;
+- atmosphere: NONE;
+- measurement elevation mask: 0 deg;
+- solution elevation mask: 5 deg;
+- EPH output: enabled;
+- ION output: disabled.
+
+The test runs the same NAV/config/seed twice and requires byte-identical receiver and truth outputs.
+
+## Urban-state and path coverage
+
+CI #727 produced these signal-state counts:
+
+| State | Count |
+| --- | ---: |
+| LOS | 3762 |
+| LOS_MULTIPATH | 2538 |
+| NLOS_TRACKED | 3559 |
+| BLOCKED | 11741 |
+| BLOCKED with propagation evaluated | 1841 |
+
+Path diagnostics:
+
+| Diagnostic | Count |
+| --- | ---: |
+| DIRECT_ROOF | 11700 |
+| first-order REFLECTION | 3600 |
+| direct LOS with retained reflection | 0 |
+
+The zero direct-LOS/reflection overlap is consistent with the #130 frozen-scene reachability result. `LOS_MULTIPATH` in this closed four-wall scene is reached through the physically continuous roof-edge-affected direct field; the diffraction transfer function is not added as an independent second copy of the direct signal. The test therefore does not create direct-plus-full-diffraction double counting merely to make `LOS_MULTIPATH` reachable.
+
+The run also checks that evaluated `BLOCKED` rows do not leak receiver observations and that `NLOS_TRACKED` is supported by indirect propagation rather than a fabricated direct path.
+
+## Position and velocity results
+
+Production solution path, CI #727:
+
+| Metric | Result |
+| --- | ---: |
+| valid position epochs | 177 |
+| maximum horizontal error | 2.29263 m |
+| maximum vertical error | 39.592 m |
+| maximum 3D position error | 39.6384 m |
+| valid velocity epochs | 177 |
+| maximum velocity error | 0.00535238 m/s |
+
+The maximum-position-error epoch is:
+
+`GPST 2347:436679000000000 ns`
+
+Urban states at that epoch:
+
+- LOS: 21
+- LOS_MULTIPATH: 14
+- NLOS_TRACKED: 20
+- BLOCKED: 65
+
+These error values are observations from the fixed authentic-NAV physical simulation. **They are not acceptance targets, tuning objectives, injected offsets, or minimum/maximum requirements.** No wall parameter, threshold, ephemeris value, observation value, or receiver solution was adjusted to obtain the approximately 39.6 m 3D error.
+
+## Independent RTKLIB consumption
+
+The same serialized RANGEA was independently consumed by the pinned RTKLIB path in two ways:
+
+| Navigation used by validator | Valid position epochs | Maximum 3D error |
+| --- | ---: | ---: |
+| authentic filtered RINEX NAV | 177 | 39.6387 m |
+| navigation serialized into receiver log and reconstructed | 177 | 39.6387 m |
+
+This establishes that the degradation is present in the serialized observations and remains explainable when the observations are positioned outside the simulator's maintained in-memory solution state.
+
+The repository's existing non-urban RANGEA round-trip regressions also remain green; #124 does not replace or weaken them.
+
+## Loss, reacquisition, and ADR reset
+
+A separate authentic-NAV REA run is used to exercise signal loss and reacquisition deterministically instead of waiting for incidental satellite motion.
+
+CI #727 produced:
+
+- reacquisition events: 55
+- cycle-slip/reset events: 55
+- signal-off epochs: 10
+- signal-on epochs: 40
+
+The test requires actual `SIGNAL_OFF`/`SIGNAL_ON` events and verifies that lock/carrier continuity is restarted after reacquisition.
+
+The primary 180 s KS run has zero forced reacquisition and zero forced cycle-slip events; those transitions are not injected into the main position-error result.
+
+## Determinism and traceability
+
+For fixed authentic NAV, configuration, receiver position, and seed, the harness requires repeated runs to produce byte-identical:
+
+- `simulated.log`
+- `scenario.json`
+- `observation_truth.csv`
+- `solution_truth.csv`
+- `urban_signal_truth.csv`
+- `urban_path_truth.csv`
+- `run_manifest.json`
+- mechanically filtered BeiDou NAV subset
+
+The state/path assertions are derived from the same truth outputs written by the production synthesis path. Position and velocity metrics are calculated from `solution_truth.csv`, while an independent serialized RANGEA validation is performed through pinned RTKLIB.
+
+## Explicit limitations
+
+1. The #124 PASS is not a claim that every frozen V1 signal has an authoritative urban DLL correlation model. Unsupported GPS/QZSS correlation profiles continue to fail explicitly.
+2. The acceptance case uses BeiDou because its frozen V1 correlation coverage is complete for this code path, not because the navigation was modified to create a desired geometry.
+3. Atmosphere is disabled in this urban acceptance run so that the test isolates the urban observation effects. Existing broadcast-atmosphere tests remain responsible for atmosphere-model validation.
+4. The scene remains the frozen deterministic four-wall V1 model. No finite-width street-canyon extension was introduced for #124.
+5. The approximately 39.6 m worst 3D error is evidence from this one frozen case, not a promise about error distribution in arbitrary real urban environments.
+
+## Acceptance conclusion
+
+Within the explicitly supported correlation scope, the chain
+
+`authentic BRD400DLR NAV -> broadcast satellite state -> four-wall propagation -> coherent received field -> DLL/tracking -> pseudorange/Doppler/ADR/CN0 -> RANGEA -> RTKLIB PVT -> truth diagnostics`
+
+is deterministic, traceable, and end-to-end consumable. The validation does not fabricate navigation information and does not tune the final position solution.

--- a/docs/URBAN_E2E_VALIDATION.md
+++ b/docs/URBAN_E2E_VALIDATION.md
@@ -46,9 +46,24 @@ The BeiDou-only scope is selected because the five frozen BeiDou V1 signal corre
 
 Reference filtered-NAV FNV-1a-64 from CI: `2552251af489a9ec`.
 
-## Frozen acceptance configuration
+## Validation identity and commands
 
-Reference metric run: GitHub Actions CI #727.
+Validated PR head: `f87e8e18769d720208f3f2fd2d5e7728ccb0f51a`.
+
+Authoritative metric and cross-platform validation run: GitHub Actions CI #729 (`33832212284`). The run completed successfully on Linux and Windows; both platforms passed all 337 tests. The Linux focused E2E step reproduced the metrics recorded below.
+
+Commands represented by the CI validation are:
+
+```text
+cmake -S . -B build -DBUILD_TESTING=ON
+cmake --build build --config Release --parallel
+ctest --test-dir build -C Release --output-on-failure
+./build/gnss_sim_integration_tests --gtest_filter=UrbanE2EValidation.*
+```
+
+The commit that adds this evidence paragraph is documentation-only; the validated implementation/test head above is the exact code revision exercised by CI #729.
+
+## Frozen acceptance configuration
 
 - start: GPST week 2347, SOW 436500 s;
 - duration: 180 s;
@@ -67,7 +82,7 @@ The test runs the same NAV/config/seed twice and requires byte-identical receive
 
 ## Urban-state and path coverage
 
-CI #727 produced these signal-state counts:
+CI #729 produced these signal-state counts:
 
 | State | Count |
 | --- | ---: |
@@ -91,7 +106,7 @@ The run also checks that evaluated `BLOCKED` rows do not leak receiver observati
 
 ## Position and velocity results
 
-Production solution path, CI #727:
+Production solution path, CI #729:
 
 | Metric | Result |
 | --- | ---: |
@@ -132,7 +147,7 @@ The repository's existing non-urban RANGEA round-trip regressions also remain gr
 
 A separate authentic-NAV REA run is used to exercise signal loss and reacquisition deterministically instead of waiting for incidental satellite motion.
 
-CI #727 produced:
+CI #729 produced:
 
 - reacquisition events: 55
 - cycle-slip/reset events: 55
@@ -164,7 +179,8 @@ The state/path assertions are derived from the same truth outputs written by the
 2. The acceptance case uses BeiDou because its frozen V1 correlation coverage is complete for this code path, not because the navigation was modified to create a desired geometry.
 3. Atmosphere is disabled in this urban acceptance run so that the test isolates the urban observation effects. Existing broadcast-atmosphere tests remain responsible for atmosphere-model validation.
 4. The scene remains the frozen deterministic four-wall V1 model. No finite-width street-canyon extension was introduced for #124.
-5. The approximately 39.6 m worst 3D error is evidence from this one frozen case, not a promise about error distribution in arbitrary real urban environments.
+5. No suitable representative measured-urban observation/log data set is frozen in this issue's validation inputs, so measured-urban statistical comparison remains an explicit future validation limitation rather than a claimed result.
+6. The approximately 39.6 m worst 3D error is evidence from this one frozen case, not a promise about error distribution in arbitrary real urban environments.
 
 ## Acceptance conclusion
 

--- a/tests/integration/test_urban_e2e_validation.cpp
+++ b/tests/integration/test_urban_e2e_validation.cpp
@@ -25,8 +25,7 @@ constexpr double kTruthLatitudeDeg = 20.0;
 constexpr double kTruthLongitudeDeg = 120.0;
 constexpr double kTruthHeightM = 100.0;
 constexpr std::int64_t kPrimaryDurationSeconds = 180;
-constexpr const char* kSourceFixtureSha256 =
-    "17c6bb00a8a0ef8f732b803925311e7b1ead658ae2e11f62635371eb915e9781";
+constexpr const char* kSourceFixtureSha256 = "17c6bb00a8a0ef8f732b803925311e7b1ead658ae2e11f62635371eb915e9781";
 constexpr const char* kFilteredNavName = "brd400dlr_beidou_verbatim_nav.rnx";
 
 std::string brd4_source_nav_path() {

--- a/tests/integration/test_urban_e2e_validation.cpp
+++ b/tests/integration/test_urban_e2e_validation.cpp
@@ -5,12 +5,12 @@
 #include "rangea_roundtrip.h"
 
 #include <algorithm>
-#include <array>
 #include <cmath>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <gtest/gtest.h>
+#include <iomanip>
 #include <iostream>
 #include <map>
 #include <set>
@@ -25,9 +25,11 @@ constexpr double kTruthLatitudeDeg = 20.0;
 constexpr double kTruthLongitudeDeg = 120.0;
 constexpr double kTruthHeightM = 100.0;
 constexpr std::int64_t kPrimaryDurationSeconds = 180;
-constexpr const char* kFixtureSha256 = "17c6bb00a8a0ef8f732b803925311e7b1ead658ae2e11f62635371eb915e9781";
+constexpr const char* kSourceFixtureSha256 =
+    "17c6bb00a8a0ef8f732b803925311e7b1ead658ae2e11f62635371eb915e9781";
+constexpr const char* kFilteredNavName = "brd400dlr_beidou_verbatim_nav.rnx";
 
-std::string brd4_nav_path() {
+std::string brd4_source_nav_path() {
     return std::string(GNSS_SIM_TEST_DATA_DIR) + "/brd400dlr_rinex4_acceptance_nav.rnx";
 }
 
@@ -45,7 +47,7 @@ gnss_sim::SimConfig urban_config() {
     config.elevation_mask_deg = 0.0;
     config.solution_elevation_mask_deg = 5.0;
     config.output_eph = true;
-    config.output_ion = true;
+    config.output_ion = false;
     config.measurement_noise_enabled = false;
     config.multipath_enabled = true;
     config.atmosphere_mode = gnss_sim::AtmosphereMode::NONE;
@@ -57,6 +59,73 @@ gnss_sim::SimConfig urban_config() {
 std::string read_file(const std::filesystem::path& path) {
     std::ifstream input(path, std::ios::binary);
     return std::string((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
+}
+
+std::string fnv1a64_hex(const std::string& data) {
+    std::uint64_t hash = UINT64_C(14695981039346656037);
+    for (unsigned char byte : data) {
+        hash ^= static_cast<std::uint64_t>(byte);
+        hash *= UINT64_C(1099511628211);
+    }
+    std::ostringstream output;
+    output << std::hex << std::setfill('0') << std::setw(16) << hash;
+    return output.str();
+}
+
+bool materialize_verbatim_beidou_nav(const std::filesystem::path& destination, std::string* error_message) {
+    const std::string source = read_file(brd4_source_nav_path());
+    if (source.empty() || source.find('\r') != std::string::npos) {
+        if (error_message != nullptr) {
+            *error_message = "BRD400DLR source fixture is empty or is not LF-normalized";
+        }
+        return false;
+    }
+
+    std::istringstream input(source);
+    std::ofstream output(destination, std::ios::binary | std::ios::trunc);
+    if (!output) {
+        if (error_message != nullptr) {
+            *error_message = "cannot create verbatim BeiDou NAV subset";
+        }
+        return false;
+    }
+
+    bool header = true;
+    bool keep_record = false;
+    bool saw_header_end = false;
+    int ephemeris_records = 0;
+    std::set<std::string> satellites;
+    std::string line;
+    while (std::getline(input, line)) {
+        if (header) {
+            output << line << '\n';
+            if (line.find("END OF HEADER") != std::string::npos) {
+                header = false;
+                saw_header_end = true;
+            }
+            continue;
+        }
+        if (line.rfind("> ", 0) == 0) {
+            keep_record = line.rfind("> EPH C", 0) == 0;
+            if (keep_record) {
+                ++ephemeris_records;
+                if (line.size() >= 9U) {
+                    satellites.insert(line.substr(6, 3));
+                }
+            }
+        }
+        if (keep_record) {
+            output << line << '\n';
+        }
+    }
+    output.close();
+    if (!saw_header_end || ephemeris_records < 4 || satellites.size() < 4U || !output) {
+        if (error_message != nullptr) {
+            *error_message = "verbatim BeiDou NAV subset does not contain enough authentic ephemerides";
+        }
+        return false;
+    }
+    return true;
 }
 
 std::vector<std::string> parse_csv_line(const std::string& line) {
@@ -314,10 +383,9 @@ bool parse_solution_stats(const std::filesystem::path& path, SolutionStats* stat
             }
         }
         if (row[static_cast<std::size_t>(velocity_valid)] == "1") {
-            const double velocity_error =
-                std::sqrt(std::pow(std::stod(row[static_cast<std::size_t>(vx)]), 2.0) +
-                          std::pow(std::stod(row[static_cast<std::size_t>(vy)]), 2.0) +
-                          std::pow(std::stod(row[static_cast<std::size_t>(vz)]), 2.0));
+            const double velocity_error = std::sqrt(std::pow(std::stod(row[static_cast<std::size_t>(vx)]), 2.0) +
+                                                    std::pow(std::stod(row[static_cast<std::size_t>(vy)]), 2.0) +
+                                                    std::pow(std::stod(row[static_cast<std::size_t>(vz)]), 2.0));
             ++result.valid_velocity_epochs;
             if (velocity_error >= result.max_velocity_error_mps) {
                 result.max_velocity_error_mps = velocity_error;
@@ -340,7 +408,11 @@ bool run_simulator_in_directory(const std::filesystem::path& directory, const gn
         }
         return false;
     }
-    const std::string input_path = brd4_nav_path();
+    const std::filesystem::path filtered_nav_path = directory / kFilteredNavName;
+    if (!materialize_verbatim_beidou_nav(filtered_nav_path, error_message)) {
+        return false;
+    }
+    const std::string input_path = filtered_nav_path.string();
     const std::string output_path = (directory / "simulated.log").string();
     const gnss_sim::SimulatorRunOptions options{input_path.c_str(), output_path.c_str(), brd4_start_time()};
     return gnss_sim::run_simulator(config, options, summary, error_message);
@@ -351,7 +423,7 @@ void cleanup(const std::filesystem::path& path) {
     std::filesystem::remove_all(path, error);
 }
 
-TEST(UrbanE2EValidation, AuthenticBrd4UrbanRunIsDeterministicTraceableAndRtklibConsumable) {
+TEST(UrbanE2EValidation, AuthenticBrd4BeidouUrbanRunIsDeterministicTraceableAndRtklibConsumable) {
     const std::filesystem::path first_directory = "gnss_sim_urban_e2e_a";
     const std::filesystem::path second_directory = "gnss_sim_urban_e2e_b";
     const gnss_sim::SimConfig config = urban_config();
@@ -361,6 +433,7 @@ TEST(UrbanE2EValidation, AuthenticBrd4UrbanRunIsDeterministicTraceableAndRtklibC
     ASSERT_TRUE(run_simulator_in_directory(first_directory, config, &first_summary, &error_message)) << error_message;
     ASSERT_TRUE(run_simulator_in_directory(second_directory, config, &second_summary, &error_message)) << error_message;
 
+    EXPECT_EQ(read_file(first_directory / kFilteredNavName), read_file(second_directory / kFilteredNavName));
     for (const char* file_name : {"simulated.log", "scenario.json", "observation_truth.csv", "solution_truth.csv",
                                   "urban_signal_truth.csv", "urban_path_truth.csv", "run_manifest.json"}) {
         EXPECT_EQ(read_file(first_directory / file_name), read_file(second_directory / file_name)) << file_name;
@@ -372,9 +445,10 @@ TEST(UrbanE2EValidation, AuthenticBrd4UrbanRunIsDeterministicTraceableAndRtklibC
     SolutionStats solution{};
     ASSERT_TRUE(parse_solution_stats(first_directory / "solution_truth.csv", &solution));
 
+    const std::string filtered_nav_path = (first_directory / kFilteredNavName).string();
     gnss_sim::RangeaRoundtripSummary original_nav_roundtrip{};
     ASSERT_TRUE(gnss_sim::validate_rangea_roundtrip_file(
-        (first_directory / "simulated.log").string().c_str(), brd4_nav_path().c_str(), kTruthLatitudeDeg,
+        (first_directory / "simulated.log").string().c_str(), filtered_nav_path.c_str(), kTruthLatitudeDeg,
         kTruthLongitudeDeg, kTruthHeightM, config.solution_elevation_mask_deg, false, &original_nav_roundtrip,
         &error_message))
         << error_message;
@@ -386,9 +460,12 @@ TEST(UrbanE2EValidation, AuthenticBrd4UrbanRunIsDeterministicTraceableAndRtklibC
 
     const auto max_position_epoch = urban.epoch_states.find(solution.max_position_epoch);
     ASSERT_NE(max_position_epoch, urban.epoch_states.end());
+    const std::string filtered_nav_hash = fnv1a64_hex(read_file(first_directory / kFilteredNavName));
 
     std::cout << "URBAN_E2E_NAV_SOURCE=BRD400DLR_S_20250030000_01D_MN.rnx\n"
-              << "URBAN_E2E_NAV_FIXTURE_SHA256=" << kFixtureSha256 << '\n'
+              << "URBAN_E2E_NAV_SOURCE_FIXTURE_SHA256=" << kSourceFixtureSha256 << '\n'
+              << "URBAN_E2E_NAV_FILTER=verbatim_all_BeiDou_EPH_records\n"
+              << "URBAN_E2E_NAV_FILTERED_FNV1A64=" << filtered_nav_hash << '\n'
               << "URBAN_E2E_CONFIG=start_gpst_2347_436500,duration_s=" << kPrimaryDurationSeconds
               << ",rate_hz=1,receiver=20_120_100,seed=0x124,noise=off,multipath=on\n"
               << "URBAN_E2E_STATE_COUNTS LOS=" << urban.los << " LOS_MULTIPATH=" << urban.los_multipath
@@ -401,8 +478,7 @@ TEST(UrbanE2EValidation, AuthenticBrd4UrbanRunIsDeterministicTraceableAndRtklibC
               << " cycle_slip=" << urban.cycle_slips << '\n'
               << "URBAN_E2E_INTERNAL_RTKLIB valid_position_epochs=" << solution.valid_position_epochs
               << " max_horizontal_m=" << solution.max_horizontal_error_m
-              << " max_vertical_m=" << solution.max_vertical_error_m
-              << " max_3d_m=" << solution.max_position_3d_error_m
+              << " max_vertical_m=" << solution.max_vertical_error_m << " max_3d_m=" << solution.max_position_3d_error_m
               << " valid_velocity_epochs=" << solution.valid_velocity_epochs
               << " max_velocity_mps=" << solution.max_velocity_error_mps << '\n'
               << "URBAN_E2E_RANGEA_ORIGINAL_NAV valid_position_epochs=" << original_nav_roundtrip.valid_position_epochs
@@ -443,7 +519,7 @@ TEST(UrbanE2EValidation, AuthenticBrd4UrbanRunIsDeterministicTraceableAndRtklibC
     cleanup(second_directory);
 }
 
-TEST(UrbanE2EValidation, AuthenticBrd4ReaExercisesReacquisitionAndLockReset) {
+TEST(UrbanE2EValidation, AuthenticBrd4BeidouReaExercisesReacquisitionAndLockReset) {
     const std::filesystem::path directory = "gnss_sim_urban_e2e_rea";
     gnss_sim::SimConfig config = urban_config();
     config.scenario = gnss_sim::ScenarioType::REA;

--- a/tests/integration/test_urban_e2e_validation.cpp
+++ b/tests/integration/test_urban_e2e_validation.cpp
@@ -1,0 +1,473 @@
+#include "gnss/rtklib_adapter.h"
+#include "gnss_sim/sim_config.h"
+#include "gnss_sim/sim_time.h"
+#include "gnss_sim/simulator.h"
+#include "rangea_roundtrip.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <map>
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr double kPi = 3.141592653589793238462643383279502884;
+constexpr double kTruthLatitudeDeg = 20.0;
+constexpr double kTruthLongitudeDeg = 120.0;
+constexpr double kTruthHeightM = 100.0;
+constexpr std::int64_t kPrimaryDurationSeconds = 180;
+constexpr const char* kFixtureSha256 = "17c6bb00a8a0ef8f732b803925311e7b1ead658ae2e11f62635371eb915e9781";
+
+std::string brd4_nav_path() {
+    return std::string(GNSS_SIM_TEST_DATA_DIR) + "/brd400dlr_rinex4_acceptance_nav.rnx";
+}
+
+gnss_sim::SimTime brd4_start_time() {
+    gnss_sim::SimTime time{};
+    EXPECT_TRUE(gnss_sim::sim_time_from_week_sow(2347, 436500.0, &time));
+    return time;
+}
+
+gnss_sim::SimConfig urban_config() {
+    gnss_sim::SimConfig config = gnss_sim::default_sim_config();
+    config.scenario = gnss_sim::ScenarioType::KS;
+    config.duration_ns = kPrimaryDurationSeconds * gnss_sim::NANOSECONDS_PER_SECOND;
+    config.sampling_rate_hz = 1;
+    config.elevation_mask_deg = 0.0;
+    config.solution_elevation_mask_deg = 5.0;
+    config.output_eph = true;
+    config.output_ion = true;
+    config.measurement_noise_enabled = false;
+    config.multipath_enabled = true;
+    config.atmosphere_mode = gnss_sim::AtmosphereMode::NONE;
+    config.receiver = {kTruthLatitudeDeg, kTruthLongitudeDeg, kTruthHeightM};
+    config.seed = 0x124U;
+    return config;
+}
+
+std::string read_file(const std::filesystem::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    return std::string((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
+}
+
+std::vector<std::string> parse_csv_line(const std::string& line) {
+    std::vector<std::string> fields;
+    std::string field;
+    bool quoted = false;
+    for (std::size_t index = 0; index < line.size(); ++index) {
+        const char character = line[index];
+        if (quoted) {
+            if (character == '"' && index + 1U < line.size() && line[index + 1U] == '"') {
+                field.push_back('"');
+                ++index;
+            } else if (character == '"') {
+                quoted = false;
+            } else {
+                field.push_back(character);
+            }
+        } else if (character == '"') {
+            quoted = true;
+        } else if (character == ',') {
+            fields.push_back(field);
+            field.clear();
+        } else {
+            field.push_back(character);
+        }
+    }
+    fields.push_back(field);
+    return fields;
+}
+
+std::vector<std::vector<std::string>> read_csv(const std::filesystem::path& path) {
+    std::vector<std::vector<std::string>> rows;
+    std::ifstream input(path, std::ios::binary);
+    std::string line;
+    while (std::getline(input, line)) {
+        if (!line.empty() && line.back() == '\r') {
+            line.pop_back();
+        }
+        rows.push_back(parse_csv_line(line));
+    }
+    return rows;
+}
+
+int column_index(const std::vector<std::string>& header, const char* name) {
+    for (std::size_t index = 0; index < header.size(); ++index) {
+        if (header[index] == name) {
+            return static_cast<int>(index);
+        }
+    }
+    return -1;
+}
+
+std::string epoch_key(const std::string& week, const std::string& tow_ns) {
+    return week + ":" + tow_ns;
+}
+
+struct EpochStateCounts {
+    std::uint64_t los = 0;
+    std::uint64_t los_multipath = 0;
+    std::uint64_t nlos_tracked = 0;
+    std::uint64_t blocked = 0;
+};
+
+struct UrbanStats {
+    std::uint64_t los = 0;
+    std::uint64_t los_multipath = 0;
+    std::uint64_t nlos_tracked = 0;
+    std::uint64_t blocked = 0;
+    std::uint64_t blocked_propagation_evaluated = 0;
+    std::uint64_t blocked_without_observation = 0;
+    std::uint64_t los_multipath_roof_edge = 0;
+    std::uint64_t nlos_tracked_indirect = 0;
+    std::uint64_t direct_los_with_reflection = 0;
+    std::uint64_t reacquisition_events = 0;
+    std::uint64_t cycle_slips = 0;
+    std::uint64_t reflection_paths = 0;
+    std::uint64_t direct_roof_paths = 0;
+    std::uint64_t propagation_evaluated_rows = 0;
+    std::set<std::string> signal_names;
+    std::map<std::string, EpochStateCounts> epoch_states;
+};
+
+bool parse_urban_stats(const std::filesystem::path& signal_path, const std::filesystem::path& path_path,
+                       UrbanStats* stats) {
+    if (stats == nullptr) {
+        return false;
+    }
+    const std::vector<std::vector<std::string>> rows = read_csv(signal_path);
+    if (rows.size() <= 1U) {
+        return false;
+    }
+    const std::vector<std::string>& header = rows.front();
+    const int week = column_index(header, "gps_week");
+    const int tow = column_index(header, "tow_ns");
+    const int signal_name = column_index(header, "signal_name");
+    const int propagation = column_index(header, "propagation_evaluated");
+    const int direct_los = column_index(header, "direct_los");
+    const int diffraction = column_index(header, "diffraction_status");
+    const int reflection_count = column_index(header, "reflection_count");
+    const int state = column_index(header, "urban_state");
+    const int reacquisition = column_index(header, "reacquisition_event");
+    const int cycle_slip = column_index(header, "cycle_slip_event");
+    const int emitted = column_index(header, "receiver_observation_emitted");
+    if (week < 0 || tow < 0 || signal_name < 0 || propagation < 0 || direct_los < 0 || diffraction < 0 ||
+        reflection_count < 0 || state < 0 || reacquisition < 0 || cycle_slip < 0 || emitted < 0) {
+        return false;
+    }
+
+    UrbanStats result{};
+    for (std::size_t row_index = 1; row_index < rows.size(); ++row_index) {
+        const std::vector<std::string>& row = rows[row_index];
+        if (row.size() != header.size()) {
+            return false;
+        }
+        result.signal_names.insert(row[static_cast<std::size_t>(signal_name)]);
+        const bool evaluated = row[static_cast<std::size_t>(propagation)] == "1";
+        const bool has_direct = row[static_cast<std::size_t>(direct_los)] == "1";
+        const int reflections = std::stoi(row[static_cast<std::size_t>(reflection_count)]);
+        const std::string& current_state = row[static_cast<std::size_t>(state)];
+        EpochStateCounts& epoch =
+            result.epoch_states[epoch_key(row[static_cast<std::size_t>(week)], row[static_cast<std::size_t>(tow)])];
+        if (evaluated) {
+            ++result.propagation_evaluated_rows;
+        }
+        if (current_state == "LOS") {
+            ++result.los;
+            ++epoch.los;
+        } else if (current_state == "LOS_MULTIPATH") {
+            ++result.los_multipath;
+            ++epoch.los_multipath;
+            if (evaluated && has_direct && row[static_cast<std::size_t>(diffraction)] == "VALID") {
+                ++result.los_multipath_roof_edge;
+            }
+        } else if (current_state == "NLOS_TRACKED") {
+            ++result.nlos_tracked;
+            ++epoch.nlos_tracked;
+            if (evaluated && !has_direct) {
+                ++result.nlos_tracked_indirect;
+            }
+        } else if (current_state == "BLOCKED") {
+            ++result.blocked;
+            ++epoch.blocked;
+            if (evaluated) {
+                ++result.blocked_propagation_evaluated;
+            }
+            if (evaluated && row[static_cast<std::size_t>(emitted)] == "0") {
+                ++result.blocked_without_observation;
+            }
+        }
+        if (evaluated && has_direct && reflections > 0) {
+            ++result.direct_los_with_reflection;
+        }
+        if (row[static_cast<std::size_t>(reacquisition)] == "1") {
+            ++result.reacquisition_events;
+        }
+        if (row[static_cast<std::size_t>(cycle_slip)] == "1") {
+            ++result.cycle_slips;
+        }
+    }
+
+    const std::vector<std::vector<std::string>> path_rows = read_csv(path_path);
+    if (path_rows.empty()) {
+        return false;
+    }
+    const int path_kind = column_index(path_rows.front(), "path_kind");
+    if (path_kind < 0) {
+        return false;
+    }
+    for (std::size_t row_index = 1; row_index < path_rows.size(); ++row_index) {
+        if (path_rows[row_index].size() != path_rows.front().size()) {
+            return false;
+        }
+        const std::string& kind = path_rows[row_index][static_cast<std::size_t>(path_kind)];
+        if (kind == "DIRECT_ROOF") {
+            ++result.direct_roof_paths;
+        } else if (kind == "REFLECTION") {
+            ++result.reflection_paths;
+        }
+    }
+    *stats = result;
+    return true;
+}
+
+struct SolutionStats {
+    std::uint64_t valid_position_epochs = 0;
+    std::uint64_t valid_velocity_epochs = 0;
+    double max_horizontal_error_m = 0.0;
+    double max_vertical_error_m = 0.0;
+    double max_position_3d_error_m = 0.0;
+    double max_velocity_error_mps = 0.0;
+    std::string max_position_epoch;
+    std::string max_velocity_epoch;
+};
+
+bool parse_solution_stats(const std::filesystem::path& path, SolutionStats* stats) {
+    if (stats == nullptr) {
+        return false;
+    }
+    const std::vector<std::vector<std::string>> rows = read_csv(path);
+    if (rows.size() <= 1U) {
+        return false;
+    }
+    const std::vector<std::string>& header = rows.front();
+    const int week = column_index(header, "gps_week");
+    const int tow = column_index(header, "tow_ns");
+    const int position_valid = column_index(header, "position_valid");
+    const int x = column_index(header, "position_x_m");
+    const int y = column_index(header, "position_y_m");
+    const int z = column_index(header, "position_z_m");
+    const int velocity_valid = column_index(header, "velocity_valid");
+    const int vx = column_index(header, "velocity_x_mps");
+    const int vy = column_index(header, "velocity_y_mps");
+    const int vz = column_index(header, "velocity_z_mps");
+    if (week < 0 || tow < 0 || position_valid < 0 || x < 0 || y < 0 || z < 0 || velocity_valid < 0 || vx < 0 ||
+        vy < 0 || vz < 0) {
+        return false;
+    }
+
+    double truth_ecef[3]{};
+    if (!gnss_sim::rtklib_llh_to_ecef(kTruthLatitudeDeg, kTruthLongitudeDeg, kTruthHeightM, truth_ecef)) {
+        return false;
+    }
+    const double latitude = kTruthLatitudeDeg * kPi / 180.0;
+    const double longitude = kTruthLongitudeDeg * kPi / 180.0;
+    const double sin_latitude = std::sin(latitude);
+    const double cos_latitude = std::cos(latitude);
+    const double sin_longitude = std::sin(longitude);
+    const double cos_longitude = std::cos(longitude);
+    const double east[3] = {-sin_longitude, cos_longitude, 0.0};
+    const double north[3] = {-sin_latitude * cos_longitude, -sin_latitude * sin_longitude, cos_latitude};
+    const double up[3] = {cos_latitude * cos_longitude, cos_latitude * sin_longitude, sin_latitude};
+
+    SolutionStats result{};
+    for (std::size_t row_index = 1; row_index < rows.size(); ++row_index) {
+        const std::vector<std::string>& row = rows[row_index];
+        if (row.size() != header.size()) {
+            return false;
+        }
+        const std::string key = epoch_key(row[static_cast<std::size_t>(week)], row[static_cast<std::size_t>(tow)]);
+        if (row[static_cast<std::size_t>(position_valid)] == "1") {
+            const double delta[3] = {std::stod(row[static_cast<std::size_t>(x)]) - truth_ecef[0],
+                                     std::stod(row[static_cast<std::size_t>(y)]) - truth_ecef[1],
+                                     std::stod(row[static_cast<std::size_t>(z)]) - truth_ecef[2]};
+            const double east_error = delta[0] * east[0] + delta[1] * east[1] + delta[2] * east[2];
+            const double north_error = delta[0] * north[0] + delta[1] * north[1] + delta[2] * north[2];
+            const double up_error = delta[0] * up[0] + delta[1] * up[1] + delta[2] * up[2];
+            const double horizontal_error = std::hypot(east_error, north_error);
+            const double position_error = std::sqrt(delta[0] * delta[0] + delta[1] * delta[1] + delta[2] * delta[2]);
+            ++result.valid_position_epochs;
+            result.max_horizontal_error_m = std::max(result.max_horizontal_error_m, horizontal_error);
+            result.max_vertical_error_m = std::max(result.max_vertical_error_m, std::abs(up_error));
+            if (position_error >= result.max_position_3d_error_m) {
+                result.max_position_3d_error_m = position_error;
+                result.max_position_epoch = key;
+            }
+        }
+        if (row[static_cast<std::size_t>(velocity_valid)] == "1") {
+            const double velocity_error =
+                std::sqrt(std::pow(std::stod(row[static_cast<std::size_t>(vx)]), 2.0) +
+                          std::pow(std::stod(row[static_cast<std::size_t>(vy)]), 2.0) +
+                          std::pow(std::stod(row[static_cast<std::size_t>(vz)]), 2.0));
+            ++result.valid_velocity_epochs;
+            if (velocity_error >= result.max_velocity_error_mps) {
+                result.max_velocity_error_mps = velocity_error;
+                result.max_velocity_epoch = key;
+            }
+        }
+    }
+    *stats = result;
+    return true;
+}
+
+bool run_simulator_in_directory(const std::filesystem::path& directory, const gnss_sim::SimConfig& config,
+                                gnss_sim::SimulatorRunSummary* summary, std::string* error_message) {
+    std::error_code filesystem_error;
+    std::filesystem::remove_all(directory, filesystem_error);
+    filesystem_error.clear();
+    if (!std::filesystem::create_directories(directory, filesystem_error) || filesystem_error) {
+        if (error_message != nullptr) {
+            *error_message = "cannot create urban E2E validation directory";
+        }
+        return false;
+    }
+    const std::string input_path = brd4_nav_path();
+    const std::string output_path = (directory / "simulated.log").string();
+    const gnss_sim::SimulatorRunOptions options{input_path.c_str(), output_path.c_str(), brd4_start_time()};
+    return gnss_sim::run_simulator(config, options, summary, error_message);
+}
+
+void cleanup(const std::filesystem::path& path) {
+    std::error_code error;
+    std::filesystem::remove_all(path, error);
+}
+
+TEST(UrbanE2EValidation, AuthenticBrd4UrbanRunIsDeterministicTraceableAndRtklibConsumable) {
+    const std::filesystem::path first_directory = "gnss_sim_urban_e2e_a";
+    const std::filesystem::path second_directory = "gnss_sim_urban_e2e_b";
+    const gnss_sim::SimConfig config = urban_config();
+    gnss_sim::SimulatorRunSummary first_summary{};
+    gnss_sim::SimulatorRunSummary second_summary{};
+    std::string error_message;
+    ASSERT_TRUE(run_simulator_in_directory(first_directory, config, &first_summary, &error_message)) << error_message;
+    ASSERT_TRUE(run_simulator_in_directory(second_directory, config, &second_summary, &error_message)) << error_message;
+
+    for (const char* file_name : {"simulated.log", "scenario.json", "observation_truth.csv", "solution_truth.csv",
+                                  "urban_signal_truth.csv", "urban_path_truth.csv", "run_manifest.json"}) {
+        EXPECT_EQ(read_file(first_directory / file_name), read_file(second_directory / file_name)) << file_name;
+    }
+
+    UrbanStats urban{};
+    ASSERT_TRUE(parse_urban_stats(first_directory / "urban_signal_truth.csv", first_directory / "urban_path_truth.csv",
+                                  &urban));
+    SolutionStats solution{};
+    ASSERT_TRUE(parse_solution_stats(first_directory / "solution_truth.csv", &solution));
+
+    gnss_sim::RangeaRoundtripSummary original_nav_roundtrip{};
+    ASSERT_TRUE(gnss_sim::validate_rangea_roundtrip_file(
+        (first_directory / "simulated.log").string().c_str(), brd4_nav_path().c_str(), kTruthLatitudeDeg,
+        kTruthLongitudeDeg, kTruthHeightM, config.solution_elevation_mask_deg, false, &original_nav_roundtrip,
+        &error_message))
+        << error_message;
+    gnss_sim::SerializedNavRoundtripSummary serialized_nav_roundtrip{};
+    ASSERT_TRUE(gnss_sim::validate_serialized_navigation_roundtrip_file(
+        (first_directory / "simulated.log").string().c_str(), kTruthLatitudeDeg, kTruthLongitudeDeg, kTruthHeightM,
+        config.solution_elevation_mask_deg, false, &serialized_nav_roundtrip, &error_message))
+        << error_message;
+
+    const auto max_position_epoch = urban.epoch_states.find(solution.max_position_epoch);
+    ASSERT_NE(max_position_epoch, urban.epoch_states.end());
+
+    std::cout << "URBAN_E2E_NAV_SOURCE=BRD400DLR_S_20250030000_01D_MN.rnx\n"
+              << "URBAN_E2E_NAV_FIXTURE_SHA256=" << kFixtureSha256 << '\n'
+              << "URBAN_E2E_CONFIG=start_gpst_2347_436500,duration_s=" << kPrimaryDurationSeconds
+              << ",rate_hz=1,receiver=20_120_100,seed=0x124,noise=off,multipath=on\n"
+              << "URBAN_E2E_STATE_COUNTS LOS=" << urban.los << " LOS_MULTIPATH=" << urban.los_multipath
+              << " NLOS_TRACKED=" << urban.nlos_tracked << " BLOCKED=" << urban.blocked
+              << " BLOCKED_EVALUATED=" << urban.blocked_propagation_evaluated << '\n'
+              << "URBAN_E2E_PATH_COUNTS DIRECT_ROOF=" << urban.direct_roof_paths
+              << " REFLECTION=" << urban.reflection_paths
+              << " DIRECT_LOS_WITH_REFLECTION=" << urban.direct_los_with_reflection << '\n'
+              << "URBAN_E2E_TRANSITIONS reacquisition=" << urban.reacquisition_events
+              << " cycle_slip=" << urban.cycle_slips << '\n'
+              << "URBAN_E2E_INTERNAL_RTKLIB valid_position_epochs=" << solution.valid_position_epochs
+              << " max_horizontal_m=" << solution.max_horizontal_error_m
+              << " max_vertical_m=" << solution.max_vertical_error_m
+              << " max_3d_m=" << solution.max_position_3d_error_m
+              << " valid_velocity_epochs=" << solution.valid_velocity_epochs
+              << " max_velocity_mps=" << solution.max_velocity_error_mps << '\n'
+              << "URBAN_E2E_RANGEA_ORIGINAL_NAV valid_position_epochs=" << original_nav_roundtrip.valid_position_epochs
+              << " max_3d_m=" << original_nav_roundtrip.max_position_error_m << '\n'
+              << "URBAN_E2E_RANGEA_SERIALIZED_NAV valid_position_epochs="
+              << serialized_nav_roundtrip.position.valid_position_epochs
+              << " max_3d_m=" << serialized_nav_roundtrip.position.max_position_error_m << '\n'
+              << "URBAN_E2E_MAX_POSITION_EPOCH=" << solution.max_position_epoch
+              << " LOS=" << max_position_epoch->second.los
+              << " LOS_MULTIPATH=" << max_position_epoch->second.los_multipath
+              << " NLOS_TRACKED=" << max_position_epoch->second.nlos_tracked
+              << " BLOCKED=" << max_position_epoch->second.blocked << '\n';
+
+    EXPECT_EQ(first_summary.scheduled_epochs, static_cast<std::uint64_t>(kPrimaryDurationSeconds));
+    EXPECT_GT(first_summary.valid_position_epochs, 0U);
+    EXPECT_GT(first_summary.valid_velocity_epochs, 0U);
+    EXPECT_EQ(solution.valid_position_epochs, first_summary.valid_position_epochs);
+    EXPECT_EQ(solution.valid_velocity_epochs, first_summary.valid_velocity_epochs);
+    EXPECT_GT(urban.signal_names.size(), 1U);
+    EXPECT_GT(urban.los, 0U);
+    EXPECT_GT(urban.los_multipath, 0U);
+    EXPECT_GT(urban.nlos_tracked, 0U);
+    EXPECT_GT(urban.blocked_propagation_evaluated, 0U);
+    EXPECT_GT(urban.blocked_without_observation, 0U);
+    EXPECT_GT(urban.los_multipath_roof_edge, 0U);
+    EXPECT_GT(urban.nlos_tracked_indirect, 0U);
+    EXPECT_GT(urban.reflection_paths, 0U);
+    EXPECT_EQ(urban.direct_los_with_reflection, 0U);
+    EXPECT_EQ(urban.direct_roof_paths, urban.propagation_evaluated_rows);
+    EXPECT_GT(original_nav_roundtrip.valid_position_epochs, 0U);
+    EXPECT_GT(serialized_nav_roundtrip.position.valid_position_epochs, 0U);
+    EXPECT_TRUE(std::isfinite(solution.max_horizontal_error_m));
+    EXPECT_TRUE(std::isfinite(solution.max_vertical_error_m));
+    EXPECT_TRUE(std::isfinite(solution.max_position_3d_error_m));
+    EXPECT_TRUE(std::isfinite(solution.max_velocity_error_mps));
+
+    cleanup(first_directory);
+    cleanup(second_directory);
+}
+
+TEST(UrbanE2EValidation, AuthenticBrd4ReaExercisesReacquisitionAndLockReset) {
+    const std::filesystem::path directory = "gnss_sim_urban_e2e_rea";
+    gnss_sim::SimConfig config = urban_config();
+    config.scenario = gnss_sim::ScenarioType::REA;
+    config.duration_ns = 50LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    config.rea.signal_on_ns = 20LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    config.rea.signal_off_ns = 5LL * gnss_sim::NANOSECONDS_PER_SECOND;
+
+    gnss_sim::SimulatorRunSummary summary{};
+    std::string error_message;
+    ASSERT_TRUE(run_simulator_in_directory(directory, config, &summary, &error_message)) << error_message;
+    UrbanStats urban{};
+    ASSERT_TRUE(parse_urban_stats(directory / "urban_signal_truth.csv", directory / "urban_path_truth.csv", &urban));
+
+    const std::string events = read_file(directory / "event_truth.csv");
+    EXPECT_NE(events.find("SIGNAL_OFF"), std::string::npos);
+    EXPECT_NE(events.find("SIGNAL_ON"), std::string::npos);
+    EXPECT_GT(urban.reacquisition_events, 0U);
+    EXPECT_GT(summary.signal_off_epochs, 0U);
+    EXPECT_GT(summary.signal_on_epochs, 0U);
+
+    std::cout << "URBAN_E2E_REA reacquisition_events=" << urban.reacquisition_events
+              << " cycle_slips=" << urban.cycle_slips << " signal_off_epochs=" << summary.signal_off_epochs
+              << " signal_on_epochs=" << summary.signal_on_epochs << '\n';
+    cleanup(directory);
+}
+
+} // namespace


### PR DESCRIPTION
Closes #124

## Scope
Validation/tooling/report only. No production physics model, NAV/EPH/ION values, tracking thresholds, material parameters, or target-PVT tuning changes.

## Authentic NAV
- provenance-fixed fixture: `tests/data/minimal/brd400dlr_rinex4_acceptance_nav.rnx`
- source: `BRD400DLR_S_20250030000_01D_MN.rnx` from Wuhan University IGS Data Center
- fixture SHA256: `17c6bb00a8a0ef8f732b803925311e7b1ead658ae2e11f62635371eb915e9781`
- the harness mechanically copies all BeiDou EPH records field-for-field; it does not select satellites by desired geometry/PVT and never modifies, interpolates, retargets, or synthesizes ephemerides
- `.gitattributes` freezes this provenance fixture to LF on every platform

## Why the E2E acceptance uses BeiDou
The initial full mixed BRD400DLR urban run correctly failed fast because some frozen GPS/QZSS signal definitions still have deliberately unsupported code-correlation profiles. This PR does not weaken #119 by substituting guessed BPSK correlations. BeiDou is used because its five frozen V1 correlation profiles required by the urban path are explicitly modeled.

## E2E coverage
The production simulator is run twice with fixed NAV/config/seed and receiver/truth artifacts are byte-compared. The harness verifies all physically reachable frozen-scene states and paths, parses production solution truth, and independently sends serialized RANGEA through pinned RTKLIB with both the authentic filtered RINEX NAV and reconstructed serialized receiver NAV. A separate authentic-NAV REA run exercises loss/reacquisition/lock reset.

Authoritative CI #729 metrics:
- states: LOS 3762, LOS_MULTIPATH 2538, NLOS_TRACKED 3559, BLOCKED 11741
- paths: DIRECT_ROOF 11700, first-order REFLECTION 3600, direct LOS + retained reflection 0
- production solution: 177 valid position epochs, max horizontal 2.29263 m, max vertical 39.592 m, max 3D 39.6384 m
- velocity: 177 valid epochs, max error 0.00535238 m/s
- serialized RANGEA + authentic filtered NAV: 177 valid epochs, max 3D 39.6387 m
- serialized RANGEA + serialized/reconstructed NAV: 177 valid epochs, max 3D 39.6387 m
- max-error epoch `2347:436679000000000`: LOS 21 / LOS_MULTIPATH 14 / NLOS_TRACKED 20 / BLOCKED 65
- REA: 55 reacquisition events, 55 cycle-slip/reset events, 10 signal-off epochs, 40 signal-on epochs

The approximately 39.6 m worst 3D error is an observed physically emergent result, **not** a target, threshold, injected offset, or tuning objective.

## #130 semantics preserved
`direct LOS + retained first-order reflection = 0` remains true in the frozen closed four-wall scene. `LOS_MULTIPATH` is reached through the clear-side roof-edge-affected direct field. Diffraction is not double-counted as a second full direct component.

## Permanent evidence
`docs/URBAN_E2E_VALIDATION.md` records exact provenance, config/seed, commands, state/path coverage, PVT/velocity results, RTKLIB round-trip evidence, determinism, interpretation, and limitations, including the absence of a frozen representative measured-urban data set.

## Final validation
- implementation/test/report head `f87e8e18769d720208f3f2fd2d5e7728ccb0f51a`: CI #729 (`33832212284`) fully green; Linux and Windows each passed 337/337 tests and the Linux focused E2E step reproduced the metrics above.
- final documentation-only head `7047ebbfd5750ac404da7fdf0ad7e42b8631591d`: CI #730 (`33832508524`) fully green on format, tooling, Ubuntu and Windows.
- final diff contains only `.gitattributes`, CI/CMake registration, the E2E integration test, and the permanent validation report; no production physics/simulator source file is changed.