### PR TITLE
Validate synchronized multi-seed batches end to end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,12 @@ jobs:
         run: cmake --build build --config Release --parallel
       - name: Test
         run: ctest --test-dir build -C Release --output-on-failure
+      - name: Validate synchronized multi-seed batch generation (Linux)
+        if: runner.os == 'Linux'
+        run: python3 tests/integration/test_synchronized_batch.py --source-dir . --build-dir build --work-dir build/synchronized_batch_ci
+      - name: Validate synchronized multi-seed batch generation (Windows)
+        if: runner.os == 'Windows'
+        run: python tests/integration/test_synchronized_batch.py --source-dir . --build-dir build --work-dir build/synchronized_batch_ci
       - name: Report RANGEA round-trip positioning error
         if: runner.os == 'Linux'
         shell: bash

--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ ctest --test-dir build -C Release --output-on-failure
 
 The simulator writes the receiver log plus versioned truth/manifest files beside it. Normal pull-request CI runs deterministic short acceptance tests; long 8-hour / 50 Hz resource validation is defined separately in `.github/workflows/extended.yml` and documented in `docs/EXTENDED_VALIDATION.md`.
 
+## Synchronized multi-seed batches
+
+For simultaneous cross-board KS/REA/TTFF comparison, use the batch wrapper so every realization shares one physical GPST window and one common base configuration while receiving a distinct deterministic seed:
+
+```bash
+python3 tools/batch_generation/generate_batch.py \
+  --simulator build/gnss-data-simulator \
+  --config config/default_v1.json \
+  --nav /path/to/real_broadcast_nav.rnx \
+  --output-dir output/batch_001 \
+  --week 2347 \
+  --sow 436500
+```
+
+The default batch is KS x8 + REA x8 + TTFF x8 with seed ranges `1001..1008`, `2001..2008`, and `3001..3008`. See [`docs/SYNCHRONIZED_BATCH_GENERATION.md`](docs/SYNCHRONIZED_BATCH_GENERATION.md) for the invariant-time contract, manifest layout, reproducibility rules, and CI validation.
+
 ## Design and V1 behavior
 
 - [`docs/DESIGN_SPEC.md`](docs/DESIGN_SPEC.md) — architecture and V1 scope.
@@ -32,6 +48,7 @@ The simulator writes the receiver log plus versioned truth/manifest files beside
 - [`docs/STARTUP_RECOVERY_MODEL.md`](docs/STARTUP_RECOVERY_MODEL.md) — HOT/WARM/COLD TTFF and REA recovery model.
 - [`docs/V1_ACCEPTANCE_MATRIX.md`](docs/V1_ACCEPTANCE_MATRIX.md) — short deterministic V1 acceptance coverage.
 - [`docs/EXTENDED_VALIDATION.md`](docs/EXTENDED_VALIDATION.md) — 8-hour / 50 Hz streaming, determinism, and memory validation.
+- [`docs/SYNCHRONIZED_BATCH_GENERATION.md`](docs/SYNCHRONIZED_BATCH_GENERATION.md) — synchronized x8 multi-seed batch generation and reproducibility contract.
 
 ## Validation data
 

