### PR TITLE
Wire carrier tracking into runtime observations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ add_library(gnss_sim_core STATIC
     src/model/atmosphere_model.cpp
     src/model/bestpos_rtk_model.cpp
     src/model/carrier_tracking.cpp
+    src/model/carrier_tracking_runtime.cpp
     src/model/cn0_model.cpp
     src/model/code_correlation.cpp
     src/model/code_tracking_dll.cpp
@@ -243,6 +244,7 @@ if(BUILD_TESTING)
         tests/unit/test_atmosphere_model.cpp
         tests/unit/test_bestpos_rtk_model.cpp
         tests/unit/test_carrier_tracking.cpp
+        tests/unit/test_carrier_tracking_config.cpp
         tests/unit/test_cn0_model.cpp
         tests/unit/test_cn0_normalized_builder.cpp
         tests/unit/test_cn0_statistics.cpp
@@ -297,6 +299,7 @@ if(BUILD_TESTING)
     add_executable(gnss_sim_integration_tests
         tests/integration/test_scenarios.cpp
         tests/integration/test_all_signal_residuals.cpp
+        tests/integration/test_carrier_tracking_runtime.cpp
         tests/integration/test_measurement_noise_integration.cpp
         tests/integration/test_nav_equivalence.cpp
         tests/integration/test_rea_fade.cpp

--- a/docs/CARRIER_TRACKING_RUNTIME.md
+++ b/docs/CARRIER_TRACKING_RUNTIME.md
@@ -1,0 +1,157 @@
+# Carrier Tracking Runtime Integration
+
+This document records the Issue #161 runtime integration of the standalone carrier-tracking core from Issue #160.
+
+## Scope
+
+The runtime layer is deliberately separate from physical propagation. It does not recompute satellite geometry, reflections, diffraction, DLL roots, coherent received power, or the urban carrier path derivative.
+
+The observation chain is:
+
+```text
+clean authentic-NAV measurement
+        |
+        v
+urban physical propagation (when enabled)
+        |
+        |  range_rate += environmental_range_rate_mps
+        |  Doppler    -= environmental_range_rate_mps / wavelength
+        v
+physical observation / existing truth outputs
+        |
+        v
+receiver carrier tracker
+        |
+        |  Doppler    += carrier_tracking_error_hz
+        |  range_rate -= wavelength * carrier_tracking_error_hz
+        v
+reported observation
+        |
+        v
+existing generic measurement-error model (when enabled)
+```
+
+Therefore the `environmental_range_rate_mps` validated by Issue #152 remains an independent physical quantity. Carrier tracking does not replace or modify it.
+
+## Configuration
+
+Carrier tracking is explicitly opt-in:
+
+```json
+{
+  "carrier_tracking": {
+    "enabled": true,
+    "coherent_integration_sec": 0.020,
+    "pll_noise_bandwidth_hz": 5.0,
+    "fll_noise_bandwidth_hz": 4.0,
+    "fll_pull_in_bandwidth_hz": 8.0,
+    "fll_pull_in_duration_sec": 0.5,
+    "pll_enter_cn0_dbhz": 30.0,
+    "pll_exit_cn0_dbhz": 27.0,
+    "pll_enter_persistence_sec": 1.0,
+    "pll_exit_persistence_sec": 0.3,
+    "fll_enter_cn0_dbhz": 22.0,
+    "fll_exit_cn0_dbhz": 18.0,
+    "fll_enter_persistence_sec": 0.2,
+    "fll_exit_persistence_sec": 0.5,
+    "doppler_valid_delay_sec": 0.2,
+    "adr_valid_after_pll_sec": 1.0
+  }
+}
+```
+
+The default is `enabled=false`. All numerical parameters are still validated while disabled, so an invalid dormant configuration cannot silently become active later.
+
+## Effective C/N0 source
+
+The carrier tracker consumes the C/N0 already produced by the receiver signal chain:
+
+- urban/multipath enabled: `UrbanSignalEpochResult::effective_cn0_dbhz`;
+- open sky: `SignalTracker::cn0_dbhz`.
+
+No independent attenuation, fixed Doppler sigma, or target-PVT error term is introduced.
+
+## Time stepping
+
+Simulator output rates are 1, 5, 10, 20, or 50 Hz, while the frozen coherent integration interval is 20 ms. A carrier state machine update only once per output epoch would skip 0.2/0.3/0.5 s persistence boundaries at low output rates.
+
+The runtime therefore divides each elapsed output interval into substeps no larger than `coherent_integration_sec`. C/N0 is held constant during those substeps in V1. This preserves the configured persistence, FLL pull-in, Doppler-valid, and PLL/ADR timing semantics without pretending that new propagation samples exist between receiver output epochs.
+
+The first epoch on which code tracking is alive establishes the carrier runtime timestamp only. It does not retroactively advance carrier acquisition through an interval during which no carrier runtime state existed. Consequently Doppler is not restored instantly on the first code-tracking/reacquisition sample.
+
+## Per-signal RNG ownership
+
+Each satellite + signal owns an independent deterministic PCG stream derived from:
+
+- simulator seed;
+- satellite number;
+- central `SignalId`.
+
+The carrier runtime never advances `RuntimeState::rng`, which remains the pre-existing receiver startup/acquisition RNG. It also does not use the generic measurement-error noise stream/state.
+
+When `carrier_tracking.enabled=false`, the runtime does not call the carrier updater and consumes no carrier samples. Changing dormant carrier parameters therefore cannot reorder or perturb legacy receiver output.
+
+Power/signal/code-tracking hard resets clear carrier tracking and continuity state but intentionally retain that signal's independent RNG stream. This models a receiver channel whose random process continues deterministically while lock state is restarted, without coupling unrelated signals.
+
+## Doppler and range-rate sign convention
+
+The existing clean measurement convention is:
+
+```text
+D = -(range_rate - satellite_clock_drift) / wavelength
+```
+
+For carrier frequency error `e_f` in hertz, Issue #159 defines:
+
+```text
+D_measured = D_physical + e_f
+```
+
+The wavelength-consistent range-rate representation must therefore be:
+
+```text
+range_rate_measured = range_rate_physical - wavelength * e_f
+```
+
+The runtime applies both terms together. Pseudorange is not changed by the carrier-tracking layer.
+
+## Independent validity
+
+Carrier validity is ANDed with the already-existing code/urban validity rather than replacing it.
+
+- `PLL_TRACK`: Doppler can be valid after the carrier acquisition delay; ADR becomes valid only after the configured PLL confirmation age.
+- `FLL_TRACK`: pseudorange can remain valid; Doppler can remain valid; ADR is invalid.
+- `CARRIER_UNLOCKED`: pseudorange can remain valid while Doppler and ADR are invalid.
+- no code tracking / BLOCKED: no normal carrier result is emitted and carrier state is hard-reset.
+
+Thus code, Doppler, and ADR validity are intentionally independent.
+
+## PLL continuity and ambiguity segments
+
+The pre-existing `CarrierAmbiguityState` is keyed to code-tracker `tracking_start_time`. A PLL-to-FLL transition can break carrier-phase continuity while code tracking remains alive, so resetting that existing ambiguity object alone would regenerate the same integer ambiguity.
+
+Issue #161 therefore maintains a separate deterministic carrier phase-segment identifier. On the first transition from `PLL_TRACK` to a non-PLL state:
+
+1. ADR becomes invalid immediately through the #160 result;
+2. the phase-segment identifier increments;
+3. a deterministic non-zero integer cycle offset is derived from the per-signal ambiguity key and new segment id;
+4. when a later PLL segment satisfies the ADR-valid delay, that offset is added to both reported ADR cycles and the reported ambiguity-cycle field.
+
+The code tracker `tracking_start_time` is not falsified or rewritten. Power/signal/code loss already establishes a fresh code-tracking ambiguity and resets this carrier phase-segment overlay.
+
+## Truth boundary for Issue #161
+
+Existing truth files are intentionally written before the receiver carrier-tracking layer. This keeps the existing physical/urban truth schema stable and preserves the Issue #152 path-rate evidence chain.
+
+Issue #162 will add exact in-memory carrier-tracking diagnostics including mode, active bandwidth, theoretical sigma, actual tracking error, phase segment/cycle-slip status, and final carrier validity. Issue #161 does not change truth CSV schemas.
+
+## V1 exclusions
+
+This runtime work does not add:
+
+- receiver oscillator/common-mode phase noise;
+- moving receiver or reflector models;
+- IF/IQ/baseband samples;
+- arbitrary weak-signal Doppler noise;
+- PVT-target tuning;
+- any NAV/EPH/ION fabrication or modification.

--- a/include/gnss_sim/sim_config.h
+++ b/include/gnss_sim/sim_config.h
@@ -73,6 +73,25 @@ struct MeasurementErrorConfig {
     MeasurementFadeErrorConfig rea_fade;
 };
 
+struct CarrierTrackingReceiverConfig {
+    bool enabled;
+    double coherent_integration_sec;
+    double pll_noise_bandwidth_hz;
+    double fll_noise_bandwidth_hz;
+    double fll_pull_in_bandwidth_hz;
+    double fll_pull_in_duration_sec;
+    double pll_enter_cn0_dbhz;
+    double pll_exit_cn0_dbhz;
+    double pll_enter_persistence_sec;
+    double pll_exit_persistence_sec;
+    double fll_enter_cn0_dbhz;
+    double fll_exit_cn0_dbhz;
+    double fll_enter_persistence_sec;
+    double fll_exit_persistence_sec;
+    double doppler_valid_delay_sec;
+    double adr_valid_after_pll_sec;
+};
+
 struct UrbanRfMaterialConfig {
     double relative_permittivity_real;
     double conductivity_c_s_per_m;
@@ -135,6 +154,7 @@ struct SimConfig {
     ReaConfig rea;
     BestposRtkConfig bestpos_rtk;
     MeasurementErrorConfig measurement_error;
+    CarrierTrackingReceiverConfig carrier_tracking;
     UrbanRfConfig urban_rf;
     std::vector<Cn0HighBaselineConfig> cn0_high_dbhz;
     std::uint64_t seed;

--- a/src/core/sim_config.cpp
+++ b/src/core/sim_config.cpp
@@ -357,22 +357,18 @@ bool parse_carrier_tracking(const cJSON* root, SimConfig* config, std::string* e
            read_optional_number(object, "coherent_integration_sec", &carrier.coherent_integration_sec, error_message) &&
            read_optional_number(object, "pll_noise_bandwidth_hz", &carrier.pll_noise_bandwidth_hz, error_message) &&
            read_optional_number(object, "fll_noise_bandwidth_hz", &carrier.fll_noise_bandwidth_hz, error_message) &&
-           read_optional_number(object, "fll_pull_in_bandwidth_hz", &carrier.fll_pull_in_bandwidth_hz,
-                                error_message) &&
-           read_optional_number(object, "fll_pull_in_duration_sec", &carrier.fll_pull_in_duration_sec,
-                                error_message) &&
+           read_optional_number(object, "fll_pull_in_bandwidth_hz", &carrier.fll_pull_in_bandwidth_hz, error_message) &&
+           read_optional_number(object, "fll_pull_in_duration_sec", &carrier.fll_pull_in_duration_sec, error_message) &&
            read_optional_number(object, "pll_enter_cn0_dbhz", &carrier.pll_enter_cn0_dbhz, error_message) &&
            read_optional_number(object, "pll_exit_cn0_dbhz", &carrier.pll_exit_cn0_dbhz, error_message) &&
            read_optional_number(object, "pll_enter_persistence_sec", &carrier.pll_enter_persistence_sec,
                                 error_message) &&
-           read_optional_number(object, "pll_exit_persistence_sec", &carrier.pll_exit_persistence_sec,
-                                error_message) &&
+           read_optional_number(object, "pll_exit_persistence_sec", &carrier.pll_exit_persistence_sec, error_message) &&
            read_optional_number(object, "fll_enter_cn0_dbhz", &carrier.fll_enter_cn0_dbhz, error_message) &&
            read_optional_number(object, "fll_exit_cn0_dbhz", &carrier.fll_exit_cn0_dbhz, error_message) &&
            read_optional_number(object, "fll_enter_persistence_sec", &carrier.fll_enter_persistence_sec,
                                 error_message) &&
-           read_optional_number(object, "fll_exit_persistence_sec", &carrier.fll_exit_persistence_sec,
-                                error_message) &&
+           read_optional_number(object, "fll_exit_persistence_sec", &carrier.fll_exit_persistence_sec, error_message) &&
            read_optional_number(object, "doppler_valid_delay_sec", &carrier.doppler_valid_delay_sec, error_message) &&
            read_optional_number(object, "adr_valid_after_pll_sec", &carrier.adr_valid_after_pll_sec, error_message);
 }
@@ -867,9 +863,10 @@ bool load_sim_config_json(const char* file_path, SimConfig* config, std::string*
             parse_atmosphere_mode(atmosphere_name, &parsed.atmosphere_mode, error_message) &&
             parse_receiver(root, &parsed, error_message) && parse_ttff(root, &parsed, error_message) &&
             parse_rea(root, &parsed, error_message) && parse_bestpos_rtk(root, &parsed, error_message) &&
-            parse_measurement_error(root, &parsed, error_message) && parse_carrier_tracking(root, &parsed, error_message) &&
-            parse_urban_rf(root, &parsed, error_message) && parse_cn0_high_dbhz(root, &parsed, error_message) &&
-            parse_seed(root, &parsed, error_message) && validate_sim_config(parsed, error_message);
+            parse_measurement_error(root, &parsed, error_message) &&
+            parse_carrier_tracking(root, &parsed, error_message) && parse_urban_rf(root, &parsed, error_message) &&
+            parse_cn0_high_dbhz(root, &parsed, error_message) && parse_seed(root, &parsed, error_message) &&
+            validate_sim_config(parsed, error_message);
     }
 
     cJSON_Delete(root);

--- a/src/core/sim_config.cpp
+++ b/src/core/sim_config.cpp
@@ -2,6 +2,7 @@
 
 #include "gnss/signal_definitions.h"
 #include "gnss_sim/sim_time.h"
+#include "model/carrier_tracking.h"
 
 #include <cJSON.h>
 #include <cmath>
@@ -327,6 +328,55 @@ bool parse_measurement_error(const cJSON* root, SimConfig* config, std::string* 
            parse_measurement_fade(object, &config->measurement_error.rea_fade, error_message);
 }
 
+bool parse_carrier_tracking(const cJSON* root, SimConfig* config, std::string* error_message) {
+    const cJSON* object = cJSON_GetObjectItemCaseSensitive(root, "carrier_tracking");
+    if (object == nullptr) {
+        return true;
+    }
+    const char* const allowed_keys[] = {"enabled",
+                                        "coherent_integration_sec",
+                                        "pll_noise_bandwidth_hz",
+                                        "fll_noise_bandwidth_hz",
+                                        "fll_pull_in_bandwidth_hz",
+                                        "fll_pull_in_duration_sec",
+                                        "pll_enter_cn0_dbhz",
+                                        "pll_exit_cn0_dbhz",
+                                        "pll_enter_persistence_sec",
+                                        "pll_exit_persistence_sec",
+                                        "fll_enter_cn0_dbhz",
+                                        "fll_exit_cn0_dbhz",
+                                        "fll_enter_persistence_sec",
+                                        "fll_exit_persistence_sec",
+                                        "doppler_valid_delay_sec",
+                                        "adr_valid_after_pll_sec"};
+    if (!validate_object_keys(object, "carrier_tracking", allowed_keys, 16U, error_message)) {
+        return false;
+    }
+    CarrierTrackingReceiverConfig& carrier = config->carrier_tracking;
+    return read_optional_bool(object, "enabled", &carrier.enabled, error_message) &&
+           read_optional_number(object, "coherent_integration_sec", &carrier.coherent_integration_sec, error_message) &&
+           read_optional_number(object, "pll_noise_bandwidth_hz", &carrier.pll_noise_bandwidth_hz, error_message) &&
+           read_optional_number(object, "fll_noise_bandwidth_hz", &carrier.fll_noise_bandwidth_hz, error_message) &&
+           read_optional_number(object, "fll_pull_in_bandwidth_hz", &carrier.fll_pull_in_bandwidth_hz,
+                                error_message) &&
+           read_optional_number(object, "fll_pull_in_duration_sec", &carrier.fll_pull_in_duration_sec,
+                                error_message) &&
+           read_optional_number(object, "pll_enter_cn0_dbhz", &carrier.pll_enter_cn0_dbhz, error_message) &&
+           read_optional_number(object, "pll_exit_cn0_dbhz", &carrier.pll_exit_cn0_dbhz, error_message) &&
+           read_optional_number(object, "pll_enter_persistence_sec", &carrier.pll_enter_persistence_sec,
+                                error_message) &&
+           read_optional_number(object, "pll_exit_persistence_sec", &carrier.pll_exit_persistence_sec,
+                                error_message) &&
+           read_optional_number(object, "fll_enter_cn0_dbhz", &carrier.fll_enter_cn0_dbhz, error_message) &&
+           read_optional_number(object, "fll_exit_cn0_dbhz", &carrier.fll_exit_cn0_dbhz, error_message) &&
+           read_optional_number(object, "fll_enter_persistence_sec", &carrier.fll_enter_persistence_sec,
+                                error_message) &&
+           read_optional_number(object, "fll_exit_persistence_sec", &carrier.fll_exit_persistence_sec,
+                                error_message) &&
+           read_optional_number(object, "doppler_valid_delay_sec", &carrier.doppler_valid_delay_sec, error_message) &&
+           read_optional_number(object, "adr_valid_after_pll_sec", &carrier.adr_valid_after_pll_sec, error_message);
+}
+
 bool parse_urban_rf_material(const cJSON* object, const char* section_name, UrbanRfMaterialConfig* config,
                              std::string* error_message) {
     if (object == nullptr) {
@@ -492,6 +542,26 @@ bool parse_seed(const cJSON* root, SimConfig* config, std::string* error_message
     return true;
 }
 
+CarrierTrackingConfig to_carrier_tracking_config(const CarrierTrackingReceiverConfig& config) {
+    CarrierTrackingConfig output{};
+    output.coherent_integration_sec = config.coherent_integration_sec;
+    output.pll_noise_bandwidth_hz = config.pll_noise_bandwidth_hz;
+    output.fll_noise_bandwidth_hz = config.fll_noise_bandwidth_hz;
+    output.fll_pull_in_bandwidth_hz = config.fll_pull_in_bandwidth_hz;
+    output.fll_pull_in_duration_sec = config.fll_pull_in_duration_sec;
+    output.pll_enter_cn0_dbhz = config.pll_enter_cn0_dbhz;
+    output.pll_exit_cn0_dbhz = config.pll_exit_cn0_dbhz;
+    output.pll_enter_persistence_sec = config.pll_enter_persistence_sec;
+    output.pll_exit_persistence_sec = config.pll_exit_persistence_sec;
+    output.fll_enter_cn0_dbhz = config.fll_enter_cn0_dbhz;
+    output.fll_exit_cn0_dbhz = config.fll_exit_cn0_dbhz;
+    output.fll_enter_persistence_sec = config.fll_enter_persistence_sec;
+    output.fll_exit_persistence_sec = config.fll_exit_persistence_sec;
+    output.doppler_valid_delay_sec = config.doppler_valid_delay_sec;
+    output.adr_valid_after_pll_sec = config.adr_valid_after_pll_sec;
+    return output;
+}
+
 bool finite_nonnegative(double value) {
     return std::isfinite(value) && value >= 0.0;
 }
@@ -615,6 +685,23 @@ SimConfig default_sim_config() {
                                 {0.70, 0.15, 2.5, 2.0},
                                 {0.40, 0.10, 1.5, 0.8},
                                 {0.25, 0.80, 0.20, 4.5}};
+    const CarrierTrackingConfig carrier = default_carrier_tracking_config();
+    config.carrier_tracking = {false,
+                               carrier.coherent_integration_sec,
+                               carrier.pll_noise_bandwidth_hz,
+                               carrier.fll_noise_bandwidth_hz,
+                               carrier.fll_pull_in_bandwidth_hz,
+                               carrier.fll_pull_in_duration_sec,
+                               carrier.pll_enter_cn0_dbhz,
+                               carrier.pll_exit_cn0_dbhz,
+                               carrier.pll_enter_persistence_sec,
+                               carrier.pll_exit_persistence_sec,
+                               carrier.fll_enter_cn0_dbhz,
+                               carrier.fll_exit_cn0_dbhz,
+                               carrier.fll_enter_persistence_sec,
+                               carrier.fll_exit_persistence_sec,
+                               carrier.doppler_valid_delay_sec,
+                               carrier.adr_valid_after_pll_sec};
     config.urban_rf.default_material = {6.27, 0.0043, 1.1925, 0.006, 0.012, 0.006, 5.0};
     config.urban_rf.default_antenna = {{0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0}};
     config.seed = 1U;
@@ -651,6 +738,11 @@ bool validate_sim_config(const SimConfig& config, std::string* error_message) {
     }
     if (!valid_measurement_error_config(config.measurement_error)) {
         set_error(error_message, "measurement_error configuration is invalid");
+        return false;
+    }
+    std::string carrier_error;
+    if (!validate_carrier_tracking_config(to_carrier_tracking_config(config.carrier_tracking), &carrier_error)) {
+        set_error(error_message, std::string("carrier_tracking configuration is invalid: ") + carrier_error);
         return false;
     }
     if (!valid_urban_rf_config(config.urban_rf)) {
@@ -730,6 +822,7 @@ bool load_sim_config_json(const char* file_path, SimConfig* config, std::string*
                                         "measurement_noise_enabled",
                                         "bestpos_rtk",
                                         "measurement_error",
+                                        "carrier_tracking",
                                         "urban_rf",
                                         "cn0_high_dbhz",
                                         "multipath_enabled",
@@ -742,7 +835,7 @@ bool load_sim_config_json(const char* file_path, SimConfig* config, std::string*
                                         "seed"};
 
     SimConfig parsed = default_sim_config();
-    bool success = validate_object_keys(root, "root", allowed_keys, 21U, error_message);
+    bool success = validate_object_keys(root, "root", allowed_keys, 22U, error_message);
 
     double duration_sec = static_cast<double>(parsed.duration_ns) / static_cast<double>(NANOSECONDS_PER_SECOND);
     const char* scenario_name = scenario_type_name(parsed.scenario);
@@ -774,9 +867,9 @@ bool load_sim_config_json(const char* file_path, SimConfig* config, std::string*
             parse_atmosphere_mode(atmosphere_name, &parsed.atmosphere_mode, error_message) &&
             parse_receiver(root, &parsed, error_message) && parse_ttff(root, &parsed, error_message) &&
             parse_rea(root, &parsed, error_message) && parse_bestpos_rtk(root, &parsed, error_message) &&
-            parse_measurement_error(root, &parsed, error_message) && parse_urban_rf(root, &parsed, error_message) &&
-            parse_cn0_high_dbhz(root, &parsed, error_message) && parse_seed(root, &parsed, error_message) &&
-            validate_sim_config(parsed, error_message);
+            parse_measurement_error(root, &parsed, error_message) && parse_carrier_tracking(root, &parsed, error_message) &&
+            parse_urban_rf(root, &parsed, error_message) && parse_cn0_high_dbhz(root, &parsed, error_message) &&
+            parse_seed(root, &parsed, error_message) && validate_sim_config(parsed, error_message);
     }
 
     cJSON_Delete(root);

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -452,7 +452,7 @@ AcquisitionContext startup_context(StartupMode mode) {
 }
 
 MeasurementErrorContext measurement_error_context(const SimConfig& config, const ScenarioEpochState& scenario,
-                                                  const SignalTracker& tracker) {
+                                                   const SignalTracker& tracker) {
     MeasurementErrorContext context{};
     context.phase = MeasurementErrorPhase::kStable;
     context.rea_fade_progress = 0.0;
@@ -1006,10 +1006,10 @@ bool update_tracking_and_measurements(RuntimeState* runtime, const SimConfig& co
                                                  &reported_observation, error_message)) {
                         return false;
                     }
-                } else if (!apply_measurement_error(
-                               config.measurement_error, config.seed,
-                               measurement_error_context(config, scenario, signal.tracker), signal.tracker, observation,
-                               &signal.measurement_error, &reported_observation, error_message)) {
+                } else if (!apply_measurement_error(config.measurement_error, config.seed,
+                                                    measurement_error_context(config, scenario, signal.tracker),
+                                                    signal.tracker, observation, &signal.measurement_error,
+                                                    &reported_observation, error_message)) {
                     return false;
                 }
             }

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -11,6 +11,7 @@
 #include "gnss_sim/sim_time.h"
 #include "model/atmosphere_model.h"
 #include "model/bestpos_rtk_model.h"
+#include "model/carrier_tracking_runtime.h"
 #include "model/cn0_model.h"
 #include "model/code_tracking_dll.h"
 #include "model/measurement_error_model.h"
@@ -54,6 +55,7 @@ struct SignalRuntime {
     CarrierAmbiguityState ambiguity;
     MeasurementErrorState measurement_error;
     UrbanCarrierTemporalState urban_carrier_temporal;
+    CarrierTrackingRuntimeState carrier_tracking;
     bool ever_scheduled;
 };
 
@@ -310,7 +312,8 @@ ColdFamilyRuntime* cold_family_state(SatelliteRuntime* satellite, NavMessageFami
 }
 
 bool build_satellite_runtimes(const std::vector<TruthScheduleEntry>& schedule, const SimTime& reset_time,
-                              std::vector<SatelliteRuntime>* satellites, std::string* error_message) {
+                              std::uint64_t simulator_seed, std::vector<SatelliteRuntime>* satellites,
+                              std::string* error_message) {
     if (satellites == nullptr) {
         set_error(error_message, "satellite runtime output is null");
         return false;
@@ -341,6 +344,8 @@ bool build_satellite_runtimes(const std::vector<TruthScheduleEntry>& schedule, c
             reset_signal_tracker(&signal.tracker, definitions[index].signal_id, reset_time);
             reset_carrier_ambiguity_state(&signal.ambiguity);
             reset_urban_carrier_temporal_state(&signal.urban_carrier_temporal);
+            initialize_carrier_tracking_runtime_state(simulator_seed, satellite_number, definitions[index].signal_id,
+                                                      &signal.carrier_tracking);
             satellite.signals.push_back(signal);
         }
         for (const TruthScheduleEntry& entry : schedule) {
@@ -509,6 +514,7 @@ bool receiver_power_on(RuntimeState* runtime, const SimConfig& config, const Sim
             reset_carrier_ambiguity_state(&signal.ambiguity);
             reset_measurement_error_state(&signal.measurement_error);
             reset_urban_carrier_temporal_state(&signal.urban_carrier_temporal);
+            reset_carrier_tracking_runtime_state(&signal.carrier_tracking);
             signal.ever_scheduled = false;
         }
         for (ColdFamilyRuntime& family : satellite.cold_families) {
@@ -534,6 +540,7 @@ void receiver_power_off(RuntimeState* runtime, const SimTime& time) {
             reset_carrier_ambiguity_state(&signal.ambiguity);
             reset_measurement_error_state(&signal.measurement_error);
             reset_urban_carrier_temporal_state(&signal.urban_carrier_temporal);
+            reset_carrier_tracking_runtime_state(&signal.carrier_tracking);
         }
     }
 }
@@ -546,6 +553,7 @@ void receiver_signal_off(RuntimeState* runtime, const SimTime& time) {
             reset_carrier_ambiguity_state(&signal.ambiguity);
             reset_measurement_error_state(&signal.measurement_error);
             reset_urban_carrier_temporal_state(&signal.urban_carrier_temporal);
+            reset_carrier_tracking_runtime_state(&signal.carrier_tracking);
         }
     }
 }
@@ -936,9 +944,26 @@ bool update_tracking_and_measurements(RuntimeState* runtime, const SimConfig& co
                 }
                 reset_carrier_ambiguity_state(&signal.ambiguity);
                 reset_measurement_error_state(&signal.measurement_error);
+                reset_carrier_tracking_runtime_state(&signal.carrier_tracking);
                 continue;
             }
             satellite_tracking = true;
+
+            CarrierTrackingRuntimeResult carrier_result{};
+            if (config.carrier_tracking.enabled) {
+                double wavelength_m = 0.0;
+                if (!signal_wavelength_m(*definition, glonass_fcn, &wavelength_m)) {
+                    set_error(error_message, "cannot determine carrier tracking signal wavelength");
+                    return false;
+                }
+                const double carrier_cn0_dbhz =
+                    config.multipath_enabled ? urban_epoch.effective_cn0_dbhz : signal.tracker.cn0_dbhz;
+                if (!update_carrier_tracking_runtime(config.carrier_tracking, scenario.time, true, carrier_cn0_dbhz,
+                                                     wavelength_m, &signal.carrier_tracking, &carrier_result,
+                                                     error_message)) {
+                    return false;
+                }
+            }
 
             AtmosphereCorrection atmosphere{};
             if (!compute_atmosphere_correction(config.atmosphere_mode, truth_nav, scenario.time,
@@ -968,11 +993,25 @@ bool update_tracking_and_measurements(RuntimeState* runtime, const SimConfig& co
                 return false;
             }
             MeasurementObservation reported_observation = observation;
-            if (config.measurement_noise_enabled &&
-                !apply_measurement_error(
-                    config.measurement_error, config.seed, measurement_error_context(config, scenario, signal.tracker),
-                    signal.tracker, observation, &signal.measurement_error, &reported_observation, error_message)) {
+            if (config.carrier_tracking.enabled &&
+                !apply_carrier_tracking_runtime_result(carrier_result, &reported_observation, error_message)) {
                 return false;
+            }
+            if (config.measurement_noise_enabled) {
+                if (config.carrier_tracking.enabled) {
+                    const MeasurementObservation measurement_error_input = reported_observation;
+                    if (!apply_measurement_error(config.measurement_error, config.seed,
+                                                 measurement_error_context(config, scenario, signal.tracker),
+                                                 signal.tracker, measurement_error_input, &signal.measurement_error,
+                                                 &reported_observation, error_message)) {
+                        return false;
+                    }
+                } else if (!apply_measurement_error(
+                               config.measurement_error, config.seed,
+                               measurement_error_context(config, scenario, signal.tracker), signal.tracker, observation,
+                               &signal.measurement_error, &reported_observation, error_message)) {
+                    return false;
+                }
             }
             measurements->push_back(reported_observation);
         }
@@ -1055,7 +1094,8 @@ bool run_simulator(const SimConfig& config, const SimulatorRunOptions& options, 
         load_truth_navigation(runtime.navigation, options.rinex_nav_path, error_message) &&
         make_static_receiver_truth(config.receiver, &runtime.receiver, error_message) &&
         build_truth_schedule(truth_navigation_store(runtime.navigation), &runtime.truth_schedule, error_message) &&
-        build_satellite_runtimes(runtime.truth_schedule, options.start_time, &runtime.satellites, error_message);
+        build_satellite_runtimes(runtime.truth_schedule, options.start_time, config.seed, &runtime.satellites,
+                                 error_message);
     if (!ok) {
         destroy_navigation_state(runtime.navigation);
         return false;

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -452,7 +452,7 @@ AcquisitionContext startup_context(StartupMode mode) {
 }
 
 MeasurementErrorContext measurement_error_context(const SimConfig& config, const ScenarioEpochState& scenario,
-                                                   const SignalTracker& tracker) {
+                                                  const SignalTracker& tracker) {
     MeasurementErrorContext context{};
     context.phase = MeasurementErrorPhase::kStable;
     context.rea_fade_progress = 0.0;

--- a/src/model/carrier_tracking_runtime.cpp
+++ b/src/model/carrier_tracking_runtime.cpp
@@ -1,0 +1,240 @@
+#include "model/carrier_tracking_runtime.h"
+
+#include "gnss_sim/sim_time.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace gnss_sim {
+namespace {
+
+constexpr double kTwoPi = 6.283185307179586476925286766559;
+constexpr double kMinimumUniform = 1.0 / 9007199254740992.0;
+constexpr double kNegativeInfinityCn0FloorDbhz = -120.0;
+constexpr std::uint64_t kSatelliteSalt = 0x9E3779B97F4A7C15ULL;
+constexpr std::uint64_t kSignalSalt = 0xBF58476D1CE4E5B9ULL;
+constexpr std::uint64_t kSequenceSalt = 0x94D049BB133111EBULL;
+constexpr std::uint64_t kAmbiguitySalt = 0xD6E8FEB86659FD93ULL;
+
+void set_error(std::string* error_message, const char* message) {
+    if (error_message != nullptr) {
+        *error_message = message;
+    }
+}
+
+std::uint64_t mix64(std::uint64_t value) {
+    value += 0x9E3779B97F4A7C15ULL;
+    value = (value ^ (value >> 30U)) * 0xBF58476D1CE4E5B9ULL;
+    value = (value ^ (value >> 27U)) * 0x94D049BB133111EBULL;
+    return value ^ (value >> 31U);
+}
+
+std::uint64_t signal_key(std::uint64_t simulator_seed, int satellite_number, SignalId signal_id) {
+    const std::uint64_t satellite = static_cast<std::uint64_t>(static_cast<std::uint32_t>(satellite_number));
+    const std::uint64_t signal = static_cast<std::uint64_t>(signal_id);
+    return mix64(simulator_seed ^ mix64(satellite + kSatelliteSalt) ^ mix64(signal + kSignalSalt));
+}
+
+double standard_normal_sample(DeterministicRng* rng) {
+    const double u1 = std::max(rng_uniform_01(rng), kMinimumUniform);
+    const double u2 = rng_uniform_01(rng);
+    return std::sqrt(-2.0 * std::log(u1)) * std::cos(kTwoPi * u2);
+}
+
+std::int64_t segment_cycle_offset(std::uint64_t ambiguity_key, std::uint64_t segment_id) {
+    if (segment_id == 0U) {
+        return 0;
+    }
+    const std::uint64_t mixed = mix64(ambiguity_key ^ mix64(segment_id + kAmbiguitySalt));
+    constexpr std::int64_t kSpan = 200001;
+    std::int64_t offset = static_cast<std::int64_t>(mixed % static_cast<std::uint64_t>(kSpan)) - 100000;
+    if (offset == 0) {
+        offset = 1;
+    }
+    return offset;
+}
+
+void fill_runtime_result(const CarrierTrackingRuntimeState& state, const CarrierTrackingResult& tracking,
+                         bool cycle_slip_event, CarrierTrackingRuntimeResult* result) {
+    result->tracking = tracking;
+    result->phase_segment_id = state.phase_segment_id;
+    result->adr_cycle_offset_cycles = state.adr_cycle_offset_cycles;
+    result->cycle_slip_event = cycle_slip_event;
+}
+
+CarrierTrackingResult unlocked_result(const CarrierTrackingRuntimeState& state) {
+    CarrierTrackingResult result{};
+    result.mode = CarrierTrackingMode::kCarrierUnlocked;
+    result.fll_phase = CarrierTrackingFllPhase::kNone;
+    result.carrier_segment_id = state.tracking.carrier_segment_id;
+    return result;
+}
+
+double normalized_cn0(double effective_cn0_dbhz) {
+    if (std::isinf(effective_cn0_dbhz) && effective_cn0_dbhz < 0.0) {
+        return kNegativeInfinityCn0FloorDbhz;
+    }
+    return effective_cn0_dbhz;
+}
+
+} // namespace
+
+CarrierTrackingConfig carrier_tracking_core_config(const CarrierTrackingReceiverConfig& config) {
+    CarrierTrackingConfig output{};
+    output.coherent_integration_sec = config.coherent_integration_sec;
+    output.pll_noise_bandwidth_hz = config.pll_noise_bandwidth_hz;
+    output.fll_noise_bandwidth_hz = config.fll_noise_bandwidth_hz;
+    output.fll_pull_in_bandwidth_hz = config.fll_pull_in_bandwidth_hz;
+    output.fll_pull_in_duration_sec = config.fll_pull_in_duration_sec;
+    output.pll_enter_cn0_dbhz = config.pll_enter_cn0_dbhz;
+    output.pll_exit_cn0_dbhz = config.pll_exit_cn0_dbhz;
+    output.pll_enter_persistence_sec = config.pll_enter_persistence_sec;
+    output.pll_exit_persistence_sec = config.pll_exit_persistence_sec;
+    output.fll_enter_cn0_dbhz = config.fll_enter_cn0_dbhz;
+    output.fll_exit_cn0_dbhz = config.fll_exit_cn0_dbhz;
+    output.fll_enter_persistence_sec = config.fll_enter_persistence_sec;
+    output.fll_exit_persistence_sec = config.fll_exit_persistence_sec;
+    output.doppler_valid_delay_sec = config.doppler_valid_delay_sec;
+    output.adr_valid_after_pll_sec = config.adr_valid_after_pll_sec;
+    return output;
+}
+
+void initialize_carrier_tracking_runtime_state(std::uint64_t simulator_seed, int satellite_number, SignalId signal_id,
+                                               CarrierTrackingRuntimeState* state) {
+    if (state == nullptr) {
+        return;
+    }
+    *state = CarrierTrackingRuntimeState{};
+    const std::uint64_t key = signal_key(simulator_seed, satellite_number, signal_id);
+    seed_rng(&state->rng, key, mix64(key ^ kSequenceSalt));
+    state->ambiguity_key = mix64(key ^ kAmbiguitySalt);
+    state->initialized = true;
+    reset_carrier_tracking_state(&state->tracking);
+}
+
+void reset_carrier_tracking_runtime_state(CarrierTrackingRuntimeState* state) {
+    if (state == nullptr || !state->initialized) {
+        return;
+    }
+    reset_carrier_tracking_state(&state->tracking);
+    state->last_update_time = SimTime{};
+    state->phase_segment_id = 0U;
+    state->adr_cycle_offset_cycles = 0;
+    state->time_initialized = false;
+}
+
+bool update_carrier_tracking_runtime(const CarrierTrackingReceiverConfig& config, const SimTime& current_time,
+                                     bool code_tracking, double effective_cn0_dbhz, double wavelength_m,
+                                     CarrierTrackingRuntimeState* state, CarrierTrackingRuntimeResult* result,
+                                     std::string* error_message) {
+    if (state == nullptr || result == nullptr || !state->initialized) {
+        set_error(error_message, "carrier tracking runtime state/result is invalid");
+        return false;
+    }
+    *result = CarrierTrackingRuntimeResult{};
+    const CarrierTrackingConfig core_config = carrier_tracking_core_config(config);
+    if (!validate_carrier_tracking_config(core_config, error_message)) {
+        return false;
+    }
+    if (!std::isfinite(wavelength_m) || wavelength_m <= 0.0) {
+        set_error(error_message, "carrier tracking runtime wavelength must be finite and positive");
+        return false;
+    }
+    const double cn0_dbhz = normalized_cn0(effective_cn0_dbhz);
+    if (!std::isfinite(cn0_dbhz)) {
+        set_error(error_message, "carrier tracking runtime effective CN0 is invalid");
+        return false;
+    }
+
+    if (!code_tracking) {
+        reset_carrier_tracking_runtime_state(state);
+        fill_runtime_result(*state, unlocked_result(*state), false, result);
+        return true;
+    }
+
+    if (!state->time_initialized) {
+        state->last_update_time = current_time;
+        state->time_initialized = true;
+        fill_runtime_result(*state, unlocked_result(*state), false, result);
+        return true;
+    }
+
+    std::int64_t elapsed_ns = 0;
+    if (!difference_time_ns(current_time, state->last_update_time, &elapsed_ns) || elapsed_ns <= 0) {
+        set_error(error_message, "carrier tracking runtime time must advance monotonically");
+        return false;
+    }
+
+    double remaining_sec = static_cast<double>(elapsed_ns) / static_cast<double>(NANOSECONDS_PER_SECOND);
+    CarrierTrackingResult tracking = unlocked_result(*state);
+    bool cycle_slip_event = false;
+    while (remaining_sec > 0.0) {
+        const double dt_sec = std::min(remaining_sec, core_config.coherent_integration_sec);
+        const CarrierTrackingMode previous_mode = state->tracking.mode;
+        CarrierTrackingInput input{};
+        input.signal_available = true;
+        input.effective_cn0_dbhz = cn0_dbhz;
+        input.wavelength_m = wavelength_m;
+        input.dt_sec = dt_sec;
+        input.standard_normal_sample = standard_normal_sample(&state->rng);
+        if (!update_carrier_tracking(core_config, input, &state->tracking, &tracking, error_message)) {
+            return false;
+        }
+        if (previous_mode == CarrierTrackingMode::kPllTrack && tracking.mode != CarrierTrackingMode::kPllTrack) {
+            ++state->phase_segment_id;
+            state->adr_cycle_offset_cycles = segment_cycle_offset(state->ambiguity_key, state->phase_segment_id);
+            cycle_slip_event = true;
+        }
+        remaining_sec -= dt_sec;
+        if (remaining_sec < std::numeric_limits<double>::epsilon()) {
+            remaining_sec = 0.0;
+        }
+    }
+
+    state->last_update_time = current_time;
+    fill_runtime_result(*state, tracking, cycle_slip_event, result);
+    return true;
+}
+
+bool apply_carrier_tracking_runtime_result(const CarrierTrackingRuntimeResult& carrier,
+                                           MeasurementObservation* observation, std::string* error_message) {
+    if (observation == nullptr || !std::isfinite(observation->wavelength_m) || observation->wavelength_m <= 0.0 ||
+        !std::isfinite(observation->range_rate_mps) || !std::isfinite(observation->doppler_hz) ||
+        !std::isfinite(observation->adr_cycles) || !std::isfinite(carrier.tracking.tracking_error_hz) ||
+        !std::isfinite(carrier.tracking.tracking_error_mps)) {
+        set_error(error_message, "carrier tracking measurement application has invalid arguments");
+        return false;
+    }
+
+    MeasurementObservation output = *observation;
+    if (carrier.tracking.mode != CarrierTrackingMode::kCarrierUnlocked) {
+        output.doppler_hz += carrier.tracking.tracking_error_hz;
+        output.range_rate_mps -= carrier.tracking.tracking_error_mps;
+    }
+
+    output.doppler_valid = output.doppler_valid && carrier.tracking.doppler_valid;
+    output.adr_valid = output.adr_valid && carrier.tracking.adr_valid;
+    if (output.adr_valid) {
+        if ((carrier.adr_cycle_offset_cycles > 0 &&
+             output.ambiguity_cycles > std::numeric_limits<std::int64_t>::max() - carrier.adr_cycle_offset_cycles) ||
+            (carrier.adr_cycle_offset_cycles < 0 &&
+             output.ambiguity_cycles < std::numeric_limits<std::int64_t>::min() - carrier.adr_cycle_offset_cycles)) {
+            set_error(error_message, "carrier tracking ambiguity offset overflow");
+            return false;
+        }
+        output.ambiguity_cycles += carrier.adr_cycle_offset_cycles;
+        output.adr_cycles += static_cast<double>(carrier.adr_cycle_offset_cycles);
+    }
+
+    if (!output.observation_available) {
+        output.pseudorange_valid = false;
+        output.doppler_valid = false;
+        output.adr_valid = false;
+    }
+
+    *observation = output;
+    return true;
+}
+
+} // namespace gnss_sim

--- a/src/model/carrier_tracking_runtime.h
+++ b/src/model/carrier_tracking_runtime.h
@@ -1,0 +1,61 @@
+#ifndef GNSS_SIM_SRC_MODEL_CARRIER_TRACKING_RUNTIME_H_
+#define GNSS_SIM_SRC_MODEL_CARRIER_TRACKING_RUNTIME_H_
+
+#include "core/deterministic_rng.h"
+#include "gnss_sim/sim_config.h"
+#include "gnss_sim/sim_types.h"
+#include "model/carrier_tracking.h"
+#include "model/measurement_model.h"
+
+#include <cstdint>
+#include <string>
+
+namespace gnss_sim {
+
+struct CarrierTrackingRuntimeState {
+    CarrierTrackingState tracking;
+    DeterministicRng rng;
+    SimTime last_update_time;
+    std::uint64_t ambiguity_key;
+    std::uint64_t phase_segment_id;
+    std::int64_t adr_cycle_offset_cycles;
+    bool initialized;
+    bool time_initialized;
+};
+
+struct CarrierTrackingRuntimeResult {
+    CarrierTrackingResult tracking;
+    std::uint64_t phase_segment_id;
+    std::int64_t adr_cycle_offset_cycles;
+    bool cycle_slip_event;
+};
+
+CarrierTrackingConfig carrier_tracking_core_config(const CarrierTrackingReceiverConfig& config);
+
+void initialize_carrier_tracking_runtime_state(std::uint64_t simulator_seed, int satellite_number, SignalId signal_id,
+                                               CarrierTrackingRuntimeState* state);
+
+// Hard-reset tracking/continuity state while intentionally preserving the
+// independent per-signal RNG stream. No legacy/global RNG is consumed here.
+void reset_carrier_tracking_runtime_state(CarrierTrackingRuntimeState* state);
+
+// Advance one carrier tracker from its previous runtime timestamp to
+// current_time. The interval is subdivided into steps no larger than the
+// configured coherent integration time so output rates below 50 Hz cannot skip
+// persistence/pull-in/validity timing boundaries.
+bool update_carrier_tracking_runtime(const CarrierTrackingReceiverConfig& config, const SimTime& current_time,
+                                     bool code_tracking, double effective_cn0_dbhz, double wavelength_m,
+                                     CarrierTrackingRuntimeState* state, CarrierTrackingRuntimeResult* result,
+                                     std::string* error_message);
+
+// Apply only the receiver carrier-tracking layer. The observation passed here
+// is already the clean/open-sky or urban-physical observation, including any
+// environmental_range_rate_mps term. Sign convention:
+//   D_measured = D_physical + tracking_error_hz
+//   range_rate_measured = range_rate_physical - wavelength * tracking_error_hz
+bool apply_carrier_tracking_runtime_result(const CarrierTrackingRuntimeResult& carrier,
+                                           MeasurementObservation* observation, std::string* error_message);
+
+} // namespace gnss_sim
+
+#endif // GNSS_SIM_SRC_MODEL_CARRIER_TRACKING_RUNTIME_H_

--- a/tests/integration/test_carrier_tracking_runtime.cpp
+++ b/tests/integration/test_carrier_tracking_runtime.cpp
@@ -152,7 +152,8 @@ TEST(CarrierTrackingRuntime, MeasurementApplicationPreservesDopplerRangeRateSign
     carrier.tracking.adr_valid = false;
 
     std::string error_message;
-    ASSERT_TRUE(gnss_sim::apply_carrier_tracking_runtime_result(carrier, &observation, &error_message)) << error_message;
+    ASSERT_TRUE(gnss_sim::apply_carrier_tracking_runtime_result(carrier, &observation, &error_message))
+        << error_message;
     EXPECT_DOUBLE_EQ(observation.doppler_hz, -47.0);
     EXPECT_DOUBLE_EQ(observation.range_rate_mps, 11.4);
     EXPECT_TRUE(observation.pseudorange_valid);
@@ -177,7 +178,8 @@ TEST(CarrierTrackingRuntime, CarrierUnlockedKeepsCodeButInvalidatesDopplerAndAdr
     carrier.tracking.adr_valid = false;
 
     std::string error_message;
-    ASSERT_TRUE(gnss_sim::apply_carrier_tracking_runtime_result(carrier, &observation, &error_message)) << error_message;
+    ASSERT_TRUE(gnss_sim::apply_carrier_tracking_runtime_result(carrier, &observation, &error_message))
+        << error_message;
     EXPECT_DOUBLE_EQ(observation.doppler_hz, -50.0);
     EXPECT_DOUBLE_EQ(observation.range_rate_mps, 12.0);
     EXPECT_TRUE(observation.pseudorange_valid);
@@ -205,7 +207,8 @@ TEST(CarrierTrackingRuntime, NewPllSegmentUsesDifferentIntegerAmbiguityOffset) {
     carrier.phase_segment_id = 1U;
 
     std::string error_message;
-    ASSERT_TRUE(gnss_sim::apply_carrier_tracking_runtime_result(carrier, &observation, &error_message)) << error_message;
+    ASSERT_TRUE(gnss_sim::apply_carrier_tracking_runtime_result(carrier, &observation, &error_message))
+        << error_message;
     EXPECT_EQ(observation.ambiguity_cycles, 537);
     EXPECT_DOUBLE_EQ(observation.adr_cycles, 1037.25);
 }

--- a/tests/integration/test_carrier_tracking_runtime.cpp
+++ b/tests/integration/test_carrier_tracking_runtime.cpp
@@ -1,0 +1,331 @@
+#include "gnss/signal_definitions.h"
+#include "gnss_sim/sim_config.h"
+#include "gnss_sim/sim_time.h"
+#include "gnss_sim/simulator.h"
+#include "model/carrier_tracking_runtime.h"
+
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <string>
+
+namespace {
+
+constexpr double kWavelengthM = 0.190293672798365;
+
+std::string nav_path() {
+    return std::string(GNSS_SIM_TEST_DATA_DIR) + "/gps_loopback_nav.rnx";
+}
+
+gnss_sim::SimTime make_time(double sow_sec) {
+    gnss_sim::SimTime time{};
+    EXPECT_TRUE(gnss_sim::sim_time_from_week_sow(2253, sow_sec, &time));
+    return time;
+}
+
+std::string read_file(const std::filesystem::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    return std::string((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
+}
+
+bool run_sim(const std::filesystem::path& directory, const gnss_sim::SimConfig& config,
+             gnss_sim::SimulatorRunSummary* summary, std::string* error_message) {
+    std::error_code error;
+    std::filesystem::remove_all(directory, error);
+    error.clear();
+    if (!std::filesystem::create_directories(directory, error) || error) {
+        if (error_message != nullptr) {
+            *error_message = "cannot create carrier tracking runtime test directory";
+        }
+        return false;
+    }
+    const std::filesystem::path output_path = directory / "simulated.log";
+    const std::string nav = nav_path();
+    const std::string output = output_path.string();
+    const gnss_sim::SimulatorRunOptions options{nav.c_str(), output.c_str(), make_time(172900.0), nullptr};
+    return gnss_sim::run_simulator(config, options, summary, error_message);
+}
+
+void cleanup(const std::filesystem::path& path) {
+    std::error_code error;
+    std::filesystem::remove_all(path, error);
+}
+
+TEST(CarrierTrackingRuntime, SubstepsLowRateOutputAcrossPersistenceBoundaries) {
+    gnss_sim::CarrierTrackingRuntimeState state{};
+    gnss_sim::initialize_carrier_tracking_runtime_state(7U, 1, gnss_sim::SignalId::kGpsL1Ca, &state);
+    const gnss_sim::CarrierTrackingReceiverConfig config = gnss_sim::default_sim_config().carrier_tracking;
+    gnss_sim::CarrierTrackingRuntimeResult result{};
+    std::string error_message;
+
+    ASSERT_TRUE(gnss_sim::update_carrier_tracking_runtime(config, make_time(100.0), true, 35.0, kWavelengthM, &state,
+                                                          &result, &error_message))
+        << error_message;
+    EXPECT_EQ(result.tracking.mode, gnss_sim::CarrierTrackingMode::kCarrierUnlocked);
+    EXPECT_FALSE(result.tracking.doppler_valid);
+
+    ASSERT_TRUE(gnss_sim::update_carrier_tracking_runtime(config, make_time(100.2), true, 35.0, kWavelengthM, &state,
+                                                          &result, &error_message))
+        << error_message;
+    EXPECT_EQ(result.tracking.mode, gnss_sim::CarrierTrackingMode::kFllTrack);
+    EXPECT_EQ(result.tracking.fll_phase, gnss_sim::CarrierTrackingFllPhase::kPullIn);
+    EXPECT_FALSE(result.tracking.doppler_valid);
+
+    ASSERT_TRUE(gnss_sim::update_carrier_tracking_runtime(config, make_time(100.4), true, 35.0, kWavelengthM, &state,
+                                                          &result, &error_message))
+        << error_message;
+    EXPECT_EQ(result.tracking.mode, gnss_sim::CarrierTrackingMode::kFllTrack);
+    EXPECT_TRUE(result.tracking.doppler_valid);
+    EXPECT_FALSE(result.tracking.adr_valid);
+
+    ASSERT_TRUE(gnss_sim::update_carrier_tracking_runtime(config, make_time(101.2), true, 35.0, kWavelengthM, &state,
+                                                          &result, &error_message))
+        << error_message;
+    EXPECT_EQ(result.tracking.mode, gnss_sim::CarrierTrackingMode::kPllTrack);
+    EXPECT_FALSE(result.tracking.adr_valid);
+
+    ASSERT_TRUE(gnss_sim::update_carrier_tracking_runtime(config, make_time(102.2), true, 35.0, kWavelengthM, &state,
+                                                          &result, &error_message))
+        << error_message;
+    EXPECT_EQ(result.tracking.mode, gnss_sim::CarrierTrackingMode::kPllTrack);
+    EXPECT_TRUE(result.tracking.doppler_valid);
+    EXPECT_TRUE(result.tracking.adr_valid);
+}
+
+TEST(CarrierTrackingRuntime, PllLossImmediatelyBreaksAdrAndStartsNewPhaseSegment) {
+    gnss_sim::CarrierTrackingRuntimeState state{};
+    gnss_sim::initialize_carrier_tracking_runtime_state(11U, 3, gnss_sim::SignalId::kGpsL1Ca, &state);
+    const gnss_sim::CarrierTrackingReceiverConfig config = gnss_sim::default_sim_config().carrier_tracking;
+    gnss_sim::CarrierTrackingRuntimeResult result{};
+    std::string error_message;
+
+    ASSERT_TRUE(gnss_sim::update_carrier_tracking_runtime(config, make_time(200.0), true, 35.0, kWavelengthM, &state,
+                                                          &result, &error_message));
+    ASSERT_TRUE(gnss_sim::update_carrier_tracking_runtime(config, make_time(202.2), true, 35.0, kWavelengthM, &state,
+                                                          &result, &error_message))
+        << error_message;
+    ASSERT_EQ(result.tracking.mode, gnss_sim::CarrierTrackingMode::kPllTrack);
+    ASSERT_TRUE(result.tracking.adr_valid);
+    EXPECT_EQ(result.phase_segment_id, 0U);
+    EXPECT_EQ(result.adr_cycle_offset_cycles, 0);
+
+    ASSERT_TRUE(gnss_sim::update_carrier_tracking_runtime(config, make_time(202.5), true, 26.0, kWavelengthM, &state,
+                                                          &result, &error_message))
+        << error_message;
+    EXPECT_EQ(result.tracking.mode, gnss_sim::CarrierTrackingMode::kFllTrack);
+    EXPECT_FALSE(result.tracking.adr_valid);
+    EXPECT_TRUE(result.cycle_slip_event);
+    EXPECT_EQ(result.phase_segment_id, 1U);
+    EXPECT_NE(result.adr_cycle_offset_cycles, 0);
+
+    ASSERT_TRUE(gnss_sim::update_carrier_tracking_runtime(config, make_time(203.5), true, 35.0, kWavelengthM, &state,
+                                                          &result, &error_message))
+        << error_message;
+    EXPECT_EQ(result.tracking.mode, gnss_sim::CarrierTrackingMode::kPllTrack);
+    EXPECT_FALSE(result.tracking.adr_valid);
+
+    ASSERT_TRUE(gnss_sim::update_carrier_tracking_runtime(config, make_time(204.5), true, 35.0, kWavelengthM, &state,
+                                                          &result, &error_message))
+        << error_message;
+    EXPECT_TRUE(result.tracking.adr_valid);
+    EXPECT_EQ(result.phase_segment_id, 1U);
+    EXPECT_NE(result.adr_cycle_offset_cycles, 0);
+}
+
+TEST(CarrierTrackingRuntime, MeasurementApplicationPreservesDopplerRangeRateSignConvention) {
+    gnss_sim::MeasurementObservation observation{};
+    observation.wavelength_m = 0.2;
+    observation.range_rate_mps = 12.0;
+    observation.doppler_hz = -50.0;
+    observation.adr_cycles = 1234.0;
+    observation.ambiguity_cycles = 100;
+    observation.observation_available = true;
+    observation.pseudorange_valid = true;
+    observation.doppler_valid = true;
+    observation.adr_valid = true;
+
+    gnss_sim::CarrierTrackingRuntimeResult carrier{};
+    carrier.tracking.mode = gnss_sim::CarrierTrackingMode::kFllTrack;
+    carrier.tracking.tracking_error_hz = 3.0;
+    carrier.tracking.tracking_error_mps = 0.6;
+    carrier.tracking.doppler_valid = true;
+    carrier.tracking.adr_valid = false;
+
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::apply_carrier_tracking_runtime_result(carrier, &observation, &error_message)) << error_message;
+    EXPECT_DOUBLE_EQ(observation.doppler_hz, -47.0);
+    EXPECT_DOUBLE_EQ(observation.range_rate_mps, 11.4);
+    EXPECT_TRUE(observation.pseudorange_valid);
+    EXPECT_TRUE(observation.doppler_valid);
+    EXPECT_FALSE(observation.adr_valid);
+}
+
+TEST(CarrierTrackingRuntime, CarrierUnlockedKeepsCodeButInvalidatesDopplerAndAdr) {
+    gnss_sim::MeasurementObservation observation{};
+    observation.wavelength_m = 0.2;
+    observation.range_rate_mps = 12.0;
+    observation.doppler_hz = -50.0;
+    observation.adr_cycles = 1234.0;
+    observation.observation_available = true;
+    observation.pseudorange_valid = true;
+    observation.doppler_valid = true;
+    observation.adr_valid = true;
+
+    gnss_sim::CarrierTrackingRuntimeResult carrier{};
+    carrier.tracking.mode = gnss_sim::CarrierTrackingMode::kCarrierUnlocked;
+    carrier.tracking.doppler_valid = false;
+    carrier.tracking.adr_valid = false;
+
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::apply_carrier_tracking_runtime_result(carrier, &observation, &error_message)) << error_message;
+    EXPECT_DOUBLE_EQ(observation.doppler_hz, -50.0);
+    EXPECT_DOUBLE_EQ(observation.range_rate_mps, 12.0);
+    EXPECT_TRUE(observation.pseudorange_valid);
+    EXPECT_FALSE(observation.doppler_valid);
+    EXPECT_FALSE(observation.adr_valid);
+}
+
+TEST(CarrierTrackingRuntime, NewPllSegmentUsesDifferentIntegerAmbiguityOffset) {
+    gnss_sim::MeasurementObservation observation{};
+    observation.wavelength_m = 0.2;
+    observation.range_rate_mps = 0.0;
+    observation.doppler_hz = 0.0;
+    observation.adr_cycles = 1000.25;
+    observation.ambiguity_cycles = 500;
+    observation.observation_available = true;
+    observation.pseudorange_valid = true;
+    observation.doppler_valid = true;
+    observation.adr_valid = true;
+
+    gnss_sim::CarrierTrackingRuntimeResult carrier{};
+    carrier.tracking.mode = gnss_sim::CarrierTrackingMode::kPllTrack;
+    carrier.tracking.doppler_valid = true;
+    carrier.tracking.adr_valid = true;
+    carrier.adr_cycle_offset_cycles = 37;
+    carrier.phase_segment_id = 1U;
+
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::apply_carrier_tracking_runtime_result(carrier, &observation, &error_message)) << error_message;
+    EXPECT_EQ(observation.ambiguity_cycles, 537);
+    EXPECT_DOUBLE_EQ(observation.adr_cycles, 1037.25);
+}
+
+TEST(CarrierTrackingRuntime, SamePerSignalSeedAndInputsAreDeterministic) {
+    gnss_sim::CarrierTrackingRuntimeState first{};
+    gnss_sim::CarrierTrackingRuntimeState second{};
+    gnss_sim::initialize_carrier_tracking_runtime_state(42U, 5, gnss_sim::SignalId::kGpsL1Ca, &first);
+    gnss_sim::initialize_carrier_tracking_runtime_state(42U, 5, gnss_sim::SignalId::kGpsL1Ca, &second);
+    const gnss_sim::CarrierTrackingReceiverConfig config = gnss_sim::default_sim_config().carrier_tracking;
+    std::string first_error;
+    std::string second_error;
+
+    for (int index = 0; index <= 30; ++index) {
+        const double cn0 = index < 18 ? 35.0 : 26.0;
+        gnss_sim::CarrierTrackingRuntimeResult first_result{};
+        gnss_sim::CarrierTrackingRuntimeResult second_result{};
+        ASSERT_TRUE(gnss_sim::update_carrier_tracking_runtime(config, make_time(300.0 + 0.1 * index), true, cn0,
+                                                              kWavelengthM, &first, &first_result, &first_error))
+            << first_error;
+        ASSERT_TRUE(gnss_sim::update_carrier_tracking_runtime(config, make_time(300.0 + 0.1 * index), true, cn0,
+                                                              kWavelengthM, &second, &second_result, &second_error))
+            << second_error;
+        EXPECT_EQ(first_result.tracking.mode, second_result.tracking.mode);
+        EXPECT_DOUBLE_EQ(first_result.tracking.tracking_error_hz, second_result.tracking.tracking_error_hz);
+        EXPECT_DOUBLE_EQ(first_result.tracking.tracking_error_mps, second_result.tracking.tracking_error_mps);
+        EXPECT_EQ(first_result.tracking.doppler_valid, second_result.tracking.doppler_valid);
+        EXPECT_EQ(first_result.tracking.adr_valid, second_result.tracking.adr_valid);
+        EXPECT_EQ(first_result.phase_segment_id, second_result.phase_segment_id);
+        EXPECT_EQ(first_result.adr_cycle_offset_cycles, second_result.adr_cycle_offset_cycles);
+    }
+}
+
+TEST(CarrierTrackingRuntime, HardResetClearsTrackingAndContinuityState) {
+    gnss_sim::CarrierTrackingRuntimeState state{};
+    gnss_sim::initialize_carrier_tracking_runtime_state(19U, 7, gnss_sim::SignalId::kGpsL1Ca, &state);
+    const gnss_sim::CarrierTrackingReceiverConfig config = gnss_sim::default_sim_config().carrier_tracking;
+    gnss_sim::CarrierTrackingRuntimeResult result{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::update_carrier_tracking_runtime(config, make_time(400.0), true, 35.0, kWavelengthM, &state,
+                                                          &result, &error_message));
+    ASSERT_TRUE(gnss_sim::update_carrier_tracking_runtime(config, make_time(402.2), true, 35.0, kWavelengthM, &state,
+                                                          &result, &error_message));
+    ASSERT_TRUE(result.tracking.adr_valid);
+
+    gnss_sim::reset_carrier_tracking_runtime_state(&state);
+    EXPECT_EQ(state.tracking.mode, gnss_sim::CarrierTrackingMode::kCarrierUnlocked);
+    EXPECT_FALSE(state.time_initialized);
+    EXPECT_EQ(state.phase_segment_id, 0U);
+    EXPECT_EQ(state.adr_cycle_offset_cycles, 0);
+
+    ASSERT_TRUE(gnss_sim::update_carrier_tracking_runtime(config, make_time(500.0), true, 35.0, kWavelengthM, &state,
+                                                          &result, &error_message));
+    EXPECT_EQ(result.tracking.mode, gnss_sim::CarrierTrackingMode::kCarrierUnlocked);
+    EXPECT_FALSE(result.tracking.doppler_valid);
+    EXPECT_FALSE(result.tracking.adr_valid);
+}
+
+TEST(CarrierTrackingRuntime, DisabledSimulatorFeaturePreservesBytesAndPhysicalUrbanTruth) {
+    const std::filesystem::path baseline_dir = "gnss_sim_carrier_disabled_baseline";
+    const std::filesystem::path altered_dir = "gnss_sim_carrier_disabled_altered";
+    gnss_sim::SimConfig baseline = gnss_sim::default_sim_config();
+    baseline.scenario = gnss_sim::ScenarioType::KS;
+    baseline.atmosphere_mode = gnss_sim::AtmosphereMode::NONE;
+    baseline.elevation_mask_deg = 0.0;
+    baseline.sampling_rate_hz = 10;
+    baseline.duration_ns = 4LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    baseline.seed = 7U;
+    baseline.multipath_enabled = true;
+    ASSERT_FALSE(baseline.carrier_tracking.enabled);
+
+    gnss_sim::SimConfig altered = baseline;
+    altered.carrier_tracking.pll_noise_bandwidth_hz = 6.0;
+    altered.carrier_tracking.fll_noise_bandwidth_hz = 5.0;
+    altered.carrier_tracking.fll_pull_in_bandwidth_hz = 9.0;
+
+    gnss_sim::SimulatorRunSummary first_summary{};
+    gnss_sim::SimulatorRunSummary second_summary{};
+    std::string error_message;
+    ASSERT_TRUE(run_sim(baseline_dir, baseline, &first_summary, &error_message)) << error_message;
+    ASSERT_TRUE(run_sim(altered_dir, altered, &second_summary, &error_message)) << error_message;
+    EXPECT_EQ(read_file(baseline_dir / "simulated.log"), read_file(altered_dir / "simulated.log"));
+    EXPECT_EQ(read_file(baseline_dir / "urban_signal_truth.csv"), read_file(altered_dir / "urban_signal_truth.csv"));
+    EXPECT_EQ(read_file(baseline_dir / "urban_path_truth.csv"), read_file(altered_dir / "urban_path_truth.csv"));
+
+    cleanup(baseline_dir);
+    cleanup(altered_dir);
+}
+
+TEST(CarrierTrackingRuntime, EnabledSimulatorFeatureIsDeterministicAndLeavesPhysicalTruthUnchanged) {
+    const std::filesystem::path disabled_dir = "gnss_sim_carrier_physical_truth";
+    const std::filesystem::path enabled_a_dir = "gnss_sim_carrier_enabled_a";
+    const std::filesystem::path enabled_b_dir = "gnss_sim_carrier_enabled_b";
+    gnss_sim::SimConfig config = gnss_sim::default_sim_config();
+    config.scenario = gnss_sim::ScenarioType::KS;
+    config.atmosphere_mode = gnss_sim::AtmosphereMode::NONE;
+    config.elevation_mask_deg = 0.0;
+    config.sampling_rate_hz = 10;
+    config.duration_ns = 6LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    config.seed = 7U;
+    config.multipath_enabled = true;
+
+    gnss_sim::SimulatorRunSummary disabled_summary{};
+    gnss_sim::SimulatorRunSummary enabled_a_summary{};
+    gnss_sim::SimulatorRunSummary enabled_b_summary{};
+    std::string error_message;
+    ASSERT_TRUE(run_sim(disabled_dir, config, &disabled_summary, &error_message)) << error_message;
+
+    config.carrier_tracking.enabled = true;
+    ASSERT_TRUE(run_sim(enabled_a_dir, config, &enabled_a_summary, &error_message)) << error_message;
+    ASSERT_TRUE(run_sim(enabled_b_dir, config, &enabled_b_summary, &error_message)) << error_message;
+
+    EXPECT_EQ(read_file(enabled_a_dir / "simulated.log"), read_file(enabled_b_dir / "simulated.log"));
+    EXPECT_NE(read_file(disabled_dir / "simulated.log"), read_file(enabled_a_dir / "simulated.log"));
+    EXPECT_EQ(read_file(disabled_dir / "urban_signal_truth.csv"), read_file(enabled_a_dir / "urban_signal_truth.csv"));
+    EXPECT_EQ(read_file(disabled_dir / "urban_path_truth.csv"), read_file(enabled_a_dir / "urban_path_truth.csv"));
+
+    cleanup(disabled_dir);
+    cleanup(enabled_a_dir);
+    cleanup(enabled_b_dir);
+}
+
+} // namespace

--- a/tests/unit/test_carrier_tracking_config.cpp
+++ b/tests/unit/test_carrier_tracking_config.cpp
@@ -1,0 +1,97 @@
+#include "gnss_sim/sim_config.h"
+
+#include <cstdio>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <string>
+
+namespace {
+
+constexpr const char* kConfigPath = "gnss_sim_carrier_tracking_config.json";
+
+void write_config(const char* text) {
+    std::ofstream output(kConfigPath, std::ios::binary | std::ios::trunc);
+    output << text;
+}
+
+class CarrierTrackingConfigTest : public ::testing::Test {
+  protected:
+    void TearDown() override {
+        static_cast<void>(std::remove(kConfigPath));
+    }
+};
+
+TEST_F(CarrierTrackingConfigTest, FrozenDefaultsRemainOptIn) {
+    const gnss_sim::SimConfig config = gnss_sim::default_sim_config();
+    EXPECT_FALSE(config.carrier_tracking.enabled);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.coherent_integration_sec, 0.020);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.pll_noise_bandwidth_hz, 5.0);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.fll_noise_bandwidth_hz, 4.0);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.fll_pull_in_bandwidth_hz, 8.0);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.fll_pull_in_duration_sec, 0.5);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.pll_enter_cn0_dbhz, 30.0);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.pll_exit_cn0_dbhz, 27.0);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.pll_enter_persistence_sec, 1.0);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.pll_exit_persistence_sec, 0.3);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.fll_enter_cn0_dbhz, 22.0);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.fll_exit_cn0_dbhz, 18.0);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.fll_enter_persistence_sec, 0.2);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.fll_exit_persistence_sec, 0.5);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.doppler_valid_delay_sec, 0.2);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.adr_valid_after_pll_sec, 1.0);
+}
+
+TEST_F(CarrierTrackingConfigTest, LoadsExplicitOverrides) {
+    write_config(R"json({
+        "carrier_tracking": {
+            "enabled": true,
+            "coherent_integration_sec": 0.01,
+            "pll_noise_bandwidth_hz": 6.0,
+            "fll_noise_bandwidth_hz": 5.0,
+            "fll_pull_in_bandwidth_hz": 9.0,
+            "fll_pull_in_duration_sec": 0.6,
+            "pll_enter_cn0_dbhz": 31.0,
+            "pll_exit_cn0_dbhz": 28.0,
+            "pll_enter_persistence_sec": 1.2,
+            "pll_exit_persistence_sec": 0.4,
+            "fll_enter_cn0_dbhz": 23.0,
+            "fll_exit_cn0_dbhz": 19.0,
+            "fll_enter_persistence_sec": 0.25,
+            "fll_exit_persistence_sec": 0.55,
+            "doppler_valid_delay_sec": 0.25,
+            "adr_valid_after_pll_sec": 1.1
+        }
+    })json");
+
+    gnss_sim::SimConfig config{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::load_sim_config_json(kConfigPath, &config, &error_message)) << error_message;
+    EXPECT_TRUE(config.carrier_tracking.enabled);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.coherent_integration_sec, 0.01);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.pll_noise_bandwidth_hz, 6.0);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.fll_noise_bandwidth_hz, 5.0);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.fll_pull_in_bandwidth_hz, 9.0);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.pll_enter_cn0_dbhz, 31.0);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.fll_exit_cn0_dbhz, 19.0);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.adr_valid_after_pll_sec, 1.1);
+}
+
+TEST_F(CarrierTrackingConfigTest, RejectsInvalidCoreOrderingEvenWhenDisabled) {
+    write_config(R"json({"carrier_tracking":{"enabled":false,"pll_exit_cn0_dbhz":35.0}})json");
+
+    gnss_sim::SimConfig config{};
+    std::string error_message;
+    EXPECT_FALSE(gnss_sim::load_sim_config_json(kConfigPath, &config, &error_message));
+    EXPECT_NE(error_message.find("carrier_tracking"), std::string::npos) << error_message;
+}
+
+TEST_F(CarrierTrackingConfigTest, RejectsUnknownCarrierKey) {
+    write_config(R"json({"carrier_tracking":{"doppler_sigma_mps":1.0}})json");
+
+    gnss_sim::SimConfig config{};
+    std::string error_message;
+    EXPECT_FALSE(gnss_sim::load_sim_config_json(kConfigPath, &config, &error_message));
+    EXPECT_NE(error_message.find("carrier_tracking"), std::string::npos) << error_message;
+}
+
+} // namespace


