### PR TITLE
Implement configurable PLL/FLL carrier tracking core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ add_library(gnss_sim_core STATIC
     src/gnss/signal_definitions.cpp
     src/model/atmosphere_model.cpp
     src/model/bestpos_rtk_model.cpp
+    src/model/carrier_tracking.cpp
     src/model/cn0_model.cpp
     src/model/code_correlation.cpp
     src/model/code_tracking_dll.cpp
@@ -241,6 +242,7 @@ if(BUILD_TESTING)
     add_executable(gnss_sim_unit_tests
         tests/unit/test_atmosphere_model.cpp
         tests/unit/test_bestpos_rtk_model.cpp
+        tests/unit/test_carrier_tracking.cpp
         tests/unit/test_cn0_model.cpp
         tests/unit/test_cn0_normalized_builder.cpp
         tests/unit/test_cn0_statistics.cpp

--- a/docs/CARRIER_TRACKING_CORE.md
+++ b/docs/CARRIER_TRACKING_CORE.md
@@ -1,0 +1,107 @@
+# Carrier tracking core V1
+
+Issue: #160  
+Parent design: #159
+
+## Scope
+
+This document describes only the standalone carrier-tracking core. Runtime observation wiring, truth CSV integration, and authentic-NAV validation belong to #161, #162, and #163 respectively.
+
+The core does not modify urban propagation physics and does not own an RNG. The caller supplies one explicit standard-normal sample per update, so later runtime integration can choose a deterministic per-satellite/per-signal RNG convention without changing this model.
+
+## Frozen defaults
+
+| Parameter | V1 default |
+| --- | ---: |
+| coherent integration time | 0.020 s |
+| PLL noise bandwidth | 5 Hz |
+| FLL steady bandwidth | 4 Hz |
+| FLL pull-in bandwidth | 8 Hz |
+| FLL pull-in duration | 0.5 s |
+| PLL enter | >=30 dB-Hz for 1.0 s |
+| PLL exit | <27 dB-Hz for 0.3 s |
+| FLL acquire | >=22 dB-Hz for 0.2 s |
+| FLL loss | <18 dB-Hz for 0.5 s |
+| Doppler-valid delay after fresh carrier acquisition | 0.2 s |
+| ADR-valid delay after PLL entry | 1.0 s |
+
+All defaults are engineering assumptions for the V1 receiver model. They are configurable and are not calibrated universal receiver constants or PVT-error targets.
+
+## State semantics
+
+The standalone carrier state is one of:
+
+- `CARRIER_UNLOCKED`: carrier Doppler and ADR invalid;
+- `FLL_TRACK`: Doppler may become valid after the acquisition delay; ADR invalid;
+- `PLL_TRACK`: Doppler valid once carrier acquisition has matured; ADR becomes valid after the PLL confirmation delay.
+
+Fresh unlocked -> FLL acquisition uses the 8 Hz pull-in bandwidth for 0.5 s. PLL -> FLL fallback uses the 4 Hz steady FLL bandwidth because carrier frequency is already acquired. A fresh unlocked -> FLL transition starts a new carrier segment. Loss to unlocked clears the filtered carrier error.
+
+Threshold comparisons preserve hysteresis: equality at the acquisition/entry threshold counts as eligible, while equality at the loss/exit threshold does not count as a loss sample.
+
+## CN0 conversion
+
+Input `effective_cn0_dbhz` is converted to linear `C/N0` in Hz as:
+
+`cn0_linear = 10^(cn0_dbhz / 10)`.
+
+The implementation bounds the linear value to a finite numerical range only to prevent floating-point overflow/underflow for extreme test inputs. Ordinary GNSS CN0 values are unaffected.
+
+## FLL thermal jitter
+
+For the V1 differential-phase FLL, thermal velocity jitter follows the standard form:
+
+`sigma_v = lambda/(2*pi*T) * sqrt(4*F*Bn/(C/N0) * (1 + 1/(T*C/N0)))`.
+
+V1 uses `F = 1.0`, corresponding to the arctangent/high-CN0 discriminator reference convention. This choice is explicit rather than silently adding an empirical weak-signal sigma. A future measured-data calibration may justify a configurable low-CN0 discriminator factor, but #160 does not tune it to produce a desired velocity error.
+
+The equivalent frequency jitter is `sigma_f = sigma_v/lambda`.
+
+Reference: ESA Navipedia, *Frequency Lock Loop (FLL)*, which gives the same thermal-jitter form and identifies `F=1` at high C/N0 and `F=2` near the threshold.
+
+## PLL thermal jitter and equivalent Doppler scale
+
+For an arctangent PLL, V1 uses the standard thermal phase jitter:
+
+`sigma_phi = sqrt(Bn/(C/N0) * (1 + 1/(2*T*C/N0)))` rad.
+
+The standalone model needs an equivalent frequency-error scale for later Doppler synthesis. V1 converts one coherent-integration phase jitter to an equivalent frequency jitter by the explicit engineering approximation:
+
+`sigma_f = sigma_phi/(2*pi*T)`.
+
+Then `sigma_v = lambda*sigma_f`.
+
+This does not claim to be a full discrete PLL transfer-function simulation. It is a simplified CN0/T/Bn-driven receiver tracking model that is intentionally more physical than a fixed final Doppler sigma while remaining outside full IF/IQ/baseband simulation.
+
+Reference: ESA Navipedia, *Phase Lock Loop (PLL)*, for the thermal phase-jitter expression.
+
+## Time correlation
+
+The carrier error is first-order filtered:
+
+`e_k = alpha*e_(k-1) + sigma_k*sqrt(1-alpha^2)*w_k`
+
+with:
+
+`tau = 1/(2*pi*Bn)`
+
+`alpha = exp(-dt/tau)`.
+
+`w_k` is the caller-provided standard-normal sample. No arbitrary long-memory `rho` is configured. With the V1 loop bandwidths, thermal error itself can be nearly uncorrelated at a 1 Hz simulator output rate; slower observable correlation is expected to come later from effective-CN0/fading evolution, propagation state, and tracking-mode persistence.
+
+## Determinism contract
+
+- The core has no global/static RNG.
+- The core never samples wall-clock state.
+- Equal config, input sequence, initial state, and standard-normal sequence produce identical results.
+- `carrier_segment_id` increments only when a fresh unlocked carrier is acquired into FLL.
+- Runtime RNG ownership and legacy-RNG compatibility are deferred to #161.
+
+## Explicit exclusions
+
+- no simulator runtime Doppler/range-rate mutation;
+- no truth CSV/schema change;
+- no receiver oscillator/common-mode phase noise;
+- no moving receiver/reflector model;
+- no arbitrary weak-signal Doppler sigma;
+- no calibration to a target RTKLIB velocity error.

--- a/src/model/carrier_tracking.cpp
+++ b/src/model/carrier_tracking.cpp
@@ -239,8 +239,7 @@ bool compute_carrier_tracking_jitter(const CarrierTrackingConfig& config, Carrie
 }
 
 bool update_carrier_tracking(const CarrierTrackingConfig& config, const CarrierTrackingInput& input,
-                             CarrierTrackingState* state, CarrierTrackingResult* result,
-                             std::string* error_message) {
+                             CarrierTrackingState* state, CarrierTrackingResult* result, std::string* error_message) {
     if (state == nullptr || result == nullptr) {
         return fail(error_message, "carrier tracking state/result is null");
     }
@@ -286,8 +285,7 @@ bool update_carrier_tracking(const CarrierTrackingConfig& config, const CarrierT
         case CarrierTrackingMode::kFllTrack:
             state->mode_age_sec += input.dt_sec;
             state->carrier_lock_age_sec += input.dt_sec;
-            if (state->fll_pull_in_active &&
-                elapsed_reached(state->mode_age_sec, config.fll_pull_in_duration_sec)) {
+            if (state->fll_pull_in_active && elapsed_reached(state->mode_age_sec, config.fll_pull_in_duration_sec)) {
                 state->fll_pull_in_active = false;
             }
 
@@ -332,9 +330,8 @@ bool update_carrier_tracking(const CarrierTrackingConfig& config, const CarrierT
     }
 
     CarrierTrackingJitter jitter{};
-    if (!compute_carrier_tracking_jitter(config, state->mode, state->fll_pull_in_active,
-                                         input.effective_cn0_dbhz, input.wavelength_m, input.dt_sec, &jitter,
-                                         error_message)) {
+    if (!compute_carrier_tracking_jitter(config, state->mode, state->fll_pull_in_active, input.effective_cn0_dbhz,
+                                         input.wavelength_m, input.dt_sec, &jitter, error_message)) {
         return false;
     }
 

--- a/src/model/carrier_tracking.cpp
+++ b/src/model/carrier_tracking.cpp
@@ -1,0 +1,388 @@
+#include "model/carrier_tracking.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace gnss_sim {
+namespace {
+
+constexpr double kTwoPi = 6.283185307179586476925286766559;
+constexpr double kElapsedToleranceSec = 1e-12;
+constexpr double kMinimumCn0LinearHz = 1e-12;
+constexpr double kMaximumCn0LinearHz = 1e12;
+constexpr double kFllNoiseFactor = 1.0;
+
+bool fail(std::string* error_message, const char* message) {
+    if (error_message != nullptr) {
+        *error_message = message;
+    }
+    return false;
+}
+
+bool positive_finite(double value) {
+    return std::isfinite(value) && value > 0.0;
+}
+
+bool finite_value(double value) {
+    return std::isfinite(value);
+}
+
+bool elapsed_reached(double elapsed_sec, double threshold_sec) {
+    return elapsed_sec + kElapsedToleranceSec >= threshold_sec;
+}
+
+double cn0_dbhz_to_linear(double cn0_dbhz) {
+    const double exponent = cn0_dbhz / 10.0;
+    double value = std::pow(10.0, exponent);
+    if (!std::isfinite(value)) {
+        value = exponent > 0.0 ? kMaximumCn0LinearHz : kMinimumCn0LinearHz;
+    }
+    return std::clamp(value, kMinimumCn0LinearHz, kMaximumCn0LinearHz);
+}
+
+void clear_persistence(CarrierTrackingState* state) {
+    state->fll_enter_persistence_sec = 0.0;
+    state->fll_exit_persistence_sec = 0.0;
+    state->pll_enter_persistence_sec = 0.0;
+    state->pll_exit_persistence_sec = 0.0;
+}
+
+void enter_unlocked(CarrierTrackingState* state) {
+    state->mode = CarrierTrackingMode::kCarrierUnlocked;
+    state->fll_pull_in_active = false;
+    state->mode_age_sec = 0.0;
+    state->carrier_lock_age_sec = 0.0;
+    state->pll_age_sec = 0.0;
+    state->tracking_error_hz = 0.0;
+    clear_persistence(state);
+}
+
+void enter_fll_from_unlocked(CarrierTrackingState* state) {
+    state->mode = CarrierTrackingMode::kFllTrack;
+    state->fll_pull_in_active = true;
+    state->mode_age_sec = 0.0;
+    state->carrier_lock_age_sec = 0.0;
+    state->pll_age_sec = 0.0;
+    state->tracking_error_hz = 0.0;
+    clear_persistence(state);
+    ++state->carrier_segment_id;
+}
+
+void enter_fll_from_pll(CarrierTrackingState* state) {
+    state->mode = CarrierTrackingMode::kFllTrack;
+    state->fll_pull_in_active = false;
+    state->mode_age_sec = 0.0;
+    state->pll_age_sec = 0.0;
+    state->fll_enter_persistence_sec = 0.0;
+    state->fll_exit_persistence_sec = 0.0;
+    state->pll_enter_persistence_sec = 0.0;
+    state->pll_exit_persistence_sec = 0.0;
+}
+
+void enter_pll(CarrierTrackingState* state) {
+    state->mode = CarrierTrackingMode::kPllTrack;
+    state->fll_pull_in_active = false;
+    state->mode_age_sec = 0.0;
+    state->pll_age_sec = 0.0;
+    state->fll_enter_persistence_sec = 0.0;
+    state->fll_exit_persistence_sec = 0.0;
+    state->pll_enter_persistence_sec = 0.0;
+    state->pll_exit_persistence_sec = 0.0;
+}
+
+CarrierTrackingFllPhase fll_phase_from_state(const CarrierTrackingState& state) {
+    if (state.mode != CarrierTrackingMode::kFllTrack) {
+        return CarrierTrackingFllPhase::kNone;
+    }
+    return state.fll_pull_in_active ? CarrierTrackingFllPhase::kPullIn : CarrierTrackingFllPhase::kSteady;
+}
+
+void fill_unlocked_result(const CarrierTrackingState& state, bool mode_changed, CarrierTrackingResult* result) {
+    result->mode = state.mode;
+    result->fll_phase = CarrierTrackingFllPhase::kNone;
+    result->jitter = CarrierTrackingJitter{};
+    result->tracking_error_hz = 0.0;
+    result->tracking_error_mps = 0.0;
+    result->carrier_lock_age_sec = 0.0;
+    result->pll_age_sec = 0.0;
+    result->carrier_segment_id = state.carrier_segment_id;
+    result->doppler_valid = false;
+    result->adr_valid = false;
+    result->mode_changed = mode_changed;
+    result->new_carrier_segment = false;
+}
+
+} // namespace
+
+CarrierTrackingConfig default_carrier_tracking_config() {
+    CarrierTrackingConfig config{};
+    config.coherent_integration_sec = 0.020;
+    config.pll_noise_bandwidth_hz = 5.0;
+    config.fll_noise_bandwidth_hz = 4.0;
+    config.fll_pull_in_bandwidth_hz = 8.0;
+    config.fll_pull_in_duration_sec = 0.5;
+
+    config.pll_enter_cn0_dbhz = 30.0;
+    config.pll_exit_cn0_dbhz = 27.0;
+    config.pll_enter_persistence_sec = 1.0;
+    config.pll_exit_persistence_sec = 0.3;
+
+    config.fll_enter_cn0_dbhz = 22.0;
+    config.fll_exit_cn0_dbhz = 18.0;
+    config.fll_enter_persistence_sec = 0.2;
+    config.fll_exit_persistence_sec = 0.5;
+
+    config.doppler_valid_delay_sec = 0.2;
+    config.adr_valid_after_pll_sec = 1.0;
+    return config;
+}
+
+bool validate_carrier_tracking_config(const CarrierTrackingConfig& config, std::string* error_message) {
+    if (!positive_finite(config.coherent_integration_sec)) {
+        return fail(error_message, "carrier coherent integration time must be finite and positive");
+    }
+    if (!positive_finite(config.pll_noise_bandwidth_hz) || !positive_finite(config.fll_noise_bandwidth_hz) ||
+        !positive_finite(config.fll_pull_in_bandwidth_hz)) {
+        return fail(error_message, "carrier loop bandwidths must be finite and positive");
+    }
+    if (config.fll_pull_in_bandwidth_hz < config.fll_noise_bandwidth_hz) {
+        return fail(error_message, "FLL pull-in bandwidth must be at least the steady FLL bandwidth");
+    }
+    if (!positive_finite(config.fll_pull_in_duration_sec) || !positive_finite(config.pll_enter_persistence_sec) ||
+        !positive_finite(config.pll_exit_persistence_sec) || !positive_finite(config.fll_enter_persistence_sec) ||
+        !positive_finite(config.fll_exit_persistence_sec) || !positive_finite(config.doppler_valid_delay_sec) ||
+        !positive_finite(config.adr_valid_after_pll_sec)) {
+        return fail(error_message, "carrier tracking durations must be finite and positive");
+    }
+    if (!finite_value(config.pll_enter_cn0_dbhz) || !finite_value(config.pll_exit_cn0_dbhz) ||
+        !finite_value(config.fll_enter_cn0_dbhz) || !finite_value(config.fll_exit_cn0_dbhz)) {
+        return fail(error_message, "carrier tracking CN0 thresholds must be finite");
+    }
+    if (!(config.pll_enter_cn0_dbhz > config.pll_exit_cn0_dbhz &&
+          config.pll_exit_cn0_dbhz > config.fll_enter_cn0_dbhz &&
+          config.fll_enter_cn0_dbhz > config.fll_exit_cn0_dbhz)) {
+        return fail(error_message,
+                    "carrier tracking CN0 thresholds must satisfy PLL-enter > PLL-exit > FLL-enter > FLL-exit");
+    }
+    return true;
+}
+
+void reset_carrier_tracking_state(CarrierTrackingState* state) {
+    if (state == nullptr) {
+        return;
+    }
+    *state = CarrierTrackingState{};
+    state->mode = CarrierTrackingMode::kCarrierUnlocked;
+}
+
+bool compute_carrier_tracking_jitter(const CarrierTrackingConfig& config, CarrierTrackingMode mode,
+                                     bool fll_pull_in_active, double effective_cn0_dbhz, double wavelength_m,
+                                     double dt_sec, CarrierTrackingJitter* jitter, std::string* error_message) {
+    if (jitter == nullptr) {
+        return fail(error_message, "carrier tracking jitter output is null");
+    }
+    *jitter = CarrierTrackingJitter{};
+    if (!validate_carrier_tracking_config(config, error_message)) {
+        return false;
+    }
+    if (!finite_value(effective_cn0_dbhz)) {
+        return fail(error_message, "effective CN0 must be finite");
+    }
+    if (!positive_finite(wavelength_m)) {
+        return fail(error_message, "carrier wavelength must be finite and positive");
+    }
+    if (!positive_finite(dt_sec)) {
+        return fail(error_message, "carrier tracking dt must be finite and positive");
+    }
+    if (mode == CarrierTrackingMode::kCarrierUnlocked) {
+        return true;
+    }
+
+    const double cn0_linear_hz = cn0_dbhz_to_linear(effective_cn0_dbhz);
+    const double integration_sec = config.coherent_integration_sec;
+    double bandwidth_hz = config.pll_noise_bandwidth_hz;
+    double phase_sigma_rad = 0.0;
+    double sigma_hz = 0.0;
+
+    if (mode == CarrierTrackingMode::kFllTrack) {
+        bandwidth_hz = fll_pull_in_active ? config.fll_pull_in_bandwidth_hz : config.fll_noise_bandwidth_hz;
+        const double correction = 1.0 + 1.0 / (integration_sec * cn0_linear_hz);
+        const double variance_term = 4.0 * kFllNoiseFactor * bandwidth_hz / cn0_linear_hz * correction;
+        sigma_hz = std::sqrt(variance_term) / (kTwoPi * integration_sec);
+    } else if (mode == CarrierTrackingMode::kPllTrack) {
+        bandwidth_hz = config.pll_noise_bandwidth_hz;
+        const double correction = 1.0 + 1.0 / (2.0 * integration_sec * cn0_linear_hz);
+        const double phase_variance_rad2 = bandwidth_hz / cn0_linear_hz * correction;
+        phase_sigma_rad = std::sqrt(phase_variance_rad2);
+        sigma_hz = phase_sigma_rad / (kTwoPi * integration_sec);
+    } else {
+        return fail(error_message, "unsupported carrier tracking mode");
+    }
+
+    const double tau_sec = 1.0 / (kTwoPi * bandwidth_hz);
+    const double alpha = std::exp(-dt_sec / tau_sec);
+    const double sigma_mps = wavelength_m * sigma_hz;
+    if (!std::isfinite(phase_sigma_rad) || !std::isfinite(sigma_hz) || !std::isfinite(sigma_mps) ||
+        !std::isfinite(tau_sec) || !std::isfinite(alpha)) {
+        return fail(error_message, "carrier tracking jitter calculation produced a non-finite value");
+    }
+
+    jitter->cn0_linear_hz = cn0_linear_hz;
+    jitter->active_bandwidth_hz = bandwidth_hz;
+    jitter->phase_sigma_rad = phase_sigma_rad;
+    jitter->sigma_hz = sigma_hz;
+    jitter->sigma_mps = sigma_mps;
+    jitter->correlation_tau_sec = tau_sec;
+    jitter->correlation_alpha = alpha;
+    return true;
+}
+
+bool update_carrier_tracking(const CarrierTrackingConfig& config, const CarrierTrackingInput& input,
+                             CarrierTrackingState* state, CarrierTrackingResult* result,
+                             std::string* error_message) {
+    if (state == nullptr || result == nullptr) {
+        return fail(error_message, "carrier tracking state/result is null");
+    }
+    *result = CarrierTrackingResult{};
+    if (!validate_carrier_tracking_config(config, error_message)) {
+        return false;
+    }
+    if (!finite_value(input.effective_cn0_dbhz)) {
+        return fail(error_message, "effective CN0 must be finite");
+    }
+    if (!positive_finite(input.wavelength_m)) {
+        return fail(error_message, "carrier wavelength must be finite and positive");
+    }
+    if (!positive_finite(input.dt_sec)) {
+        return fail(error_message, "carrier tracking dt must be finite and positive");
+    }
+    if (!finite_value(input.standard_normal_sample)) {
+        return fail(error_message, "carrier tracking Gaussian input must be finite");
+    }
+
+    const CarrierTrackingMode previous_mode = state->mode;
+    bool new_carrier_segment = false;
+
+    if (!input.signal_available) {
+        enter_unlocked(state);
+        fill_unlocked_result(*state, previous_mode != state->mode, result);
+        return true;
+    }
+
+    switch (state->mode) {
+        case CarrierTrackingMode::kCarrierUnlocked:
+            if (input.effective_cn0_dbhz >= config.fll_enter_cn0_dbhz) {
+                state->fll_enter_persistence_sec += input.dt_sec;
+            } else {
+                state->fll_enter_persistence_sec = 0.0;
+            }
+            if (elapsed_reached(state->fll_enter_persistence_sec, config.fll_enter_persistence_sec)) {
+                enter_fll_from_unlocked(state);
+                new_carrier_segment = true;
+            }
+            break;
+
+        case CarrierTrackingMode::kFllTrack:
+            state->mode_age_sec += input.dt_sec;
+            state->carrier_lock_age_sec += input.dt_sec;
+            if (state->fll_pull_in_active &&
+                elapsed_reached(state->mode_age_sec, config.fll_pull_in_duration_sec)) {
+                state->fll_pull_in_active = false;
+            }
+
+            if (input.effective_cn0_dbhz < config.fll_exit_cn0_dbhz) {
+                state->fll_exit_persistence_sec += input.dt_sec;
+            } else {
+                state->fll_exit_persistence_sec = 0.0;
+            }
+            if (elapsed_reached(state->fll_exit_persistence_sec, config.fll_exit_persistence_sec)) {
+                enter_unlocked(state);
+                break;
+            }
+
+            if (input.effective_cn0_dbhz >= config.pll_enter_cn0_dbhz) {
+                state->pll_enter_persistence_sec += input.dt_sec;
+            } else {
+                state->pll_enter_persistence_sec = 0.0;
+            }
+            if (elapsed_reached(state->pll_enter_persistence_sec, config.pll_enter_persistence_sec)) {
+                enter_pll(state);
+            }
+            break;
+
+        case CarrierTrackingMode::kPllTrack:
+            state->mode_age_sec += input.dt_sec;
+            state->carrier_lock_age_sec += input.dt_sec;
+            state->pll_age_sec += input.dt_sec;
+            if (input.effective_cn0_dbhz < config.pll_exit_cn0_dbhz) {
+                state->pll_exit_persistence_sec += input.dt_sec;
+            } else {
+                state->pll_exit_persistence_sec = 0.0;
+            }
+            if (elapsed_reached(state->pll_exit_persistence_sec, config.pll_exit_persistence_sec)) {
+                enter_fll_from_pll(state);
+            }
+            break;
+    }
+
+    if (state->mode == CarrierTrackingMode::kCarrierUnlocked) {
+        fill_unlocked_result(*state, previous_mode != state->mode, result);
+        return true;
+    }
+
+    CarrierTrackingJitter jitter{};
+    if (!compute_carrier_tracking_jitter(config, state->mode, state->fll_pull_in_active,
+                                         input.effective_cn0_dbhz, input.wavelength_m, input.dt_sec, &jitter,
+                                         error_message)) {
+        return false;
+    }
+
+    const double innovation_scale = std::sqrt(std::max(0.0, 1.0 - jitter.correlation_alpha * jitter.correlation_alpha));
+    state->tracking_error_hz = jitter.correlation_alpha * state->tracking_error_hz +
+                               jitter.sigma_hz * innovation_scale * input.standard_normal_sample;
+    if (!std::isfinite(state->tracking_error_hz)) {
+        return fail(error_message, "carrier tracking filtered error became non-finite");
+    }
+
+    result->mode = state->mode;
+    result->fll_phase = fll_phase_from_state(*state);
+    result->jitter = jitter;
+    result->tracking_error_hz = state->tracking_error_hz;
+    result->tracking_error_mps = input.wavelength_m * state->tracking_error_hz;
+    result->carrier_lock_age_sec = state->carrier_lock_age_sec;
+    result->pll_age_sec = state->pll_age_sec;
+    result->carrier_segment_id = state->carrier_segment_id;
+    result->doppler_valid = elapsed_reached(state->carrier_lock_age_sec, config.doppler_valid_delay_sec);
+    result->adr_valid = state->mode == CarrierTrackingMode::kPllTrack &&
+                        elapsed_reached(state->pll_age_sec, config.adr_valid_after_pll_sec);
+    result->mode_changed = previous_mode != state->mode;
+    result->new_carrier_segment = new_carrier_segment;
+    return true;
+}
+
+const char* carrier_tracking_mode_name(CarrierTrackingMode mode) {
+    switch (mode) {
+        case CarrierTrackingMode::kCarrierUnlocked:
+            return "CARRIER_UNLOCKED";
+        case CarrierTrackingMode::kFllTrack:
+            return "FLL_TRACK";
+        case CarrierTrackingMode::kPllTrack:
+            return "PLL_TRACK";
+    }
+    return "UNKNOWN";
+}
+
+const char* carrier_tracking_fll_phase_name(CarrierTrackingFllPhase phase) {
+    switch (phase) {
+        case CarrierTrackingFllPhase::kNone:
+            return "NONE";
+        case CarrierTrackingFllPhase::kPullIn:
+            return "PULL_IN";
+        case CarrierTrackingFllPhase::kSteady:
+            return "STEADY";
+    }
+    return "UNKNOWN";
+}
+
+} // namespace gnss_sim

--- a/src/model/carrier_tracking.h
+++ b/src/model/carrier_tracking.h
@@ -1,0 +1,118 @@
+#ifndef GNSS_SIM_SRC_MODEL_CARRIER_TRACKING_H_
+#define GNSS_SIM_SRC_MODEL_CARRIER_TRACKING_H_
+
+#include <cstdint>
+#include <string>
+
+namespace gnss_sim {
+
+enum class CarrierTrackingMode {
+    kCarrierUnlocked,
+    kFllTrack,
+    kPllTrack,
+};
+
+enum class CarrierTrackingFllPhase {
+    kNone,
+    kPullIn,
+    kSteady,
+};
+
+struct CarrierTrackingConfig {
+    double coherent_integration_sec;
+    double pll_noise_bandwidth_hz;
+    double fll_noise_bandwidth_hz;
+    double fll_pull_in_bandwidth_hz;
+    double fll_pull_in_duration_sec;
+
+    double pll_enter_cn0_dbhz;
+    double pll_exit_cn0_dbhz;
+    double pll_enter_persistence_sec;
+    double pll_exit_persistence_sec;
+
+    double fll_enter_cn0_dbhz;
+    double fll_exit_cn0_dbhz;
+    double fll_enter_persistence_sec;
+    double fll_exit_persistence_sec;
+
+    double doppler_valid_delay_sec;
+    double adr_valid_after_pll_sec;
+};
+
+struct CarrierTrackingState {
+    CarrierTrackingMode mode;
+    bool fll_pull_in_active;
+    double mode_age_sec;
+    double carrier_lock_age_sec;
+    double pll_age_sec;
+    double fll_enter_persistence_sec;
+    double fll_exit_persistence_sec;
+    double pll_enter_persistence_sec;
+    double pll_exit_persistence_sec;
+    double tracking_error_hz;
+    std::uint64_t carrier_segment_id;
+};
+
+struct CarrierTrackingInput {
+    bool signal_available;
+    double effective_cn0_dbhz;
+    double wavelength_m;
+    double dt_sec;
+    // One explicit N(0,1) draw owned by the caller. The core never owns or
+    // advances a random-number generator, so runtime integration can preserve
+    // deterministic per-signal RNG ordering.
+    double standard_normal_sample;
+};
+
+struct CarrierTrackingJitter {
+    double cn0_linear_hz;
+    double active_bandwidth_hz;
+    double phase_sigma_rad;
+    double sigma_hz;
+    double sigma_mps;
+    double correlation_tau_sec;
+    double correlation_alpha;
+};
+
+struct CarrierTrackingResult {
+    CarrierTrackingMode mode;
+    CarrierTrackingFllPhase fll_phase;
+    CarrierTrackingJitter jitter;
+    double tracking_error_hz;
+    double tracking_error_mps;
+    double carrier_lock_age_sec;
+    double pll_age_sec;
+    std::uint64_t carrier_segment_id;
+    bool doppler_valid;
+    bool adr_valid;
+    bool mode_changed;
+    bool new_carrier_segment;
+};
+
+CarrierTrackingConfig default_carrier_tracking_config();
+bool validate_carrier_tracking_config(const CarrierTrackingConfig& config, std::string* error_message);
+
+void reset_carrier_tracking_state(CarrierTrackingState* state);
+
+// Compute the thermal-jitter scale and loop-derived first-order correlation
+// coefficient for one active carrier-tracking mode. The FLL uses the standard
+// differential-phase thermal frequency-jitter expression with discriminator
+// factor F=1.0. For PLL mode, phase jitter from an arctangent PLL is converted
+// to an equivalent one-integration frequency jitter by sigma_f=sigma_phi/(2*pi*T).
+bool compute_carrier_tracking_jitter(const CarrierTrackingConfig& config, CarrierTrackingMode mode,
+                                     bool fll_pull_in_active, double effective_cn0_dbhz, double wavelength_m,
+                                     double dt_sec, CarrierTrackingJitter* jitter, std::string* error_message);
+
+// Advance one per-satellite/per-signal carrier tracker. State transitions are
+// driven by effective CN0 hysteresis/persistence. The supplied Gaussian sample
+// is filtered with alpha=exp(-dt/tau), tau=1/(2*pi*Bn).
+bool update_carrier_tracking(const CarrierTrackingConfig& config, const CarrierTrackingInput& input,
+                             CarrierTrackingState* state, CarrierTrackingResult* result,
+                             std::string* error_message);
+
+const char* carrier_tracking_mode_name(CarrierTrackingMode mode);
+const char* carrier_tracking_fll_phase_name(CarrierTrackingFllPhase phase);
+
+} // namespace gnss_sim
+
+#endif // GNSS_SIM_SRC_MODEL_CARRIER_TRACKING_H_

--- a/src/model/carrier_tracking.h
+++ b/src/model/carrier_tracking.h
@@ -107,8 +107,7 @@ bool compute_carrier_tracking_jitter(const CarrierTrackingConfig& config, Carrie
 // driven by effective CN0 hysteresis/persistence. The supplied Gaussian sample
 // is filtered with alpha=exp(-dt/tau), tau=1/(2*pi*Bn).
 bool update_carrier_tracking(const CarrierTrackingConfig& config, const CarrierTrackingInput& input,
-                             CarrierTrackingState* state, CarrierTrackingResult* result,
-                             std::string* error_message);
+                             CarrierTrackingState* state, CarrierTrackingResult* result, std::string* error_message);
 
 const char* carrier_tracking_mode_name(CarrierTrackingMode mode);
 const char* carrier_tracking_fll_phase_name(CarrierTrackingFllPhase phase);

--- a/tests/unit/test_carrier_tracking.cpp
+++ b/tests/unit/test_carrier_tracking.cpp
@@ -1,8 +1,7 @@
 #include "model/carrier_tracking.h"
 
-#include <gtest/gtest.h>
-
 #include <cmath>
+#include <gtest/gtest.h>
 #include <limits>
 #include <string>
 #include <vector>
@@ -241,8 +240,8 @@ TEST(CarrierTracking, JitterFallsWithCn0AndScalesWithBandwidthIntegrationAndWave
     wide.fll_noise_bandwidth_hz = 8.0;
     wide.fll_pull_in_bandwidth_hz = 8.0;
     CarrierTrackingJitter wider{};
-    ASSERT_TRUE(compute_carrier_tracking_jitter(wide, CarrierTrackingMode::kFllTrack, false, 35.0, kL1WavelengthM,
-                                                0.1, &wider, &error))
+    ASSERT_TRUE(compute_carrier_tracking_jitter(wide, CarrierTrackingMode::kFllTrack, false, 35.0, kL1WavelengthM, 0.1,
+                                                &wider, &error))
         << error;
     EXPECT_GT(wider.sigma_hz, fll_mid.sigma_hz);
 
@@ -275,8 +274,8 @@ TEST(CarrierTracking, IdenticalInputsAndGaussianSequenceProduceIdenticalState) {
 
     const std::vector<double> cn0 = {25.0, 25.0, 25.0, 31.0, 31.0, 31.0, 31.0, 31.0,
                                      31.0, 31.0, 31.0, 31.0, 31.0, 26.0, 26.0, 26.0};
-    const std::vector<double> gaussian = {0.1,  -0.3, 1.2,  0.4,  -0.7, 0.0, 0.9,  -1.1,
-                                          0.2, 0.5,  -0.4, 0.8,  0.3,  -0.2, 1.0,  -0.6};
+    const std::vector<double> gaussian = {0.1, -0.3, 1.2,  0.4, -0.7, 0.0,  0.9, -1.1,
+                                          0.2, 0.5,  -0.4, 0.8, 0.3,  -0.2, 1.0, -0.6};
 
     for (std::size_t index = 0; index < cn0.size(); ++index) {
         const CarrierTrackingResult first_result = step_tracker(config, &first, cn0[index], 0.1, gaussian[index]);
@@ -297,11 +296,11 @@ TEST(CarrierTracking, SupportedExtremeCn0ValuesRemainFinite) {
     CarrierTrackingJitter high{};
     std::string error;
 
-    ASSERT_TRUE(compute_carrier_tracking_jitter(config, CarrierTrackingMode::kFllTrack, false, -100.0,
-                                                kL1WavelengthM, 0.1, &low, &error))
+    ASSERT_TRUE(compute_carrier_tracking_jitter(config, CarrierTrackingMode::kFllTrack, false, -100.0, kL1WavelengthM,
+                                                0.1, &low, &error))
         << error;
-    ASSERT_TRUE(compute_carrier_tracking_jitter(config, CarrierTrackingMode::kPllTrack, false, 100.0,
-                                                kL1WavelengthM, 0.1, &high, &error))
+    ASSERT_TRUE(compute_carrier_tracking_jitter(config, CarrierTrackingMode::kPllTrack, false, 100.0, kL1WavelengthM,
+                                                0.1, &high, &error))
         << error;
 
     EXPECT_TRUE(std::isfinite(low.sigma_hz));

--- a/tests/unit/test_carrier_tracking.cpp
+++ b/tests/unit/test_carrier_tracking.cpp
@@ -1,0 +1,332 @@
+#include "model/carrier_tracking.h"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace gnss_sim {
+namespace {
+
+constexpr double kL1WavelengthM = 0.190293672798;
+
+CarrierTrackingResult step_tracker(const CarrierTrackingConfig& config, CarrierTrackingState* state, double cn0_dbhz,
+                                   double dt_sec = 0.1, double standard_normal_sample = 0.0,
+                                   bool signal_available = true) {
+    CarrierTrackingInput input{};
+    input.signal_available = signal_available;
+    input.effective_cn0_dbhz = cn0_dbhz;
+    input.wavelength_m = kL1WavelengthM;
+    input.dt_sec = dt_sec;
+    input.standard_normal_sample = standard_normal_sample;
+
+    CarrierTrackingResult result{};
+    std::string error;
+    EXPECT_TRUE(update_carrier_tracking(config, input, state, &result, &error)) << error;
+    return result;
+}
+
+TEST(CarrierTracking, DefaultConfigMatchesFrozenV1) {
+    const CarrierTrackingConfig config = default_carrier_tracking_config();
+
+    EXPECT_DOUBLE_EQ(config.coherent_integration_sec, 0.020);
+    EXPECT_DOUBLE_EQ(config.pll_noise_bandwidth_hz, 5.0);
+    EXPECT_DOUBLE_EQ(config.fll_noise_bandwidth_hz, 4.0);
+    EXPECT_DOUBLE_EQ(config.fll_pull_in_bandwidth_hz, 8.0);
+    EXPECT_DOUBLE_EQ(config.fll_pull_in_duration_sec, 0.5);
+    EXPECT_DOUBLE_EQ(config.pll_enter_cn0_dbhz, 30.0);
+    EXPECT_DOUBLE_EQ(config.pll_exit_cn0_dbhz, 27.0);
+    EXPECT_DOUBLE_EQ(config.pll_enter_persistence_sec, 1.0);
+    EXPECT_DOUBLE_EQ(config.pll_exit_persistence_sec, 0.3);
+    EXPECT_DOUBLE_EQ(config.fll_enter_cn0_dbhz, 22.0);
+    EXPECT_DOUBLE_EQ(config.fll_exit_cn0_dbhz, 18.0);
+    EXPECT_DOUBLE_EQ(config.fll_enter_persistence_sec, 0.2);
+    EXPECT_DOUBLE_EQ(config.fll_exit_persistence_sec, 0.5);
+    EXPECT_DOUBLE_EQ(config.doppler_valid_delay_sec, 0.2);
+    EXPECT_DOUBLE_EQ(config.adr_valid_after_pll_sec, 1.0);
+
+    std::string error;
+    EXPECT_TRUE(validate_carrier_tracking_config(config, &error)) << error;
+}
+
+TEST(CarrierTracking, ConfigValidationRejectsInvalidValuesAndOrdering) {
+    std::string error;
+
+    CarrierTrackingConfig config = default_carrier_tracking_config();
+    config.coherent_integration_sec = 0.0;
+    EXPECT_FALSE(validate_carrier_tracking_config(config, &error));
+
+    config = default_carrier_tracking_config();
+    config.fll_pull_in_bandwidth_hz = 3.0;
+    EXPECT_FALSE(validate_carrier_tracking_config(config, &error));
+
+    config = default_carrier_tracking_config();
+    config.pll_exit_cn0_dbhz = config.pll_enter_cn0_dbhz;
+    EXPECT_FALSE(validate_carrier_tracking_config(config, &error));
+
+    config = default_carrier_tracking_config();
+    config.fll_enter_cn0_dbhz = std::numeric_limits<double>::quiet_NaN();
+    EXPECT_FALSE(validate_carrier_tracking_config(config, &error));
+
+    config = default_carrier_tracking_config();
+    config.adr_valid_after_pll_sec = -1.0;
+    EXPECT_FALSE(validate_carrier_tracking_config(config, &error));
+}
+
+TEST(CarrierTracking, HysteresisAndPersistenceDriveUnlockedFllAndPll) {
+    const CarrierTrackingConfig config = default_carrier_tracking_config();
+    CarrierTrackingState state{};
+    reset_carrier_tracking_state(&state);
+
+    for (int index = 0; index < 10; ++index) {
+        const CarrierTrackingResult result = step_tracker(config, &state, 21.9);
+        EXPECT_EQ(result.mode, CarrierTrackingMode::kCarrierUnlocked);
+    }
+
+    EXPECT_EQ(step_tracker(config, &state, 22.0).mode, CarrierTrackingMode::kCarrierUnlocked);
+    CarrierTrackingResult result = step_tracker(config, &state, 22.0);
+    EXPECT_EQ(result.mode, CarrierTrackingMode::kFllTrack);
+    EXPECT_TRUE(result.new_carrier_segment);
+    EXPECT_EQ(result.carrier_segment_id, 1U);
+
+    for (int index = 0; index < 10; ++index) {
+        result = step_tracker(config, &state, 21.0);
+        EXPECT_EQ(result.mode, CarrierTrackingMode::kFllTrack);
+    }
+
+    for (int index = 0; index < 9; ++index) {
+        result = step_tracker(config, &state, 30.0);
+        EXPECT_EQ(result.mode, CarrierTrackingMode::kFllTrack);
+    }
+    result = step_tracker(config, &state, 30.0);
+    EXPECT_EQ(result.mode, CarrierTrackingMode::kPllTrack);
+
+    for (int index = 0; index < 5; ++index) {
+        result = step_tracker(config, &state, 27.0);
+        EXPECT_EQ(result.mode, CarrierTrackingMode::kPllTrack);
+    }
+    EXPECT_EQ(step_tracker(config, &state, 26.9).mode, CarrierTrackingMode::kPllTrack);
+    EXPECT_EQ(step_tracker(config, &state, 26.9).mode, CarrierTrackingMode::kPllTrack);
+    result = step_tracker(config, &state, 26.9);
+    EXPECT_EQ(result.mode, CarrierTrackingMode::kFllTrack);
+    EXPECT_EQ(result.fll_phase, CarrierTrackingFllPhase::kSteady);
+
+    for (int index = 0; index < 6; ++index) {
+        result = step_tracker(config, &state, 18.0);
+        EXPECT_EQ(result.mode, CarrierTrackingMode::kFllTrack);
+    }
+    for (int index = 0; index < 4; ++index) {
+        result = step_tracker(config, &state, 17.9);
+        EXPECT_EQ(result.mode, CarrierTrackingMode::kFllTrack);
+    }
+    result = step_tracker(config, &state, 17.9);
+    EXPECT_EQ(result.mode, CarrierTrackingMode::kCarrierUnlocked);
+    EXPECT_FALSE(result.doppler_valid);
+    EXPECT_FALSE(result.adr_valid);
+}
+
+TEST(CarrierTracking, FreshAcquisitionUsesPullInThenSteadyFll) {
+    const CarrierTrackingConfig config = default_carrier_tracking_config();
+    CarrierTrackingState state{};
+    reset_carrier_tracking_state(&state);
+
+    step_tracker(config, &state, 25.0);
+    CarrierTrackingResult result = step_tracker(config, &state, 25.0);
+    ASSERT_EQ(result.mode, CarrierTrackingMode::kFllTrack);
+    EXPECT_EQ(result.fll_phase, CarrierTrackingFllPhase::kPullIn);
+    EXPECT_DOUBLE_EQ(result.jitter.active_bandwidth_hz, 8.0);
+
+    for (int index = 0; index < 4; ++index) {
+        result = step_tracker(config, &state, 25.0);
+        EXPECT_EQ(result.fll_phase, CarrierTrackingFllPhase::kPullIn);
+        EXPECT_DOUBLE_EQ(result.jitter.active_bandwidth_hz, 8.0);
+    }
+    result = step_tracker(config, &state, 25.0);
+    EXPECT_EQ(result.fll_phase, CarrierTrackingFllPhase::kSteady);
+    EXPECT_DOUBLE_EQ(result.jitter.active_bandwidth_hz, 4.0);
+}
+
+TEST(CarrierTracking, DopplerAndAdrValidityHaveIndependentDelays) {
+    const CarrierTrackingConfig config = default_carrier_tracking_config();
+    CarrierTrackingState state{};
+    reset_carrier_tracking_state(&state);
+
+    step_tracker(config, &state, 25.0);
+    CarrierTrackingResult result = step_tracker(config, &state, 25.0);
+    ASSERT_EQ(result.mode, CarrierTrackingMode::kFllTrack);
+    EXPECT_FALSE(result.doppler_valid);
+    EXPECT_FALSE(result.adr_valid);
+
+    result = step_tracker(config, &state, 25.0);
+    EXPECT_FALSE(result.doppler_valid);
+    result = step_tracker(config, &state, 25.0);
+    EXPECT_TRUE(result.doppler_valid);
+    EXPECT_FALSE(result.adr_valid);
+
+    for (int index = 0; index < 9; ++index) {
+        result = step_tracker(config, &state, 30.0);
+        ASSERT_EQ(result.mode, CarrierTrackingMode::kFllTrack);
+        EXPECT_FALSE(result.adr_valid);
+    }
+    result = step_tracker(config, &state, 30.0);
+    ASSERT_EQ(result.mode, CarrierTrackingMode::kPllTrack);
+    EXPECT_TRUE(result.doppler_valid);
+    EXPECT_FALSE(result.adr_valid);
+
+    for (int index = 0; index < 9; ++index) {
+        result = step_tracker(config, &state, 30.0);
+        EXPECT_FALSE(result.adr_valid);
+    }
+    result = step_tracker(config, &state, 30.0);
+    EXPECT_TRUE(result.adr_valid);
+}
+
+TEST(CarrierTracking, PllLossImmediatelyInvalidatesAdrButKeepsDopplerInFll) {
+    const CarrierTrackingConfig config = default_carrier_tracking_config();
+    CarrierTrackingState state{};
+    reset_carrier_tracking_state(&state);
+
+    step_tracker(config, &state, 35.0);
+    step_tracker(config, &state, 35.0);
+    for (int index = 0; index < 10; ++index) {
+        step_tracker(config, &state, 35.0);
+    }
+    CarrierTrackingResult result{};
+    for (int index = 0; index < 10; ++index) {
+        result = step_tracker(config, &state, 35.0);
+    }
+    ASSERT_EQ(result.mode, CarrierTrackingMode::kPllTrack);
+    ASSERT_TRUE(result.adr_valid);
+
+    step_tracker(config, &state, 26.0);
+    step_tracker(config, &state, 26.0);
+    result = step_tracker(config, &state, 26.0);
+    EXPECT_EQ(result.mode, CarrierTrackingMode::kFllTrack);
+    EXPECT_TRUE(result.doppler_valid);
+    EXPECT_FALSE(result.adr_valid);
+}
+
+TEST(CarrierTracking, JitterFallsWithCn0AndScalesWithBandwidthIntegrationAndWavelength) {
+    const CarrierTrackingConfig config = default_carrier_tracking_config();
+    CarrierTrackingJitter fll_low{};
+    CarrierTrackingJitter fll_mid{};
+    CarrierTrackingJitter fll_high{};
+    CarrierTrackingJitter pll_low{};
+    CarrierTrackingJitter pll_high{};
+    std::string error;
+
+    ASSERT_TRUE(compute_carrier_tracking_jitter(config, CarrierTrackingMode::kFllTrack, false, 25.0, kL1WavelengthM,
+                                                0.1, &fll_low, &error))
+        << error;
+    ASSERT_TRUE(compute_carrier_tracking_jitter(config, CarrierTrackingMode::kFllTrack, false, 35.0, kL1WavelengthM,
+                                                0.1, &fll_mid, &error))
+        << error;
+    ASSERT_TRUE(compute_carrier_tracking_jitter(config, CarrierTrackingMode::kFllTrack, false, 45.0, kL1WavelengthM,
+                                                0.1, &fll_high, &error))
+        << error;
+    EXPECT_GT(fll_low.sigma_mps, fll_mid.sigma_mps);
+    EXPECT_GT(fll_mid.sigma_mps, fll_high.sigma_mps);
+
+    ASSERT_TRUE(compute_carrier_tracking_jitter(config, CarrierTrackingMode::kPllTrack, false, 25.0, kL1WavelengthM,
+                                                0.1, &pll_low, &error))
+        << error;
+    ASSERT_TRUE(compute_carrier_tracking_jitter(config, CarrierTrackingMode::kPllTrack, false, 45.0, kL1WavelengthM,
+                                                0.1, &pll_high, &error))
+        << error;
+    EXPECT_GT(pll_low.sigma_mps, pll_high.sigma_mps);
+
+    CarrierTrackingConfig wide = config;
+    wide.fll_noise_bandwidth_hz = 8.0;
+    wide.fll_pull_in_bandwidth_hz = 8.0;
+    CarrierTrackingJitter wider{};
+    ASSERT_TRUE(compute_carrier_tracking_jitter(wide, CarrierTrackingMode::kFllTrack, false, 35.0, kL1WavelengthM,
+                                                0.1, &wider, &error))
+        << error;
+    EXPECT_GT(wider.sigma_hz, fll_mid.sigma_hz);
+
+    CarrierTrackingConfig short_integration = config;
+    short_integration.coherent_integration_sec = 0.010;
+    CarrierTrackingJitter shorter{};
+    ASSERT_TRUE(compute_carrier_tracking_jitter(short_integration, CarrierTrackingMode::kFllTrack, false, 35.0,
+                                                kL1WavelengthM, 0.1, &shorter, &error))
+        << error;
+    EXPECT_GT(shorter.sigma_hz, fll_mid.sigma_hz);
+
+    CarrierTrackingJitter short_wave{};
+    CarrierTrackingJitter long_wave{};
+    ASSERT_TRUE(compute_carrier_tracking_jitter(config, CarrierTrackingMode::kFllTrack, false, 35.0, 0.10, 0.1,
+                                                &short_wave, &error))
+        << error;
+    ASSERT_TRUE(compute_carrier_tracking_jitter(config, CarrierTrackingMode::kFllTrack, false, 35.0, 0.20, 0.1,
+                                                &long_wave, &error))
+        << error;
+    EXPECT_DOUBLE_EQ(short_wave.sigma_hz, long_wave.sigma_hz);
+    EXPECT_NEAR(long_wave.sigma_mps, 2.0 * short_wave.sigma_mps, 1e-15);
+}
+
+TEST(CarrierTracking, IdenticalInputsAndGaussianSequenceProduceIdenticalState) {
+    const CarrierTrackingConfig config = default_carrier_tracking_config();
+    CarrierTrackingState first{};
+    CarrierTrackingState second{};
+    reset_carrier_tracking_state(&first);
+    reset_carrier_tracking_state(&second);
+
+    const std::vector<double> cn0 = {25.0, 25.0, 25.0, 31.0, 31.0, 31.0, 31.0, 31.0,
+                                     31.0, 31.0, 31.0, 31.0, 31.0, 26.0, 26.0, 26.0};
+    const std::vector<double> gaussian = {0.1,  -0.3, 1.2,  0.4,  -0.7, 0.0, 0.9,  -1.1,
+                                          0.2, 0.5,  -0.4, 0.8,  0.3,  -0.2, 1.0,  -0.6};
+
+    for (std::size_t index = 0; index < cn0.size(); ++index) {
+        const CarrierTrackingResult first_result = step_tracker(config, &first, cn0[index], 0.1, gaussian[index]);
+        const CarrierTrackingResult second_result = step_tracker(config, &second, cn0[index], 0.1, gaussian[index]);
+        EXPECT_EQ(first_result.mode, second_result.mode);
+        EXPECT_EQ(first_result.fll_phase, second_result.fll_phase);
+        EXPECT_DOUBLE_EQ(first_result.tracking_error_hz, second_result.tracking_error_hz);
+        EXPECT_DOUBLE_EQ(first_result.tracking_error_mps, second_result.tracking_error_mps);
+        EXPECT_EQ(first_result.doppler_valid, second_result.doppler_valid);
+        EXPECT_EQ(first_result.adr_valid, second_result.adr_valid);
+        EXPECT_EQ(first_result.carrier_segment_id, second_result.carrier_segment_id);
+    }
+}
+
+TEST(CarrierTracking, SupportedExtremeCn0ValuesRemainFinite) {
+    const CarrierTrackingConfig config = default_carrier_tracking_config();
+    CarrierTrackingJitter low{};
+    CarrierTrackingJitter high{};
+    std::string error;
+
+    ASSERT_TRUE(compute_carrier_tracking_jitter(config, CarrierTrackingMode::kFllTrack, false, -100.0,
+                                                kL1WavelengthM, 0.1, &low, &error))
+        << error;
+    ASSERT_TRUE(compute_carrier_tracking_jitter(config, CarrierTrackingMode::kPllTrack, false, 100.0,
+                                                kL1WavelengthM, 0.1, &high, &error))
+        << error;
+
+    EXPECT_TRUE(std::isfinite(low.sigma_hz));
+    EXPECT_TRUE(std::isfinite(low.sigma_mps));
+    EXPECT_TRUE(std::isfinite(low.correlation_alpha));
+    EXPECT_TRUE(std::isfinite(high.sigma_hz));
+    EXPECT_TRUE(std::isfinite(high.sigma_mps));
+    EXPECT_TRUE(std::isfinite(high.correlation_alpha));
+}
+
+TEST(CarrierTracking, SignalUnavailableImmediatelyUnlocksAndClearsTrackingError) {
+    const CarrierTrackingConfig config = default_carrier_tracking_config();
+    CarrierTrackingState state{};
+    reset_carrier_tracking_state(&state);
+
+    step_tracker(config, &state, 30.0, 0.1, 1.0);
+    CarrierTrackingResult result = step_tracker(config, &state, 30.0, 0.1, 1.0);
+    ASSERT_EQ(result.mode, CarrierTrackingMode::kFllTrack);
+
+    result = step_tracker(config, &state, 30.0, 0.1, 1.0, false);
+    EXPECT_EQ(result.mode, CarrierTrackingMode::kCarrierUnlocked);
+    EXPECT_DOUBLE_EQ(result.tracking_error_hz, 0.0);
+    EXPECT_FALSE(result.doppler_valid);
+    EXPECT_FALSE(result.adr_valid);
+}
+
+} // namespace
+} // namespace gnss_sim


### PR DESCRIPTION
Closes #160
Parent: #159

## Scope
Standalone carrier-tracking core only. No simulator runtime wiring, no Doppler/range-rate/ADR observation mutation, no truth CSV changes, no NAV/EPH/ION changes.

## V1 defaults
- coherent integration: 20 ms
- PLL bandwidth: 5 Hz
- FLL steady/pull-in: 4/8 Hz, pull-in 0.5 s
- PLL enter/exit: 30/27 dB-Hz with 1.0/0.3 s persistence
- FLL acquire/loss: 22/18 dB-Hz with 0.2/0.5 s persistence
- Doppler-valid delay: 0.2 s
- ADR-valid-after-PLL delay: 1.0 s

## Model
- states: `CARRIER_UNLOCKED`, `FLL_TRACK`, `PLL_TRACK`;
- fresh acquisition uses FLL pull-in, PLL fallback uses steady FLL;
- FLL thermal jitter follows the standard differential-phase CN0/T/Bn form with explicit V1 discriminator factor F=1.0;
- PLL thermal phase jitter is CN0/T/Bn-driven and converted to an equivalent one-integration frequency scale;
- first-order tracking-error correlation uses `tau=1/(2*pi*Bn)`, `alpha=exp(-dt/tau)`;
- caller supplies explicit standard-normal input; core owns no RNG.

## Tests
Focused unit coverage for defaults/config validation, hysteresis/persistence, pull-in timing, Doppler/ADR validity timing, CN0/bandwidth/integration/wavelength jitter scaling, determinism, extreme finite CN0 handling, and signal-unavailable reset.

## Implementation Notes
`docs/CARRIER_TRACKING_CORE.md` records equations, units, assumptions, determinism contract and V1 exclusions.

## Final verification
Final head: `6629eac86a24dbfcbf825701a33c9ba2e85ccc57`
CI #747: fully green.
- format: success
- tooling: success
- Ubuntu full tests: success
- RANGEA positioning regression: success
- serialized-NAV positioning regression: success
- authentic-NAV urban E2E: success
- static urban Doppler validation: success
- Windows build/test: success

Final diff remains exactly five expected files: core `.h/.cpp`, focused unit test, CMake registration, and Implementation Notes. No simulator/runtime/NAV files changed.