--- a/docs/SYNCHRONIZED_BATCH_GENERATION.md
+++ b/docs/SYNCHRONIZED_BATCH_GENERATION.md
@@ -1,0 +1,142 @@
+# Synchronized KS / REA / TTFF batch generation
+
+## Purpose
+
+A synchronized batch represents one common physical GNSS interval observed by multiple receiver boards or repeated receiver realizations. The batch generator therefore keeps the external environment fixed and varies only the deterministic random seed assigned to each realization.
+
+The default batch contains:
+
+- 8 KS realizations;
+- 8 REA realizations;
+- 8 TTFF realizations;
+- 24 receiver logs in total.
+
+All 24 runs receive the same GPS week/SOW start time and the same duration. The RINEX NAV input, receiver truth, sampling rate, elevation masks, atmosphere settings, REA cycle parameters, TTFF cycle parameters, and other common model settings come from one base simulator configuration.
+
+A different realization index must **not** be implemented by shifting GPST, changing satellite geometry, modifying ephemeris, moving the receiver, or moving REA/TTFF event boundaries.
+
+## Deterministic seed mapping
+
+The batch tool uses the following mapping by default:
+
+```text
+KS_01   1001
+...
+KS_08   1008
+REA_01  2001
+...
+REA_08  2008
+TTFF_01 3001
+...
+TTFF_08 3008
+```
+
+The general rule is:
+
+```text
+seed = seed_base + scenario_index * seed_stride + (realization_index - 1)
+```
+
+where the scenario order is `KS`, `REA`, `TTFF`. The defaults are `seed_base=1001`, `seed_stride=1000`, and `count=8`.
+
+The tool rejects overlapping scenario seed blocks and uint64 overflow. Seeds are fixed inputs: wall-clock time, process ID, thread scheduling, and launch order are not used to derive them.
+
+A seed may influence only model behavior that is already explicitly seed-dependent, such as deterministic CN0 phase variation or stochastic receiver acquisition/reacquisition behavior. It does not authorize changes to real NAV/EPH/ION data or deterministic external truth.
+
+## Command line
+
+Linux example:
+
+```bash
+python3 tools/batch_generation/generate_batch.py \
+  --simulator build/gnss-data-simulator \
+  --config config/default_v1.json \
+  --nav /path/to/real_broadcast_nav.rnx \
+  --output-dir output/batch_001 \
+  --week 2347 \
+  --sow 436500
+```
+
+Windows example after a Release build:
+
+```powershell
+python tools\batch_generation\generate_batch.py `
+  --simulator build\Release\gnss-data-simulator.exe `
+  --config config\default_v1.json `
+  --nav C:\data\real_broadcast_nav.rnx `
+  --output-dir output\batch_001 `
+  --week 2347 `
+  --sow 436500
+```
+
+Useful options:
+
+- `--count N`: realizations per scenario; default `8`.
+- `--seed-base N`: seed for `KS_01`; default `1001`.
+- `--seed-stride N`: offset between KS/REA/TTFF seed blocks; default `1000`.
+- `--cn0-model FILE`: pass one calibrated CN0 model unchanged to every run.
+- `--plan-only`: write the manifest and per-run effective configs without invoking the simulator.
+- `--overwrite`: replace the planned per-realization directories and manifest.
+
+## Output layout
+
+Each realization has its own directory:
+
+```text
+batch_001/
+  batch_manifest.json
+  runs/
+    KS_01/
+      KS_01.log
+      config.json
+      scenario.json
+      event_truth.csv
+      observation_truth.csv
+      solution_truth.csv
+      run_manifest.json
+    ...
+    REA_01/
+      ...
+    ...
+    TTFF_08/
+      ...
+```
+
+The separate run directories are required because the simulator intentionally writes fixed-name truth/manifest sidecars beside each receiver log. Sharing one directory across 24 simulator invocations would overwrite those sidecars and destroy the evidence needed for synchronized comparison.
+
+`batch_manifest.json` records the common GPST window, input SHA256 identities, deterministic seed schedule, effective-config hashes, receiver-log hashes, and per-run completion status. The simulator's own `run_manifest.json` remains the authoritative per-run record for the resolved configuration, simulator commit, pinned RTKLIB commit, real RINEX NAV identity, start time, and random seed.
+
+## Reproducibility contract
+
+For one supported reproducibility target, regenerating the same batch with the same:
+
+- simulator build;
+- pinned RTKLIB revision;
+- base config bytes;
+- real RINEX NAV bytes;
+- optional CN0 model bytes;
+- common GPST start;
+- duration;
+- seed schedule;
+
+must reproduce the corresponding receiver logs and truth artifacts byte-for-byte.
+
+Parallel or serial execution must not redefine this contract. The current V1 batch tool invokes runs serially, so launch scheduling cannot leak into output identity.
+
+## CI regression
+
+Normal Ubuntu and Windows pull-request CI runs `tests/integration/test_synchronized_batch.py` against the committed reduced real `BRD400DLR` RINEX 4.02 fixture. The test uses a short 1 Hz window rather than 8-hour production data, but it exercises the production batch tool and production simulator executable.
+
+The regression generates two complete 24-run batches and verifies:
+
+1. exactly 8 KS + 8 REA + 8 TTFF outputs;
+2. one common start/end GPST and common physical configuration;
+3. unique deterministic seed ranges;
+4. identical real RINEX NAV identity across all runs;
+5. identical REA signal transition timing across all 8 REA seeds;
+6. identical TTFF power transition timing across all 8 TTFF seeds;
+7. existing seed-dependent CN0 diversity on common KS observations;
+8. unchanged satellite/receiver geometry, clocks, atmosphere, TGD/ISC and code-bias truth for those common observations;
+9. byte-identical full rerun output for every corresponding seed.
+
+The regression never modifies, retargets, interpolates, or fabricates navigation records.