### PR DESCRIPTION
Closes #161
Parent: #159
Depends on: #160

## Scope
Integrates the completed carrier-tracking core into simulator runtime without changing the existing physical urban propagation model or truth schemas.

## Runtime ordering
`clean measurement -> urban physical path-rate -> existing physical truth -> carrier tracking -> existing generic measurement error -> reported RANGE`

Carrier tracking therefore consumes the same effective C/N0 already produced by the signal chain and does not recompute geometry, reflections, diffraction, DLL roots, or `environmental_range_rate_mps`.

## Compatibility
- `carrier_tracking.enabled=false` by default.
- Disabled path does not call the carrier updater and does not consume the existing/global runtime RNG.
- Per-satellite/per-signal carrier RNG streams are derived independently from simulator seed + satellite + signal.
- Existing truth files remain physical/zero-noise truth in this issue; #162 will add carrier diagnostics.

## Observation mapping
- `D_measured = D_physical + carrier_tracking_error_hz`
- `range_rate_measured = range_rate_physical - wavelength * carrier_tracking_error_hz`
- pseudorange unchanged
- FLL: code may remain valid, Doppler may be valid, ADR invalid
- carrier unlocked: code may remain valid, Doppler/ADR invalid
- PLL loss immediately invalidates ADR and starts a deterministic new phase/ambiguity segment.

## Time handling
Elapsed receiver output intervals are subdivided into steps no larger than coherent integration time, so 1/5/10/20 Hz outputs cannot skip 0.2/0.3/0.5 s persistence and pull-in boundaries.

## Tests
Focused tests cover config/defaults, substep timing, FLL/PLL/unlocked validity, sign/units, phase-segment ambiguity discontinuity, deterministic per-signal sequences, hard reset, disabled byte compatibility, enabled repeatability, and preservation of urban physical truth.

## Implementation Notes
`docs/CARRIER_TRACKING_RUNTIME.md`

Draft until CI and final diff review are green.