--- a/tests/integration/test_synchronized_batch.py
+++ b/tests/integration/test_synchronized_batch.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+"""End-to-end regression for synchronized KS/REA/TTFF batch generation."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import csv
+import hashlib
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+SCENARIOS = ("KS", "REA", "TTFF")
+START_WEEK = 2347
+START_SOW = 436500.0
+DURATION_SEC = 20.0
+COUNT = 8
+EXPECTED_SEEDS = {
+    "KS": list(range(1001, 1009)),
+    "REA": list(range(2001, 2009)),
+    "TTFF": list(range(3001, 3009)),
+}
+TRUTH_ARTIFACTS = (
+    "scenario.json",
+    "event_truth.csv",
+    "observation_truth.csv",
+    "solution_truth.csv",
+    "run_manifest.json",
+)
+PHYSICAL_OBSERVATION_FIELDS = (
+    "wavelength_m",
+    "receiver_x_m",
+    "receiver_y_m",
+    "receiver_z_m",
+    "receiver_vx_mps",
+    "receiver_vy_mps",
+    "receiver_vz_mps",
+    "transmit_week",
+    "transmit_tow_ns",
+    "transmit_sow_sec",
+    "satellite_x_m",
+    "satellite_y_m",
+    "satellite_z_m",
+    "satellite_vx_mps",
+    "satellite_vy_mps",
+    "satellite_vz_mps",
+    "azimuth_deg",
+    "elevation_deg",
+    "geometric_range_m",
+    "range_rate_mps",
+    "satellite_clock_bias_m",
+    "satellite_clock_drift_mps",
+    "receiver_clock_bias_m",
+    "receiver_clock_drift_mps",
+    "ionosphere_m",
+    "troposphere_m",
+    "broadcast_message_family",
+    "tgd_sec_0",
+    "tgd_sec_1",
+    "tgd_sec_2",
+    "tgd_sec_3",
+    "isc_sec_0",
+    "isc_sec_1",
+    "isc_sec_2",
+    "isc_sec_3",
+    "isc_sec_4",
+    "isc_sec_5",
+    "glonass_dtaun_sec",
+    "code_bias_m",
+    "code_bias_status",
+)
+
+
+class ValidationError(RuntimeError):
+    pass
+
+
+def _check(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValidationError(message)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as stream:
+            data = json.load(stream)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValidationError(f"cannot read JSON {path}: {exc}") from exc
+    _check(isinstance(data, dict), f"JSON root is not an object: {path}")
+    return data
+
+
+def _write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="\n") as stream:
+        json.dump(data, stream, indent=2, ensure_ascii=False)
+        stream.write("\n")
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _find_simulator(build_dir: Path) -> Path:
+    candidates = (
+        build_dir / "gnss-data-simulator",
+        build_dir / "gnss-data-simulator.exe",
+        build_dir / "Release" / "gnss-data-simulator.exe",
+        build_dir / "Release" / "gnss-data-simulator",
+    )
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate.resolve()
+    raise ValidationError(f"cannot find built gnss-data-simulator below {build_dir}")
+
+
+def _make_short_config(source_dir: Path, output_path: Path) -> dict[str, Any]:
+    config = _read_json(source_dir / "config" / "default_v1.json")
+    config["duration_sec"] = DURATION_SEC
+    config["sampling_rate_hz"] = 1
+    config["output_eph"] = False
+    config["output_ion"] = False
+    config["multipath_enabled"] = False
+    config["measurement_noise_enabled"] = False
+    config["ttff"]["startup_mode"] = "HOT"
+    config["ttff"]["power_on_sec"] = 6.0
+    config["ttff"]["power_off_sec"] = 4.0
+    config["rea"]["signal_on_sec"] = 6.0
+    config["rea"]["signal_off_sec"] = 4.0
+    _write_json(output_path, config)
+    return config
+
+
+def _run_batch(source_dir: Path, simulator: Path, config_path: Path, nav_path: Path, output_dir: Path) -> None:
+    batch_tool = source_dir / "tools" / "batch_generation" / "generate_batch.py"
+    command = [
+        sys.executable,
+        str(batch_tool),
+        "--simulator",
+        str(simulator),
+        "--config",
+        str(config_path),
+        "--nav",
+        str(nav_path),
+        "--output-dir",
+        str(output_dir),
+        "--week",
+        str(START_WEEK),
+        "--sow",
+        str(START_SOW),
+        "--count",
+        str(COUNT),
+    ]
+    try:
+        subprocess.run(command, cwd=source_dir, check=True)
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise ValidationError(f"synchronized batch generation failed: {exc}") from exc
+
+
+def _run_map(manifest: dict[str, Any]) -> dict[tuple[str, int], dict[str, Any]]:
+    runs = manifest.get("runs")
+    _check(isinstance(runs, list), "batch manifest runs is not a list")
+    result: dict[tuple[str, int], dict[str, Any]] = {}
+    for item in runs:
+        _check(isinstance(item, dict), "batch manifest run is not an object")
+        scenario = item.get("scenario")
+        index = item.get("realization_index")
+        _check(isinstance(scenario, str) and scenario in SCENARIOS, f"invalid run scenario: {scenario}")
+        _check(isinstance(index, int), f"invalid realization index: {index}")
+        key = (scenario, index)
+        _check(key not in result, f"duplicate run entry: {key}")
+        result[key] = item
+    return result
+
+
+def _normalized_config(config: dict[str, Any]) -> dict[str, Any]:
+    result = copy.deepcopy(config)
+    result["scenario"] = "__COMMON_SCENARIO__"
+    result["seed"] = 0
+    return result
+
+
+def _read_events(path: Path) -> list[tuple[str, ...]]:
+    with path.open("r", encoding="utf-8", newline="") as stream:
+        reader = csv.DictReader(stream)
+        _check(reader.fieldnames is not None, f"event CSV has no header: {path}")
+        rows = []
+        for row in reader:
+            rows.append(
+                (
+                    row["gps_week"],
+                    row["tow_ns"],
+                    row["sow_sec"],
+                    row["event_type"],
+                    row["cycle_index"],
+                    row["receiver_powered"],
+                    row["signal_available"],
+                    row["startup_mode"],
+                )
+            )
+    return rows
+
+
+def _observation_map(path: Path) -> dict[tuple[str, str, str, str], dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as stream:
+        reader = csv.DictReader(stream)
+        _check(reader.fieldnames is not None, f"observation CSV has no header: {path}")
+        rows: dict[tuple[str, str, str, str], dict[str, str]] = {}
+        for row in reader:
+            key = (row["gps_week"], row["tow_ns"], row["satellite_number"], row["signal_id"])
+            _check(key not in rows, f"duplicate observation key in {path}: {key}")
+            rows[key] = row
+    return rows
+
+
+def _validate_batch(
+    batch_dir: Path,
+    base_config: dict[str, Any],
+    nav_path: Path,
+) -> tuple[dict[str, Any], dict[tuple[str, int], dict[str, Any]]]:
+    manifest_path = batch_dir / "batch_manifest.json"
+    manifest = _read_json(manifest_path)
+    _check(manifest.get("schema") == "gnss-synchronized-batch-v1", "unexpected batch manifest schema")
+    _check(manifest.get("status") == "complete", "batch did not finish successfully")
+    _check(manifest.get("completed_runs") == 24, "batch did not complete exactly 24 runs")
+
+    common = manifest.get("common")
+    _check(isinstance(common, dict), "batch common section is missing")
+    _check(common.get("start_gpst") == {"week": START_WEEK, "sow_sec": START_SOW}, "common start GPST changed")
+    _check(common.get("duration_sec") == DURATION_SEC, "common duration changed")
+    _check(
+        common.get("end_gpst") == {"week": START_WEEK, "sow_sec": START_SOW + DURATION_SEC},
+        "common end GPST changed",
+    )
+    _check(common.get("realization_count_per_scenario") == COUNT, "batch realization count changed")
+
+    inputs = manifest.get("inputs")
+    _check(isinstance(inputs, dict) and isinstance(inputs.get("rinex_nav"), dict), "NAV identity missing")
+    _check(inputs["rinex_nav"].get("sha256") == _sha256(nav_path), "batch manifest NAV SHA256 mismatch")
+    _check(inputs["rinex_nav"].get("size_bytes") == nav_path.stat().st_size, "batch manifest NAV size mismatch")
+
+    run_map = _run_map(manifest)
+    _check(len(run_map) == 24, "batch manifest does not contain exactly 24 unique runs")
+    all_seeds = [run["seed"] for run in run_map.values()]
+    _check(len(all_seeds) == len(set(all_seeds)), "batch seeds are not globally unique")
+
+    reference_resolved: dict[str, Any] | None = None
+    reference_nav_identity: dict[str, Any] | None = None
+    reference_simulator_commit: str | None = None
+    reference_rtklib_commit: str | None = None
+
+    for scenario in SCENARIOS:
+        scenario_seeds = [run_map[(scenario, index)]["seed"] for index in range(1, COUNT + 1)]
+        _check(scenario_seeds == EXPECTED_SEEDS[scenario], f"{scenario} seeds changed: {scenario_seeds}")
+        for index in range(1, COUNT + 1):
+            run = run_map[(scenario, index)]
+            expected_stem = f"{scenario}_{index:02d}"
+            expected_dir = f"runs/{expected_stem}"
+            _check(run.get("run_dir") == expected_dir, f"unexpected run directory for {expected_stem}")
+            _check(run.get("output") == f"{expected_dir}/{expected_stem}.log", f"unexpected log path for {expected_stem}")
+            _check(run.get("config") == f"{expected_dir}/config.json", f"unexpected config path for {expected_stem}")
+            _check(run.get("status") == "complete", f"run is not complete: {expected_stem}")
+
+            run_dir = batch_dir / expected_dir
+            output_path = batch_dir / run["output"]
+            config_path = batch_dir / run["config"]
+            _check(output_path.is_file() and output_path.stat().st_size > 0, f"receiver log missing: {output_path}")
+            _check(run.get("output_sha256") == _sha256(output_path), f"receiver log hash mismatch: {expected_stem}")
+            _check(run.get("config_sha256") == _sha256(config_path), f"config hash mismatch: {expected_stem}")
+
+            effective = _read_json(config_path)
+            _check(effective.get("scenario") == scenario, f"config scenario mismatch: {expected_stem}")
+            _check(effective.get("seed") == run["seed"], f"config seed mismatch: {expected_stem}")
+            _check(
+                _normalized_config(effective) == _normalized_config(base_config),
+                f"shared physical config changed for {expected_stem}",
+            )
+
+            for artifact in TRUTH_ARTIFACTS:
+                artifact_path = run_dir / artifact
+                _check(artifact_path.is_file() and artifact_path.stat().st_size > 0, f"truth artifact missing: {artifact_path}")
+
+            run_manifest = _read_json(run_dir / "run_manifest.json")
+            _check(run_manifest.get("random_seed") == run["seed"], f"truth random_seed mismatch: {expected_stem}")
+            _check(
+                run_manifest.get("start_time") == {"gps_week": START_WEEK, "tow_ns": int(START_SOW * 1_000_000_000)},
+                f"truth start GPST mismatch: {expected_stem}",
+            )
+            resolved = run_manifest.get("resolved_config")
+            _check(isinstance(resolved, dict), f"resolved config missing: {expected_stem}")
+            _check(resolved.get("duration_ns") == int(DURATION_SEC * 1_000_000_000), f"duration mismatch: {expected_stem}")
+            _check(resolved.get("scenario") == scenario, f"resolved scenario mismatch: {expected_stem}")
+            _check(resolved.get("seed") == run["seed"], f"resolved seed mismatch: {expected_stem}")
+
+            normalized_resolved = _normalized_config(resolved)
+            if reference_resolved is None:
+                reference_resolved = normalized_resolved
+            else:
+                _check(normalized_resolved == reference_resolved, f"resolved shared config drifted: {expected_stem}")
+
+            nav_identity = run_manifest.get("rinex_nav")
+            _check(isinstance(nav_identity, dict), f"truth NAV identity missing: {expected_stem}")
+            _check(nav_identity.get("name") == nav_path.name, f"truth NAV filename changed: {expected_stem}")
+            if reference_nav_identity is None:
+                reference_nav_identity = nav_identity
+            else:
+                _check(nav_identity == reference_nav_identity, f"truth NAV identity drifted: {expected_stem}")
+
+            simulator_commit = run_manifest.get("simulator_commit_sha")
+            rtklib_commit = run_manifest.get("rtklib_commit_sha")
+            _check(isinstance(simulator_commit, str) and simulator_commit, f"simulator commit missing: {expected_stem}")
+            _check(isinstance(rtklib_commit, str) and rtklib_commit, f"RTKLIB commit missing: {expected_stem}")
+            if reference_simulator_commit is None:
+                reference_simulator_commit = simulator_commit
+                reference_rtklib_commit = rtklib_commit
+            else:
+                _check(simulator_commit == reference_simulator_commit, f"simulator commit drifted: {expected_stem}")
+                _check(rtklib_commit == reference_rtklib_commit, f"RTKLIB commit drifted: {expected_stem}")
+
+    for scenario, required_events in (("REA", {"SIGNAL_ON", "SIGNAL_OFF"}), ("TTFF", {"POWER_ON", "POWER_OFF"})):
+        event_bytes: bytes | None = None
+        first_events: list[tuple[str, ...]] | None = None
+        for index in range(1, COUNT + 1):
+            event_path = batch_dir / run_map[(scenario, index)]["run_dir"] / "event_truth.csv"
+            current_bytes = event_path.read_bytes()
+            if event_bytes is None:
+                event_bytes = current_bytes
+                first_events = _read_events(event_path)
+            else:
+                _check(current_bytes == event_bytes, f"{scenario} event schedule differs across seeds")
+        assert first_events is not None
+        event_types = {row[3] for row in first_events}
+        _check(required_events.issubset(event_types), f"{scenario} short regression did not exercise required transitions")
+
+    ks_observations = [
+        _observation_map(batch_dir / run_map[("KS", index)]["run_dir"] / "observation_truth.csv")
+        for index in range(1, COUNT + 1)
+    ]
+    diversity_found = False
+    for left_index in range(COUNT):
+        for right_index in range(left_index + 1, COUNT):
+            common_keys = sorted(set(ks_observations[left_index]).intersection(ks_observations[right_index]))
+            for key in common_keys:
+                left = ks_observations[left_index][key]
+                right = ks_observations[right_index][key]
+                if left["cn0_dbhz"] == right["cn0_dbhz"]:
+                    continue
+                for field in PHYSICAL_OBSERVATION_FIELDS:
+                    _check(left[field] == right[field], f"seed changed physical truth field {field} at {key}")
+                diversity_found = True
+                break
+            if diversity_found:
+                break
+        if diversity_found:
+            break
+    _check(diversity_found, "different KS seeds produced no CN0 diversity on any common observation")
+
+    return manifest, run_map
+
+
+def _validate_rerun(
+    first_dir: Path,
+    second_dir: Path,
+    first_manifest: dict[str, Any],
+    second_manifest: dict[str, Any],
+    first_runs: dict[tuple[str, int], dict[str, Any]],
+    second_runs: dict[tuple[str, int], dict[str, Any]],
+) -> None:
+    _check(first_manifest == second_manifest, "full batch manifest changed across identical rerun")
+    for key in sorted(first_runs):
+        first = first_runs[key]
+        second = second_runs[key]
+        _check(first["output_sha256"] == second["output_sha256"], f"receiver log hash changed across rerun: {key}")
+        first_run_dir = first_dir / first["run_dir"]
+        second_run_dir = second_dir / second["run_dir"]
+        for relative in (Path(first["output"]).name, "config.json", *TRUTH_ARTIFACTS):
+            first_path = first_run_dir / relative
+            second_path = second_run_dir / relative
+            _check(_sha256(first_path) == _sha256(second_path), f"artifact changed across rerun: {key} {relative}")
+
+
+def validate(args: argparse.Namespace) -> int:
+    source_dir = Path(args.source_dir).resolve()
+    build_dir = Path(args.build_dir).resolve()
+    work_dir = Path(args.work_dir).resolve()
+    simulator = _find_simulator(build_dir)
+    nav_path = source_dir / "tests" / "data" / "minimal" / "brd400dlr_rinex4_acceptance_nav.rnx"
+    _check(nav_path.is_file(), f"real RINEX NAV fixture missing: {nav_path}")
+
+    if work_dir.exists():
+        shutil.rmtree(work_dir)
+    work_dir.mkdir(parents=True)
+    base_config_path = work_dir / "base_config.json"
+    base_config = _make_short_config(source_dir, base_config_path)
+
+    first_dir = work_dir / "batch_a"
+    second_dir = work_dir / "batch_b"
+    _run_batch(source_dir, simulator, base_config_path, nav_path, first_dir)
+    first_manifest, first_runs = _validate_batch(first_dir, base_config, nav_path)
+    _run_batch(source_dir, simulator, base_config_path, nav_path, second_dir)
+    second_manifest, second_runs = _validate_batch(second_dir, base_config, nav_path)
+    _validate_rerun(first_dir, second_dir, first_manifest, second_manifest, first_runs, second_runs)
+
+    print(
+        "synchronized batch integration: PASS "
+        "(24 runs x 2, common GPST, event alignment, seed diversity, physical-truth invariance, reproducibility)"
+    )
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Validate synchronized multi-seed batch generation end to end.")
+    parser.add_argument("--source-dir", required=True)
+    parser.add_argument("--build-dir", required=True)
+    parser.add_argument("--work-dir", required=True)
+    return parser
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    try:
+        return validate(args)
+    except ValidationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/test_synchronized_batch.py
+++ b/tests/integration/test_synchronized_batch.py
@@ -126,6 +126,7 @@ def _make_short_config(source_dir: Path, output_path: Path) -> dict[str, Any]:
     config = _read_json(source_dir / "config" / "default_v1.json")
     config["duration_sec"] = DURATION_SEC
     config["sampling_rate_hz"] = 1
+    config["atmosphere_mode"] = "broadcast"
     config["output_eph"] = False
     config["output_ion"] = False
     config["multipath_enabled"] = False


### PR DESCRIPTION
Closes #156
Parent: #154
Depends on merged #155 / PR #158

## Summary
- add a production-path end-to-end regression for synchronized KS/REA/TTFF batches;
- generate two complete 24-run batches (KS x8 + REA x8 + TTFF x8) on both Ubuntu and Windows CI using the built simulator executable and the merged #155 batch tool;
- use the committed reduced real `BRD400DLR` RINEX 4.02 navigation fixture at one common GPST start;
- verify exact run count, deterministic seed ranges, shared start/end GPST, common effective physical configuration, and identical NAV identity;
- verify REA signal transition files are byte-identical across all eight REA seeds and TTFF power transition files are byte-identical across all eight TTFF seeds;
- prove different seeds produce existing seed-dependent CN0 diversity on common KS observations while receiver/satellite geometry, transmit time, clocks, atmosphere, TGD/ISC and code-bias truth stay unchanged;
- rerun the entire 24-file batch and require byte-identical corresponding receiver logs, configs and truth artifacts;
- document the synchronized-batch contract, output layout, seed mapping, reproducibility rules and CLI use.

## CI workload
The regression intentionally uses a short 20-second, 1 Hz window with shortened REA/TTFF cycles so normal CI can exercise transitions without generating production-size 8-hour data. It still invokes the normal batch wrapper and normal simulator executable for all 24 runs twice. The real NAV bytes are never edited or fabricated.

## Implementation Notes
- No C/C++ GNSS production source is changed.
- Measurement noise and urban multipath remain disabled in the short regression; seed diversity is demonstrated through the existing deterministic seed-dependent CN0 model rather than enabling a new noise source merely to force files to differ.
- Per-realization truth directories from #155 are directly validated, including `run_manifest.json`, `event_truth.csv`, `observation_truth.csv` and solution truth.
- Reproducibility is tested within each supported CI target; the test does not assert cross-OS byte identity.

## Baseline
`main @ fba82de44849963394ee831a8774c60f4582d340` (merged #155).