### PR TITLE
Merge completed carrier-tracking integration into main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,7 @@ jobs:
         if: runner.os == 'Linux'
         shell: bash
         run: ./build/gnss_sim_integration_tests --gtest_filter=StaticUrbanDopplerValidation.*
+      - name: Report authentic carrier tracking validation metrics
+        if: runner.os == 'Linux'
+        shell: bash
+        run: ./build/gnss_sim_integration_tests --gtest_filter=CarrierTrackingAuthenticValidation.*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,6 +302,7 @@ if(BUILD_TESTING)
         tests/integration/test_all_signal_residuals.cpp
         tests/integration/test_carrier_tracking_runtime.cpp
         tests/integration/test_carrier_tracking_truth.cpp
+        tests/integration/test_carrier_tracking_authentic_validation.cpp
         tests/integration/test_measurement_noise_integration.cpp
         tests/integration/test_nav_equivalence.cpp
         tests/integration/test_rea_fade.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ add_library(gnss_sim_core STATIC
     src/gnss/signal_definitions.cpp
     src/model/atmosphere_model.cpp
     src/model/bestpos_rtk_model.cpp
+    src/model/carrier_tracking.cpp
     src/model/cn0_model.cpp
     src/model/code_correlation.cpp
     src/model/code_tracking_dll.cpp
@@ -241,6 +242,7 @@ if(BUILD_TESTING)
     add_executable(gnss_sim_unit_tests
         tests/unit/test_atmosphere_model.cpp
         tests/unit/test_bestpos_rtk_model.cpp
+        tests/unit/test_carrier_tracking.cpp
         tests/unit/test_cn0_model.cpp
         tests/unit/test_cn0_normalized_builder.cpp
         tests/unit/test_cn0_statistics.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ add_library(gnss_sim_core STATIC
     src/model/atmosphere_model.cpp
     src/model/bestpos_rtk_model.cpp
     src/model/carrier_tracking.cpp
+    src/model/carrier_tracking_runtime.cpp
     src/model/cn0_model.cpp
     src/model/code_correlation.cpp
     src/model/code_tracking_dll.cpp
@@ -243,6 +244,7 @@ if(BUILD_TESTING)
         tests/unit/test_atmosphere_model.cpp
         tests/unit/test_bestpos_rtk_model.cpp
         tests/unit/test_carrier_tracking.cpp
+        tests/unit/test_carrier_tracking_config.cpp
         tests/unit/test_cn0_model.cpp
         tests/unit/test_cn0_normalized_builder.cpp
         tests/unit/test_cn0_statistics.cpp
@@ -297,6 +299,7 @@ if(BUILD_TESTING)
     add_executable(gnss_sim_integration_tests
         tests/integration/test_scenarios.cpp
         tests/integration/test_all_signal_residuals.cpp
+        tests/integration/test_carrier_tracking_runtime.cpp
         tests/integration/test_measurement_noise_integration.cpp
         tests/integration/test_nav_equivalence.cpp
         tests/integration/test_rea_fade.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,7 @@ add_library(gnss_sim_core STATIC
     src/output/novatel_nav_writer.cpp
     src/output/novatel_range_writer.cpp
     src/output/novatel_solution_writer.cpp
+    src/output/carrier_tracking_truth_writer.cpp
     src/output/truth_writer.cpp
     src/output/urban_truth_writer.cpp
     src/output/unicore_nav_writer.cpp
@@ -300,6 +301,7 @@ if(BUILD_TESTING)
         tests/integration/test_scenarios.cpp
         tests/integration/test_all_signal_residuals.cpp
         tests/integration/test_carrier_tracking_runtime.cpp
+        tests/integration/test_carrier_tracking_truth.cpp
         tests/integration/test_measurement_noise_integration.cpp
         tests/integration/test_nav_equivalence.cpp
         tests/integration/test_rea_fade.cpp

--- a/docs/CARRIER_TRACKING_AUTHENTIC_VALIDATION.md
+++ b/docs/CARRIER_TRACKING_AUTHENTIC_VALIDATION.md
@@ -1,0 +1,231 @@
+# Authentic-NAV carrier-tracking validation
+
+Issue: #163  
+Parent: #159  
+Result: **PASS**
+
+This report records the permanent V1 validation evidence for the CN0-driven carrier-tracking layer introduced by #160-#162. The validation PR changes tests, CI reporting, and this document only. It does not change production carrier-tracking equations, runtime state transitions, urban propagation, navigation handling, or the frozen V1 defaults.
+
+## Reproducible evidence
+
+- Validation base: `3d2e2b562b35834805ee4e711403327d99bd00df` (`#162` merged into `integration/issues-103-104`).
+- Validation implementation head used for the measured evidence: `30fc5f7943ad10461797eee16fb3d91a698ca221`.
+- GitHub Actions run: CI #758, run id `33864233860`.
+- Linux metrics job: `build-test (ubuntu-latest)`, job id `100995316472`.
+- Windows full build/test: PASS.
+- Ubuntu full build/test: PASS.
+- Ubuntu `ctest`: **369/369 tests passed**.
+- Focused suite: `CarrierTrackingAuthenticValidation.*`: **4/4 tests passed**.
+
+The focused suite is part of the normal `ctest` executable on both Windows and Linux; the extra Linux CI step only prints the permanent numerical evidence.
+
+## Authentic navigation provenance
+
+The validation reuses the provenance-fixed authentic BRD400DLR RINEX 4.02 fixture already established by #124/#152.
+
+- Source product/file: `BRD400DLR_S_20250030000_01D_MN.rnx`.
+- Repository fixture: `tests/data/minimal/brd400dlr_rinex4_acceptance_nav.rnx`.
+- Fixture SHA-256: `17c6bb00a8a0ef8f732b803925311e7b1ead658ae2e11f62635371eb915e9781`.
+- Runtime scope: all BeiDou `EPH` records are copied mechanically into the temporary validation NAV.
+- No ephemeris is interpolated, retargeted, synthesized, repaired, or selected to obtain a desired result.
+
+The existing authentic urban E2E validation reports the mechanically filtered NAV identity as FNV-1a64 `2552251af489a9ec`.
+
+## Static validation configuration
+
+- Start: GPST week 2347, SOW 436500 s.
+- Receiver truth: latitude 20 deg, longitude 120 deg, height 100 m.
+- Duration: 12 s.
+- Sampling rate: 10 Hz.
+- Seed: `0x163`.
+- Urban multipath: enabled.
+- Generic measurement noise: disabled.
+- Atmosphere: none.
+- Measurement elevation mask: 0 deg.
+- Solution elevation mask: 5 deg.
+- Carrier tracking: enabled for the ON run; disabled for the compatibility control.
+
+The ON case is repeated twice with identical configuration and seed. The OFF control is also repeated while changing dormant carrier-tracking bandwidth settings. These pairs verify deterministic output and disabled-feature compatibility rather than merely comparing summary statistics.
+
+## Observation-level carrier-tracking results
+
+The authentic static run produced:
+
+- carrier result rows: **5892**
+- Doppler-valid carrier rows: **5672**
+- FLL rows with code+Doppler valid but ADR invalid: **184**
+- carrier-unlocked rows with code valid but Doppler/ADR invalid: **23**
+- FLL pull-in rows: **275**
+- mode changes: **110**
+- new carrier segments: **55**
+- static-run cycle-slip events: **0**
+
+The zero static-run cycle-slip count is expected: this short static case contains initial acquisition/mode progression but no later PLL-loss event. The dedicated REA case below verifies post-lock loss/reacquisition and ambiguity discontinuity.
+
+### Statistics by carrier mode
+
+| Mode | Rows | Doppler-valid | Error RMS (Hz) | P50 abs (Hz) | P95 abs (Hz) | P99 abs (Hz) | Max abs (Hz) | Error RMS (m/s) | P95 abs (m/s) | Max abs (m/s) | Theoretical sigma RMS (Hz) | Normalized error RMS |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| CARRIER_UNLOCKED | 110 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
+| FLL_TRACK | 550 | 440 | 0.418945 | 0.213197 | 0.838282 | 1.44259 | 2.40042 | 0.091953 | 0.187786 | 0.460975 | 0.431158 | 0.967276 |
+| PLL_TRACK | 5232 | 5232 | 0.203899 | 0.106467 | 0.428708 | 0.70254 | 1.11736 | 0.0454257 | 0.0975309 | 0.264069 | 0.199136 | 1.00514 |
+
+The realized tracking-error RMS follows the theoretical jitter scale without any PVT-target tuning. The normalized RMS is about 0.97 for FLL and 1.01 for PLL. Because the tracking error is intentionally time-correlated, these numbers are evidence for the error scale, not a claim that successive samples are independent Gaussian draws.
+
+### Statistics by effective C/N0 bin
+
+| Effective C/N0 bin (dB-Hz) | Rows | Doppler-valid | Error RMS (Hz) | P95 abs (Hz) | Max abs (Hz) | Theoretical sigma RMS (Hz) | Normalized error RMS |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| <18 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
+| 18-22 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
+| 22-27 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
+| 27-30 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
+| >=30 | 5892 | 5672 | 0.227958 | 0.459245 | 2.40042 | 0.225831 | 1.00225 |
+
+**Important limitation:** this authentic short static fixture/run organically exercises only effective C/N0 >=30 dB-Hz. The empty lower bins are reported as empty rather than populated with synthetic attenuation merely to satisfy a table. Low-C/N0 model response is checked separately by the frozen thermal-jitter test, while future calibration against measured weak-signal data remains required before claiming receiver-specific low-C/N0 fidelity.
+
+## Theoretical thermal-jitter response
+
+The frozen model responds in the physically expected directions:
+
+- FLL sigma at 20 dB-Hz: **3.89848 Hz**.
+- FLL sigma at 40 dB-Hz: **0.319105 Hz**.
+- Reference 35 dB-Hz, 4 Hz FLL bandwidth, 20 ms integration: **0.570501 Hz**.
+- Increasing FLL bandwidth to 8 Hz: **0.806811 Hz**.
+- Increasing coherent integration to 40 ms: **0.284138 Hz**.
+- At 0.19 m wavelength: sigma **0.108395 m/s**.
+- Doubling wavelength to 0.38 m: sigma **0.216791 m/s** while sigma in Hz remains unchanged.
+
+This confirms that C/N0, loop bandwidth, coherent integration time, and wavelength drive the model rather than a fixed empirical final Doppler sigma.
+
+## Physical propagation remains separate from receiver tracking
+
+For the 12 s #163 run, the physical urban environmental range-rate term was:
+
+- RMS: **0.00016598 m/s**
+- P95 absolute: **0.000427493 m/s**
+- maximum absolute: **0.000447791 m/s**
+
+The exact cross-file comparison between `carrier_tracking_truth.csv` and `urban_signal_truth.csv` produced:
+
+- maximum environmental range-rate mismatch: **0 m/s**.
+
+The carrier application identities also close to floating-point roundoff:
+
+- max `D_post - D_physical - tracking_error_hz`: **1.13506e-13 Hz**.
+- max `range_rate_post - range_rate_physical + tracking_error_mps`: **2.8387e-14 m/s**.
+
+Therefore the physical urban path-rate remains an independent truth quantity; the much larger carrier-tracking error is a receiver tracking-layer effect and does not replace or mutate the physical propagation term.
+
+For reference, the existing longer authentic #152 physical-only validation in the same CI reports `STATIC_DOPPLER_ALL rate_rms_mps=0.000165374` and `rate_max_mps=0.000466691`, consistent with the same physical mechanism over a longer interval.
+
+## Independent validity states
+
+Observed post-carrier validity combinations (`code,doppler,ADR`) included:
+
+- `111`: **1952** rows
+- `110`: **414** rows
+- `100`: **69** rows
+
+Specific carrier-state evidence includes 184 FLL rows with code+Doppler valid and ADR invalid, plus 23 carrier-unlocked rows where code remains valid while Doppler and ADR are invalid. This confirms that code, Doppler, and ADR validity are not collapsed into one shared flag.
+
+## Worst carrier observation in the static run
+
+The largest absolute tracking error was:
+
+- GPST: week 2347, TOW `436502100000000` ns
+- satellite: 134
+- signal: BeiDou B1I
+- effective C/N0: **35.3704 dB-Hz**
+- carrier mode: `FLL_TRACK`
+- FLL phase: `PULL_IN`
+- theoretical sigma: **0.772633 Hz**
+- realized tracking error: **2.40042 Hz / 0.460975 m/s**
+- simultaneous physical environmental range rate: **0.000330717 m/s**
+- urban state: `NLOS_TRACKED`
+- blocking wall: `WEST`
+- received paths: 2
+- reflections: 1
+
+This context is diagnostic evidence only; the model was not adjusted to reduce this worst case.
+
+## Output-rate sanity
+
+Matching PLL observations at identical GPST/satellite/signal epochs between 1 Hz and 10 Hz runs produced:
+
+- matched PLL observations: **437**
+- maximum theoretical sigma mismatch: **0 Hz**
+- 1 Hz tracking-error RMS: **0.208418 Hz**
+- 10 Hz tracking-error RMS: **0.222627 Hz**
+- RMS ratio: **0.936175**
+
+The exact theoretical sigma at matched epochs confirms that changing output rate does not change the frozen loop-noise scale. The realized correlated sequence need not be sample-by-sample identical across output rates, so the comparison is intentionally a scale sanity check rather than an equality requirement.
+
+## Deterministic loss and reacquisition
+
+The authentic-NAV REA case uses 10 Hz output, a 6 s signal-on interval followed by 2 s signal-off, and a 14 s total duration. It produced:
+
+- code-not-tracking/reset rows: **11171**
+- reacquisition carrier-result rows: **3037**
+- reacquisition carrier-unlocked code-only rows: **23**
+- reacquisition FLL code+Doppler/no-ADR rows: **184**
+- new carrier segments: **55**
+
+One complete deterministic signal sequence (`satellite:signal = 111:16`) was:
+
+| Event | Elapsed time (s) |
+| --- | ---: |
+| first carrier result after code reacquisition | 8.8 |
+| first FLL | 9.0 |
+| first Doppler-valid | 9.2 |
+| first PLL | 10.0 |
+| first ADR-valid | 11.0 |
+
+The first FLL uses the frozen **8 Hz pull-in bandwidth**. The sequence shows the intended 0.2 s FLL qualification, 0.2 s Doppler-valid delay, PLL confirmation, and 1.0 s additional ADR-valid delay. The first post-reacquisition ADR differs from the previous segment by **261169 cycles**, proving that ADR continuity is not carried across the loss/reacquisition boundary.
+
+## Secondary RTKLIB velocity and clock-drift result
+
+RTKLIB velocity is a secondary emergent check, not the target used to choose tracking parameters.
+
+| Carrier tracking | Valid velocity epochs | 3D RMS (m/s) | 3D P95 (m/s) | 3D max (m/s) | Clock-drift RMS (m/s) | Clock-drift max (m/s) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| ON | 105 | 0.217632 | 0.339921 | 1.51026 | 0.175136 | 1.39511 |
+| OFF | 107 | 0.00578352 | 0.00716576 | 0.0244718 | 0.00425518 | 0.0186139 |
+
+The degradation appears naturally when observation-level carrier tracking is enabled. No minimum velocity degradation was required and no parameter was tuned to manufacture this difference.
+
+## Determinism and compatibility
+
+The validation verifies all of the following:
+
+1. Same authentic NAV + config + seed with carrier tracking enabled produces byte-identical receiver output and byte-identical carrier truth.
+2. With carrier tracking disabled, changing dormant carrier-tracking bandwidth settings leaves receiver output and physical truth byte-identical.
+3. `observation_truth.csv` and `urban_signal_truth.csv` are identical between carrier ON and OFF for the same physical simulation, proving the carrier layer does not mutate physical truth.
+4. Simulator-only carrier columns such as `carrier_mode` and `tracking_error_hz` do not leak into normal RANGE output.
+5. Physical environmental range-rate truth is exactly preserved and independently traceable.
+
+## V1 limitations and calibration plan
+
+This validation establishes architecture, determinism, state/validity semantics, sign/units, physical separation, and physically directed jitter scaling. It does **not** establish vendor-specific receiver fidelity.
+
+Known V1 limitations include:
+
+- the authentic static fixture used here contains no effective-C/N0 samples below 30 dB-Hz;
+- the frozen loop bandwidths, thresholds, persistence values, and integration time remain engineering assumptions rather than measurements of a specific receiver;
+- no full baseband correlator/NCO/oscillator implementation is simulated;
+- no common-mode receiver oscillator process is introduced beyond the existing receiver clock behavior;
+- this report is static/REA focused and does not calibrate moving-receiver dynamics or vendor-specific loop adaptation;
+- RTKLIB PVT is secondary and must not become a tuning target.
+
+A future calibration dataset should include measured low-C/N0 static and moving observations with trustworthy receiver status/lock information. Calibration should compare CN0-conditioned Doppler error scale, FLL/PLL occupancy, loss/reacquisition timing, and ADR continuity. Frozen model parameters should be changed only when those observation-level measurements justify the change, never to force a desired final velocity metric.
+
+## Reproduction commands
+
+```bash
+cmake -S . -B build -DBUILD_TESTING=ON
+cmake --build build --config Release --parallel
+ctest --test-dir build -C Release --output-on-failure
+./build/gnss_sim_integration_tests --gtest_filter=CarrierTrackingAuthenticValidation.*
+```
+
+On Windows, use the corresponding Release executable path produced by CMake/Visual Studio; the focused tests are already included in normal `ctest` discovery.

--- a/docs/CARRIER_TRACKING_CORE.md
+++ b/docs/CARRIER_TRACKING_CORE.md
@@ -1,0 +1,107 @@
+# Carrier tracking core V1
+
+Issue: #160  
+Parent design: #159
+
+## Scope
+
+This document describes only the standalone carrier-tracking core. Runtime observation wiring, truth CSV integration, and authentic-NAV validation belong to #161, #162, and #163 respectively.
+
+The core does not modify urban propagation physics and does not own an RNG. The caller supplies one explicit standard-normal sample per update, so later runtime integration can choose a deterministic per-satellite/per-signal RNG convention without changing this model.
+
+## Frozen defaults
+
+| Parameter | V1 default |
+| --- | ---: |
+| coherent integration time | 0.020 s |
+| PLL noise bandwidth | 5 Hz |
+| FLL steady bandwidth | 4 Hz |
+| FLL pull-in bandwidth | 8 Hz |
+| FLL pull-in duration | 0.5 s |
+| PLL enter | >=30 dB-Hz for 1.0 s |
+| PLL exit | <27 dB-Hz for 0.3 s |
+| FLL acquire | >=22 dB-Hz for 0.2 s |
+| FLL loss | <18 dB-Hz for 0.5 s |
+| Doppler-valid delay after fresh carrier acquisition | 0.2 s |
+| ADR-valid delay after PLL entry | 1.0 s |
+
+All defaults are engineering assumptions for the V1 receiver model. They are configurable and are not calibrated universal receiver constants or PVT-error targets.
+
+## State semantics
+
+The standalone carrier state is one of:
+
+- `CARRIER_UNLOCKED`: carrier Doppler and ADR invalid;
+- `FLL_TRACK`: Doppler may become valid after the acquisition delay; ADR invalid;
+- `PLL_TRACK`: Doppler valid once carrier acquisition has matured; ADR becomes valid after the PLL confirmation delay.
+
+Fresh unlocked -> FLL acquisition uses the 8 Hz pull-in bandwidth for 0.5 s. PLL -> FLL fallback uses the 4 Hz steady FLL bandwidth because carrier frequency is already acquired. A fresh unlocked -> FLL transition starts a new carrier segment. Loss to unlocked clears the filtered carrier error.
+
+Threshold comparisons preserve hysteresis: equality at the acquisition/entry threshold counts as eligible, while equality at the loss/exit threshold does not count as a loss sample.
+
+## CN0 conversion
+
+Input `effective_cn0_dbhz` is converted to linear `C/N0` in Hz as:
+
+`cn0_linear = 10^(cn0_dbhz / 10)`.
+
+The implementation bounds the linear value to a finite numerical range only to prevent floating-point overflow/underflow for extreme test inputs. Ordinary GNSS CN0 values are unaffected.
+
+## FLL thermal jitter
+
+For the V1 differential-phase FLL, thermal velocity jitter follows the standard form:
+
+`sigma_v = lambda/(2*pi*T) * sqrt(4*F*Bn/(C/N0) * (1 + 1/(T*C/N0)))`.
+
+V1 uses `F = 1.0`, corresponding to the arctangent/high-CN0 discriminator reference convention. This choice is explicit rather than silently adding an empirical weak-signal sigma. A future measured-data calibration may justify a configurable low-CN0 discriminator factor, but #160 does not tune it to produce a desired velocity error.
+
+The equivalent frequency jitter is `sigma_f = sigma_v/lambda`.
+
+Reference: ESA Navipedia, *Frequency Lock Loop (FLL)*, which gives the same thermal-jitter form and identifies `F=1` at high C/N0 and `F=2` near the threshold.
+
+## PLL thermal jitter and equivalent Doppler scale
+
+For an arctangent PLL, V1 uses the standard thermal phase jitter:
+
+`sigma_phi = sqrt(Bn/(C/N0) * (1 + 1/(2*T*C/N0)))` rad.
+
+The standalone model needs an equivalent frequency-error scale for later Doppler synthesis. V1 converts one coherent-integration phase jitter to an equivalent frequency jitter by the explicit engineering approximation:
+
+`sigma_f = sigma_phi/(2*pi*T)`.
+
+Then `sigma_v = lambda*sigma_f`.
+
+This does not claim to be a full discrete PLL transfer-function simulation. It is a simplified CN0/T/Bn-driven receiver tracking model that is intentionally more physical than a fixed final Doppler sigma while remaining outside full IF/IQ/baseband simulation.
+
+Reference: ESA Navipedia, *Phase Lock Loop (PLL)*, for the thermal phase-jitter expression.
+
+## Time correlation
+
+The carrier error is first-order filtered:
+
+`e_k = alpha*e_(k-1) + sigma_k*sqrt(1-alpha^2)*w_k`
+
+with:
+
+`tau = 1/(2*pi*Bn)`
+
+`alpha = exp(-dt/tau)`.
+
+`w_k` is the caller-provided standard-normal sample. No arbitrary long-memory `rho` is configured. With the V1 loop bandwidths, thermal error itself can be nearly uncorrelated at a 1 Hz simulator output rate; slower observable correlation is expected to come later from effective-CN0/fading evolution, propagation state, and tracking-mode persistence.
+
+## Determinism contract
+
+- The core has no global/static RNG.
+- The core never samples wall-clock state.
+- Equal config, input sequence, initial state, and standard-normal sequence produce identical results.
+- `carrier_segment_id` increments only when a fresh unlocked carrier is acquired into FLL.
+- Runtime RNG ownership and legacy-RNG compatibility are deferred to #161.
+
+## Explicit exclusions
+
+- no simulator runtime Doppler/range-rate mutation;
+- no truth CSV/schema change;
+- no receiver oscillator/common-mode phase noise;
+- no moving receiver/reflector model;
+- no arbitrary weak-signal Doppler sigma;
+- no calibration to a target RTKLIB velocity error.

--- a/docs/CARRIER_TRACKING_RUNTIME.md
+++ b/docs/CARRIER_TRACKING_RUNTIME.md
@@ -1,0 +1,157 @@
+# Carrier Tracking Runtime Integration
+
+This document records the Issue #161 runtime integration of the standalone carrier-tracking core from Issue #160.
+
+## Scope
+
+The runtime layer is deliberately separate from physical propagation. It does not recompute satellite geometry, reflections, diffraction, DLL roots, coherent received power, or the urban carrier path derivative.
+
+The observation chain is:
+
+```text
+clean authentic-NAV measurement
+        |
+        v
+urban physical propagation (when enabled)
+        |
+        |  range_rate += environmental_range_rate_mps
+        |  Doppler    -= environmental_range_rate_mps / wavelength
+        v
+physical observation / existing truth outputs
+        |
+        v
+receiver carrier tracker
+        |
+        |  Doppler    += carrier_tracking_error_hz
+        |  range_rate -= wavelength * carrier_tracking_error_hz
+        v
+reported observation
+        |
+        v
+existing generic measurement-error model (when enabled)
+```
+
+Therefore the `environmental_range_rate_mps` validated by Issue #152 remains an independent physical quantity. Carrier tracking does not replace or modify it.
+
+## Configuration
+
+Carrier tracking is explicitly opt-in:
+
+```json
+{
+  "carrier_tracking": {
+    "enabled": true,
+    "coherent_integration_sec": 0.020,
+    "pll_noise_bandwidth_hz": 5.0,
+    "fll_noise_bandwidth_hz": 4.0,
+    "fll_pull_in_bandwidth_hz": 8.0,
+    "fll_pull_in_duration_sec": 0.5,
+    "pll_enter_cn0_dbhz": 30.0,
+    "pll_exit_cn0_dbhz": 27.0,
+    "pll_enter_persistence_sec": 1.0,
+    "pll_exit_persistence_sec": 0.3,
+    "fll_enter_cn0_dbhz": 22.0,
+    "fll_exit_cn0_dbhz": 18.0,
+    "fll_enter_persistence_sec": 0.2,
+    "fll_exit_persistence_sec": 0.5,
+    "doppler_valid_delay_sec": 0.2,
+    "adr_valid_after_pll_sec": 1.0
+  }
+}
+```
+
+The default is `enabled=false`. All numerical parameters are still validated while disabled, so an invalid dormant configuration cannot silently become active later.
+
+## Effective C/N0 source
+
+The carrier tracker consumes the C/N0 already produced by the receiver signal chain:
+
+- urban/multipath enabled: `UrbanSignalEpochResult::effective_cn0_dbhz`;
+- open sky: `SignalTracker::cn0_dbhz`.
+
+No independent attenuation, fixed Doppler sigma, or target-PVT error term is introduced.
+
+## Time stepping
+
+Simulator output rates are 1, 5, 10, 20, or 50 Hz, while the frozen coherent integration interval is 20 ms. A carrier state machine update only once per output epoch would skip 0.2/0.3/0.5 s persistence boundaries at low output rates.
+
+The runtime therefore divides each elapsed output interval into substeps no larger than `coherent_integration_sec`. C/N0 is held constant during those substeps in V1. This preserves the configured persistence, FLL pull-in, Doppler-valid, and PLL/ADR timing semantics without pretending that new propagation samples exist between receiver output epochs.
+
+The first epoch on which code tracking is alive establishes the carrier runtime timestamp only. It does not retroactively advance carrier acquisition through an interval during which no carrier runtime state existed. Consequently Doppler is not restored instantly on the first code-tracking/reacquisition sample.
+
+## Per-signal RNG ownership
+
+Each satellite + signal owns an independent deterministic PCG stream derived from:
+
+- simulator seed;
+- satellite number;
+- central `SignalId`.
+
+The carrier runtime never advances `RuntimeState::rng`, which remains the pre-existing receiver startup/acquisition RNG. It also does not use the generic measurement-error noise stream/state.
+
+When `carrier_tracking.enabled=false`, the runtime does not call the carrier updater and consumes no carrier samples. Changing dormant carrier parameters therefore cannot reorder or perturb legacy receiver output.
+
+Power/signal/code-tracking hard resets clear carrier tracking and continuity state but intentionally retain that signal's independent RNG stream. This models a receiver channel whose random process continues deterministically while lock state is restarted, without coupling unrelated signals.
+
+## Doppler and range-rate sign convention
+
+The existing clean measurement convention is:
+
+```text
+D = -(range_rate - satellite_clock_drift) / wavelength
+```
+
+For carrier frequency error `e_f` in hertz, Issue #159 defines:
+
+```text
+D_measured = D_physical + e_f
+```
+
+The wavelength-consistent range-rate representation must therefore be:
+
+```text
+range_rate_measured = range_rate_physical - wavelength * e_f
+```
+
+The runtime applies both terms together. Pseudorange is not changed by the carrier-tracking layer.
+
+## Independent validity
+
+Carrier validity is ANDed with the already-existing code/urban validity rather than replacing it.
+
+- `PLL_TRACK`: Doppler can be valid after the carrier acquisition delay; ADR becomes valid only after the configured PLL confirmation age.
+- `FLL_TRACK`: pseudorange can remain valid; Doppler can remain valid; ADR is invalid.
+- `CARRIER_UNLOCKED`: pseudorange can remain valid while Doppler and ADR are invalid.
+- no code tracking / BLOCKED: no normal carrier result is emitted and carrier state is hard-reset.
+
+Thus code, Doppler, and ADR validity are intentionally independent.
+
+## PLL continuity and ambiguity segments
+
+The pre-existing `CarrierAmbiguityState` is keyed to code-tracker `tracking_start_time`. A PLL-to-FLL transition can break carrier-phase continuity while code tracking remains alive, so resetting that existing ambiguity object alone would regenerate the same integer ambiguity.
+
+Issue #161 therefore maintains a separate deterministic carrier phase-segment identifier. On the first transition from `PLL_TRACK` to a non-PLL state:
+
+1. ADR becomes invalid immediately through the #160 result;
+2. the phase-segment identifier increments;
+3. a deterministic non-zero integer cycle offset is derived from the per-signal ambiguity key and new segment id;
+4. when a later PLL segment satisfies the ADR-valid delay, that offset is added to both reported ADR cycles and the reported ambiguity-cycle field.
+
+The code tracker `tracking_start_time` is not falsified or rewritten. Power/signal/code loss already establishes a fresh code-tracking ambiguity and resets this carrier phase-segment overlay.
+
+## Truth boundary for Issue #161
+
+Existing truth files are intentionally written before the receiver carrier-tracking layer. This keeps the existing physical/urban truth schema stable and preserves the Issue #152 path-rate evidence chain.
+
+Issue #162 will add exact in-memory carrier-tracking diagnostics including mode, active bandwidth, theoretical sigma, actual tracking error, phase segment/cycle-slip status, and final carrier validity. Issue #161 does not change truth CSV schemas.
+
+## V1 exclusions
+
+This runtime work does not add:
+
+- receiver oscillator/common-mode phase noise;
+- moving receiver or reflector models;
+- IF/IQ/baseband samples;
+- arbitrary weak-signal Doppler noise;
+- PVT-target tuning;
+- any NAV/EPH/ION fabrication or modification.

--- a/docs/CARRIER_TRACKING_TRUTH.md
+++ b/docs/CARRIER_TRACKING_TRUTH.md
@@ -1,0 +1,114 @@
+# Carrier-tracking truth diagnostics
+
+Issue: #162  
+Parent design: #159  
+Runtime integration: #161
+
+## Purpose and ownership
+
+`carrier_tracking_truth.csv` is a separate, explicitly versioned diagnostic extension for the receiver carrier-tracking layer. It is intentionally separate from `observation_truth.csv` and `urban_signal_truth.csv` so the physical-truth boundary established before carrier tracking remains unchanged.
+
+The simulator assembles a `CarrierTrackingTruthSnapshot` from the exact in-memory objects used by runtime. The CSV writer only serializes that snapshot. It does not recompute PLL/FLL state, hysteresis or persistence, jitter, CN0, urban propagation, validity, ambiguity, or measurement noise, and it never consumes random numbers.
+
+The observation chain represented by the file is:
+
+```text
+clean observation
+    -> physical urban propagation (when enabled)
+    -> physical observation / existing truth outputs
+    -> carrier-tracking result
+    -> post-carrier observation recorded here
+    -> generic measurement-error layer (when enabled)
+    -> normal RANGE output
+```
+
+Thus `physical_doppler_hz` and `physical_range_rate_mps` are values immediately before the carrier layer, while `post_carrier_doppler_hz` and `post_carrier_range_rate_mps` are values immediately after it and before generic measurement noise.
+
+## Schema
+
+`carrier_truth_schema_version` is currently `1`. The file is created for every simulator run, including when carrier tracking is disabled. Stable simulator satellite/signal iteration order gives deterministic row ordering.
+
+### Identity and receiver state
+
+- `gps_week`, `tow_ns`, `sow_sec`: receiver epoch.
+- `satellite_number`, `signal_id`, `signal_name`, `glonass_fcn`: signal identity.
+- `tracking_phase`, `acquisition_context`, `signal_loss_reason`: exact code/signal-tracker state used by runtime.
+- `carrier_tracking_enabled`: resolved feature toggle.
+- `carrier_result_available`: `1` only when code tracking is active and the carrier runtime was actually advanced for that epoch.
+- `carrier_reset_reason`: `NONE`, `FEATURE_DISABLED`, or `CODE_NOT_TRACKING`. `CODE_NOT_TRACKING` records the boundary at which the carrier runtime is hard-reset after the diagnostic row is captured.
+
+### Exact carrier input, state, and result
+
+When `carrier_result_available=1`, these fields are copied directly from the same runtime result/state that is subsequently applied to the observation:
+
+- `coherent_integration_sec`: configured carrier integration interval, seconds.
+- `effective_cn0_dbhz`: exact C/N0 input used by the carrier runtime, dB-Hz.
+- `cn0_linear_hz`: exact linear C/N0 stored in the runtime jitter result, Hz.
+- `carrier_mode`: `CARRIER_UNLOCKED`, `FLL_TRACK`, or `PLL_TRACK`.
+- `fll_phase`: `NONE`, `PULL_IN`, or `STEADY`.
+- `active_bandwidth_hz`: active loop bandwidth, Hz.
+- `phase_sigma_rad`: theoretical phase jitter stored by the core, radians.
+- `sigma_hz`, `sigma_mps`: theoretical carrier tracking jitter scale in Hz and m/s.
+- `correlation_tau_sec`, `correlation_alpha`: exact first-order correlation parameters used by the core.
+- `tracking_error_hz`, `tracking_error_mps`: actual deterministic filtered carrier error applied at that epoch.
+- `mode_age_sec`, `carrier_lock_age_sec`, `pll_age_sec`: exact post-update carrier state ages.
+- `fll_enter_persistence_sec`, `fll_exit_persistence_sec`, `pll_enter_persistence_sec`, `pll_exit_persistence_sec`: exact post-update hysteresis/persistence accumulators.
+- `carrier_segment_id`: core carrier-acquisition segment identifier.
+- `phase_segment_id`, `adr_cycle_offset_cycles`: runtime carrier-phase continuity overlay from #161.
+- `mode_changed`, `new_carrier_segment`, `cycle_slip_event`: exact runtime transition/event flags.
+
+When no carrier result exists, result-only fields are blank rather than synthesized from config or other truth rows. `coherent_integration_sec` remains present because it is resolved configuration, not a reconstructed runtime result.
+
+## Physical propagation and observation boundary
+
+- `environmental_range_rate_applicable`: `1` when the urban physical propagation model is active for the run.
+- `environmental_range_rate_valid`: exact validity from `UrbanCarrierTemporalResult`.
+- `environmental_range_rate_mps`: exact physical urban path-rate term, m/s, and blank when it is not valid. Open-sky runs do not invent a zero-valued urban term; they mark it not applicable.
+
+The physical observation block contains the exact observation before carrier tracking:
+
+- `physical_snapshot_available`
+- `physical_observation_available`
+- `physical_code_valid`
+- `physical_doppler_valid`
+- `physical_adr_valid`
+- `physical_range_rate_valid`
+- `physical_range_rate_mps`
+- `physical_doppler_hz`
+- `physical_adr_cycles`
+
+The post-carrier block contains the exact observation after `apply_carrier_tracking_runtime_result()` and before generic measurement noise:
+
+- `post_carrier_snapshot_available`
+- `post_carrier_observation_available`
+- `post_carrier_code_valid`
+- `post_carrier_doppler_valid`
+- `post_carrier_adr_valid`
+- `post_carrier_range_rate_valid`
+- `post_carrier_range_rate_mps`
+- `post_carrier_doppler_hz`
+- `post_carrier_adr_cycles`
+
+`range_rate_valid` follows the same receiver-carrier observable validity as Doppler because range rate is the wavelength-equivalent representation used by the simulator.
+
+For a valid active carrier result, #161's sign convention remains directly checkable from one row:
+
+```text
+post_carrier_doppler_hz
+  = physical_doppler_hz + tracking_error_hz
+
+post_carrier_range_rate_mps
+  = physical_range_rate_mps - tracking_error_mps
+```
+
+`tracking_error_mps = wavelength * tracking_error_hz` is already computed by the carrier core; the truth writer does not derive it.
+
+## Disabled and unavailable semantics
+
+When `carrier_tracking.enabled=false`, normal receiver behavior and RNG consumption remain unchanged. The carrier truth row has `carrier_tracking_enabled=0`, `carrier_result_available=0`, and `carrier_reset_reason=FEATURE_DISABLED` while a code-tracked physical/post-carrier observation can still be recorded; those two observation snapshots are identical because the carrier layer was bypassed.
+
+When code tracking is not active, `carrier_result_available=0`, `carrier_reset_reason=CODE_NOT_TRACKING`, and observation snapshots are unavailable. Signal tracking phase/loss reason remain available so loss/reset epochs are diagnosable without reconstructing them in the writer.
+
+## Scope boundary
+
+This diagnostic file does not change normal RANGE serialization, the physical urban truth schemas, carrier equations/defaults, navigation data, or the measurement-noise layer. Authentic-NAV statistical validation and RTKLIB outcome analysis remain in #163.

--- a/include/gnss_sim/sim_config.h
+++ b/include/gnss_sim/sim_config.h
@@ -73,6 +73,25 @@ struct MeasurementErrorConfig {
     MeasurementFadeErrorConfig rea_fade;
 };
 
+struct CarrierTrackingReceiverConfig {
+    bool enabled;
+    double coherent_integration_sec;
+    double pll_noise_bandwidth_hz;
+    double fll_noise_bandwidth_hz;
+    double fll_pull_in_bandwidth_hz;
+    double fll_pull_in_duration_sec;
+    double pll_enter_cn0_dbhz;
+    double pll_exit_cn0_dbhz;
+    double pll_enter_persistence_sec;
+    double pll_exit_persistence_sec;
+    double fll_enter_cn0_dbhz;
+    double fll_exit_cn0_dbhz;
+    double fll_enter_persistence_sec;
+    double fll_exit_persistence_sec;
+    double doppler_valid_delay_sec;
+    double adr_valid_after_pll_sec;
+};
+
 struct UrbanRfMaterialConfig {
     double relative_permittivity_real;
     double conductivity_c_s_per_m;
@@ -135,6 +154,7 @@ struct SimConfig {
     ReaConfig rea;
     BestposRtkConfig bestpos_rtk;
     MeasurementErrorConfig measurement_error;
+    CarrierTrackingReceiverConfig carrier_tracking;
     UrbanRfConfig urban_rf;
     std::vector<Cn0HighBaselineConfig> cn0_high_dbhz;
     std::uint64_t seed;

--- a/src/core/sim_config.cpp
+++ b/src/core/sim_config.cpp
@@ -2,6 +2,7 @@
 
 #include "gnss/signal_definitions.h"
 #include "gnss_sim/sim_time.h"
+#include "model/carrier_tracking.h"
 
 #include <cJSON.h>
 #include <cmath>
@@ -327,6 +328,51 @@ bool parse_measurement_error(const cJSON* root, SimConfig* config, std::string* 
            parse_measurement_fade(object, &config->measurement_error.rea_fade, error_message);
 }
 
+bool parse_carrier_tracking(const cJSON* root, SimConfig* config, std::string* error_message) {
+    const cJSON* object = cJSON_GetObjectItemCaseSensitive(root, "carrier_tracking");
+    if (object == nullptr) {
+        return true;
+    }
+    const char* const allowed_keys[] = {"enabled",
+                                        "coherent_integration_sec",
+                                        "pll_noise_bandwidth_hz",
+                                        "fll_noise_bandwidth_hz",
+                                        "fll_pull_in_bandwidth_hz",
+                                        "fll_pull_in_duration_sec",
+                                        "pll_enter_cn0_dbhz",
+                                        "pll_exit_cn0_dbhz",
+                                        "pll_enter_persistence_sec",
+                                        "pll_exit_persistence_sec",
+                                        "fll_enter_cn0_dbhz",
+                                        "fll_exit_cn0_dbhz",
+                                        "fll_enter_persistence_sec",
+                                        "fll_exit_persistence_sec",
+                                        "doppler_valid_delay_sec",
+                                        "adr_valid_after_pll_sec"};
+    if (!validate_object_keys(object, "carrier_tracking", allowed_keys, 16U, error_message)) {
+        return false;
+    }
+    CarrierTrackingReceiverConfig& carrier = config->carrier_tracking;
+    return read_optional_bool(object, "enabled", &carrier.enabled, error_message) &&
+           read_optional_number(object, "coherent_integration_sec", &carrier.coherent_integration_sec, error_message) &&
+           read_optional_number(object, "pll_noise_bandwidth_hz", &carrier.pll_noise_bandwidth_hz, error_message) &&
+           read_optional_number(object, "fll_noise_bandwidth_hz", &carrier.fll_noise_bandwidth_hz, error_message) &&
+           read_optional_number(object, "fll_pull_in_bandwidth_hz", &carrier.fll_pull_in_bandwidth_hz, error_message) &&
+           read_optional_number(object, "fll_pull_in_duration_sec", &carrier.fll_pull_in_duration_sec, error_message) &&
+           read_optional_number(object, "pll_enter_cn0_dbhz", &carrier.pll_enter_cn0_dbhz, error_message) &&
+           read_optional_number(object, "pll_exit_cn0_dbhz", &carrier.pll_exit_cn0_dbhz, error_message) &&
+           read_optional_number(object, "pll_enter_persistence_sec", &carrier.pll_enter_persistence_sec,
+                                error_message) &&
+           read_optional_number(object, "pll_exit_persistence_sec", &carrier.pll_exit_persistence_sec, error_message) &&
+           read_optional_number(object, "fll_enter_cn0_dbhz", &carrier.fll_enter_cn0_dbhz, error_message) &&
+           read_optional_number(object, "fll_exit_cn0_dbhz", &carrier.fll_exit_cn0_dbhz, error_message) &&
+           read_optional_number(object, "fll_enter_persistence_sec", &carrier.fll_enter_persistence_sec,
+                                error_message) &&
+           read_optional_number(object, "fll_exit_persistence_sec", &carrier.fll_exit_persistence_sec, error_message) &&
+           read_optional_number(object, "doppler_valid_delay_sec", &carrier.doppler_valid_delay_sec, error_message) &&
+           read_optional_number(object, "adr_valid_after_pll_sec", &carrier.adr_valid_after_pll_sec, error_message);
+}
+
 bool parse_urban_rf_material(const cJSON* object, const char* section_name, UrbanRfMaterialConfig* config,
                              std::string* error_message) {
     if (object == nullptr) {
@@ -492,6 +538,26 @@ bool parse_seed(const cJSON* root, SimConfig* config, std::string* error_message
     return true;
 }
 
+CarrierTrackingConfig to_carrier_tracking_config(const CarrierTrackingReceiverConfig& config) {
+    CarrierTrackingConfig output{};
+    output.coherent_integration_sec = config.coherent_integration_sec;
+    output.pll_noise_bandwidth_hz = config.pll_noise_bandwidth_hz;
+    output.fll_noise_bandwidth_hz = config.fll_noise_bandwidth_hz;
+    output.fll_pull_in_bandwidth_hz = config.fll_pull_in_bandwidth_hz;
+    output.fll_pull_in_duration_sec = config.fll_pull_in_duration_sec;
+    output.pll_enter_cn0_dbhz = config.pll_enter_cn0_dbhz;
+    output.pll_exit_cn0_dbhz = config.pll_exit_cn0_dbhz;
+    output.pll_enter_persistence_sec = config.pll_enter_persistence_sec;
+    output.pll_exit_persistence_sec = config.pll_exit_persistence_sec;
+    output.fll_enter_cn0_dbhz = config.fll_enter_cn0_dbhz;
+    output.fll_exit_cn0_dbhz = config.fll_exit_cn0_dbhz;
+    output.fll_enter_persistence_sec = config.fll_enter_persistence_sec;
+    output.fll_exit_persistence_sec = config.fll_exit_persistence_sec;
+    output.doppler_valid_delay_sec = config.doppler_valid_delay_sec;
+    output.adr_valid_after_pll_sec = config.adr_valid_after_pll_sec;
+    return output;
+}
+
 bool finite_nonnegative(double value) {
     return std::isfinite(value) && value >= 0.0;
 }
@@ -615,6 +681,23 @@ SimConfig default_sim_config() {
                                 {0.70, 0.15, 2.5, 2.0},
                                 {0.40, 0.10, 1.5, 0.8},
                                 {0.25, 0.80, 0.20, 4.5}};
+    const CarrierTrackingConfig carrier = default_carrier_tracking_config();
+    config.carrier_tracking = {false,
+                               carrier.coherent_integration_sec,
+                               carrier.pll_noise_bandwidth_hz,
+                               carrier.fll_noise_bandwidth_hz,
+                               carrier.fll_pull_in_bandwidth_hz,
+                               carrier.fll_pull_in_duration_sec,
+                               carrier.pll_enter_cn0_dbhz,
+                               carrier.pll_exit_cn0_dbhz,
+                               carrier.pll_enter_persistence_sec,
+                               carrier.pll_exit_persistence_sec,
+                               carrier.fll_enter_cn0_dbhz,
+                               carrier.fll_exit_cn0_dbhz,
+                               carrier.fll_enter_persistence_sec,
+                               carrier.fll_exit_persistence_sec,
+                               carrier.doppler_valid_delay_sec,
+                               carrier.adr_valid_after_pll_sec};
     config.urban_rf.default_material = {6.27, 0.0043, 1.1925, 0.006, 0.012, 0.006, 5.0};
     config.urban_rf.default_antenna = {{0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0}};
     config.seed = 1U;
@@ -651,6 +734,11 @@ bool validate_sim_config(const SimConfig& config, std::string* error_message) {
     }
     if (!valid_measurement_error_config(config.measurement_error)) {
         set_error(error_message, "measurement_error configuration is invalid");
+        return false;
+    }
+    std::string carrier_error;
+    if (!validate_carrier_tracking_config(to_carrier_tracking_config(config.carrier_tracking), &carrier_error)) {
+        set_error(error_message, std::string("carrier_tracking configuration is invalid: ") + carrier_error);
         return false;
     }
     if (!valid_urban_rf_config(config.urban_rf)) {
@@ -730,6 +818,7 @@ bool load_sim_config_json(const char* file_path, SimConfig* config, std::string*
                                         "measurement_noise_enabled",
                                         "bestpos_rtk",
                                         "measurement_error",
+                                        "carrier_tracking",
                                         "urban_rf",
                                         "cn0_high_dbhz",
                                         "multipath_enabled",
@@ -742,7 +831,7 @@ bool load_sim_config_json(const char* file_path, SimConfig* config, std::string*
                                         "seed"};
 
     SimConfig parsed = default_sim_config();
-    bool success = validate_object_keys(root, "root", allowed_keys, 21U, error_message);
+    bool success = validate_object_keys(root, "root", allowed_keys, 22U, error_message);
 
     double duration_sec = static_cast<double>(parsed.duration_ns) / static_cast<double>(NANOSECONDS_PER_SECOND);
     const char* scenario_name = scenario_type_name(parsed.scenario);
@@ -774,7 +863,8 @@ bool load_sim_config_json(const char* file_path, SimConfig* config, std::string*
             parse_atmosphere_mode(atmosphere_name, &parsed.atmosphere_mode, error_message) &&
             parse_receiver(root, &parsed, error_message) && parse_ttff(root, &parsed, error_message) &&
             parse_rea(root, &parsed, error_message) && parse_bestpos_rtk(root, &parsed, error_message) &&
-            parse_measurement_error(root, &parsed, error_message) && parse_urban_rf(root, &parsed, error_message) &&
+            parse_measurement_error(root, &parsed, error_message) &&
+            parse_carrier_tracking(root, &parsed, error_message) && parse_urban_rf(root, &parsed, error_message) &&
             parse_cn0_high_dbhz(root, &parsed, error_message) && parse_seed(root, &parsed, error_message) &&
             validate_sim_config(parsed, error_message);
     }

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -21,6 +21,7 @@
 #include "model/urban_carrier_temporal.h"
 #include "model/urban_scene_geometry.h"
 #include "model/urban_signal_epoch.h"
+#include "output/carrier_tracking_truth_writer.h"
 #include "output/device_marker.h"
 #include "output/novatel_nav_writer.h"
 #include "output/novatel_range_writer.h"
@@ -798,7 +799,7 @@ bool update_tracking_and_measurements(RuntimeState* runtime, const SimConfig& co
                                       const ScenarioEpochState& scenario,
                                       std::vector<MeasurementObservation>* measurements, int* tracked_satellites,
                                       TruthWriter* truth_writer, UrbanTruthWriter* urban_truth_writer,
-                                      std::string* error_message) {
+                                      CarrierTrackingTruthWriter* carrier_truth_writer, std::string* error_message) {
     measurements->clear();
     *tracked_satellites = 0;
     const RtklibNavStore* truth_nav = truth_navigation_store(runtime->navigation);
@@ -937,9 +938,20 @@ bool update_tracking_and_measurements(RuntimeState* runtime, const SimConfig& co
             }
 
             if (signal.tracker.phase != SignalTrackingPhase::kTracking) {
-                if (config.multipath_enabled &&
-                    !urban_truth_writer_write_signal(urban_truth_writer, signal_geometry, *definition, glonass_fcn,
-                                                     urban_epoch, urban_temporal, nullptr, error_message)) {
+                CarrierTrackingTruthSnapshot carrier_truth{};
+                carrier_truth.carrier_tracking_enabled = config.carrier_tracking.enabled;
+                carrier_truth.reset_reason = CarrierTrackingTruthResetReason::kCodeNotTracking;
+                carrier_truth.coherent_integration_sec = config.carrier_tracking.coherent_integration_sec;
+                carrier_truth.environmental_range_rate_applicable = config.multipath_enabled;
+                carrier_truth.environmental_range_rate_valid =
+                    config.multipath_enabled && urban_temporal.environmental_range_rate_valid;
+                carrier_truth.environmental_range_rate_mps = urban_temporal.environmental_range_rate_mps;
+                if (!carrier_tracking_truth_writer_write_signal(carrier_truth_writer, signal_geometry, *definition,
+                                                                glonass_fcn, signal.tracker, carrier_truth,
+                                                                error_message) ||
+                    (config.multipath_enabled &&
+                     !urban_truth_writer_write_signal(urban_truth_writer, signal_geometry, *definition, glonass_fcn,
+                                                      urban_epoch, urban_temporal, nullptr, error_message))) {
                     return false;
                 }
                 reset_carrier_ambiguity_state(&signal.ambiguity);
@@ -948,6 +960,17 @@ bool update_tracking_and_measurements(RuntimeState* runtime, const SimConfig& co
                 continue;
             }
             satellite_tracking = true;
+
+            CarrierTrackingTruthSnapshot carrier_truth{};
+            carrier_truth.carrier_tracking_enabled = config.carrier_tracking.enabled;
+            carrier_truth.reset_reason = config.carrier_tracking.enabled
+                                             ? CarrierTrackingTruthResetReason::kNone
+                                             : CarrierTrackingTruthResetReason::kFeatureDisabled;
+            carrier_truth.coherent_integration_sec = config.carrier_tracking.coherent_integration_sec;
+            carrier_truth.environmental_range_rate_applicable = config.multipath_enabled;
+            carrier_truth.environmental_range_rate_valid =
+                config.multipath_enabled && urban_temporal.environmental_range_rate_valid;
+            carrier_truth.environmental_range_rate_mps = urban_temporal.environmental_range_rate_mps;
 
             CarrierTrackingRuntimeResult carrier_result{};
             if (config.carrier_tracking.enabled) {
@@ -963,6 +986,10 @@ bool update_tracking_and_measurements(RuntimeState* runtime, const SimConfig& co
                                                      error_message)) {
                     return false;
                 }
+                carrier_truth.result_available = true;
+                carrier_truth.effective_cn0_dbhz = carrier_cn0_dbhz;
+                carrier_truth.runtime_result = carrier_result;
+                carrier_truth.runtime_state = signal.carrier_tracking.tracking;
             }
 
             AtmosphereCorrection atmosphere{};
@@ -985,6 +1012,9 @@ bool update_tracking_and_measurements(RuntimeState* runtime, const SimConfig& co
                  !apply_urban_measurement_effects(urban_epoch, urban_temporal, &observation, error_message))) {
                 return false;
             }
+            carrier_truth.physical_snapshot_available = true;
+            carrier_truth.physical_observation = observation;
+            carrier_truth.physical_range_rate_valid = observation.doppler_valid;
             if ((config.multipath_enabled &&
                  !urban_truth_writer_write_signal(urban_truth_writer, signal_geometry, *definition, glonass_fcn,
                                                   urban_epoch, urban_temporal, &observation, error_message)) ||
@@ -995,6 +1025,14 @@ bool update_tracking_and_measurements(RuntimeState* runtime, const SimConfig& co
             MeasurementObservation reported_observation = observation;
             if (config.carrier_tracking.enabled &&
                 !apply_carrier_tracking_runtime_result(carrier_result, &reported_observation, error_message)) {
+                return false;
+            }
+            carrier_truth.post_carrier_snapshot_available = true;
+            carrier_truth.post_carrier_observation = reported_observation;
+            carrier_truth.post_carrier_range_rate_valid = reported_observation.doppler_valid;
+            if (!carrier_tracking_truth_writer_write_signal(carrier_truth_writer, signal_geometry, *definition,
+                                                            glonass_fcn, signal.tracker, carrier_truth,
+                                                            error_message)) {
                 return false;
             }
             if (config.measurement_noise_enabled) {
@@ -1144,8 +1182,17 @@ bool run_simulator(const SimConfig& config, const SimulatorRunOptions& options, 
         destroy_navigation_state(runtime.navigation);
         return false;
     }
+    CarrierTrackingTruthWriter* carrier_truth_writer =
+        create_carrier_tracking_truth_writer(options.output_log_path, error_message);
+    if (carrier_truth_writer == nullptr) {
+        destroy_truth_writer(truth_writer);
+        output.close();
+        destroy_navigation_state(runtime.navigation);
+        return false;
+    }
     UrbanTruthWriter* urban_truth_writer = create_urban_truth_writer(options.output_log_path, error_message);
     if (urban_truth_writer == nullptr) {
+        destroy_carrier_tracking_truth_writer(carrier_truth_writer);
         destroy_truth_writer(truth_writer);
         output.close();
         destroy_navigation_state(runtime.navigation);
@@ -1156,6 +1203,7 @@ bool run_simulator(const SimConfig& config, const SimulatorRunOptions& options, 
     if (!epoch_count_for_duration(config.duration_ns, config.sampling_rate_hz, &epoch_count)) {
         set_error(error_message, "cannot compute simulator epoch count");
         destroy_urban_truth_writer(urban_truth_writer);
+        destroy_carrier_tracking_truth_writer(carrier_truth_writer);
         destroy_truth_writer(truth_writer);
         destroy_navigation_state(runtime.navigation);
         return false;
@@ -1218,7 +1266,7 @@ bool run_simulator(const SimConfig& config, const SimulatorRunOptions& options, 
 
         int tracked_satellites = 0;
         if (!update_tracking_and_measurements(&runtime, config, scenario, &measurements, &tracked_satellites,
-                                              truth_writer, urban_truth_writer, error_message) ||
+                                              truth_writer, urban_truth_writer, carrier_truth_writer, error_message) ||
             !process_receiver_nav(&runtime, config, current_time, &output, &result, error_message)) {
             ok = false;
             break;
@@ -1254,6 +1302,9 @@ bool run_simulator(const SimConfig& config, const SimulatorRunOptions& options, 
         ok = false;
     }
     output.close();
+    if (ok && !finalize_carrier_tracking_truth_writer(carrier_truth_writer, error_message)) {
+        ok = false;
+    }
     if (ok && !finalize_urban_truth_writer(urban_truth_writer, error_message)) {
         ok = false;
     }
@@ -1262,6 +1313,7 @@ bool run_simulator(const SimConfig& config, const SimulatorRunOptions& options, 
         ok = false;
     }
     destroy_urban_truth_writer(urban_truth_writer);
+    destroy_carrier_tracking_truth_writer(carrier_truth_writer);
     destroy_truth_writer(truth_writer);
     destroy_navigation_state(runtime.navigation);
     if (!ok) {

--- a/src/core/simulator.cpp
+++ b/src/core/simulator.cpp
@@ -11,6 +11,7 @@
 #include "gnss_sim/sim_time.h"
 #include "model/atmosphere_model.h"
 #include "model/bestpos_rtk_model.h"
+#include "model/carrier_tracking_runtime.h"
 #include "model/cn0_model.h"
 #include "model/code_tracking_dll.h"
 #include "model/measurement_error_model.h"
@@ -54,6 +55,7 @@ struct SignalRuntime {
     CarrierAmbiguityState ambiguity;
     MeasurementErrorState measurement_error;
     UrbanCarrierTemporalState urban_carrier_temporal;
+    CarrierTrackingRuntimeState carrier_tracking;
     bool ever_scheduled;
 };
 
@@ -310,7 +312,8 @@ ColdFamilyRuntime* cold_family_state(SatelliteRuntime* satellite, NavMessageFami
 }
 
 bool build_satellite_runtimes(const std::vector<TruthScheduleEntry>& schedule, const SimTime& reset_time,
-                              std::vector<SatelliteRuntime>* satellites, std::string* error_message) {
+                              std::uint64_t simulator_seed, std::vector<SatelliteRuntime>* satellites,
+                              std::string* error_message) {
     if (satellites == nullptr) {
         set_error(error_message, "satellite runtime output is null");
         return false;
@@ -341,6 +344,8 @@ bool build_satellite_runtimes(const std::vector<TruthScheduleEntry>& schedule, c
             reset_signal_tracker(&signal.tracker, definitions[index].signal_id, reset_time);
             reset_carrier_ambiguity_state(&signal.ambiguity);
             reset_urban_carrier_temporal_state(&signal.urban_carrier_temporal);
+            initialize_carrier_tracking_runtime_state(simulator_seed, satellite_number, definitions[index].signal_id,
+                                                      &signal.carrier_tracking);
             satellite.signals.push_back(signal);
         }
         for (const TruthScheduleEntry& entry : schedule) {
@@ -509,6 +514,7 @@ bool receiver_power_on(RuntimeState* runtime, const SimConfig& config, const Sim
             reset_carrier_ambiguity_state(&signal.ambiguity);
             reset_measurement_error_state(&signal.measurement_error);
             reset_urban_carrier_temporal_state(&signal.urban_carrier_temporal);
+            reset_carrier_tracking_runtime_state(&signal.carrier_tracking);
             signal.ever_scheduled = false;
         }
         for (ColdFamilyRuntime& family : satellite.cold_families) {
@@ -534,6 +540,7 @@ void receiver_power_off(RuntimeState* runtime, const SimTime& time) {
             reset_carrier_ambiguity_state(&signal.ambiguity);
             reset_measurement_error_state(&signal.measurement_error);
             reset_urban_carrier_temporal_state(&signal.urban_carrier_temporal);
+            reset_carrier_tracking_runtime_state(&signal.carrier_tracking);
         }
     }
 }
@@ -546,6 +553,7 @@ void receiver_signal_off(RuntimeState* runtime, const SimTime& time) {
             reset_carrier_ambiguity_state(&signal.ambiguity);
             reset_measurement_error_state(&signal.measurement_error);
             reset_urban_carrier_temporal_state(&signal.urban_carrier_temporal);
+            reset_carrier_tracking_runtime_state(&signal.carrier_tracking);
         }
     }
 }
@@ -936,9 +944,26 @@ bool update_tracking_and_measurements(RuntimeState* runtime, const SimConfig& co
                 }
                 reset_carrier_ambiguity_state(&signal.ambiguity);
                 reset_measurement_error_state(&signal.measurement_error);
+                reset_carrier_tracking_runtime_state(&signal.carrier_tracking);
                 continue;
             }
             satellite_tracking = true;
+
+            CarrierTrackingRuntimeResult carrier_result{};
+            if (config.carrier_tracking.enabled) {
+                double wavelength_m = 0.0;
+                if (!signal_wavelength_m(*definition, glonass_fcn, &wavelength_m)) {
+                    set_error(error_message, "cannot determine carrier tracking signal wavelength");
+                    return false;
+                }
+                const double carrier_cn0_dbhz =
+                    config.multipath_enabled ? urban_epoch.effective_cn0_dbhz : signal.tracker.cn0_dbhz;
+                if (!update_carrier_tracking_runtime(config.carrier_tracking, scenario.time, true, carrier_cn0_dbhz,
+                                                     wavelength_m, &signal.carrier_tracking, &carrier_result,
+                                                     error_message)) {
+                    return false;
+                }
+            }
 
             AtmosphereCorrection atmosphere{};
             if (!compute_atmosphere_correction(config.atmosphere_mode, truth_nav, scenario.time,
@@ -968,11 +993,25 @@ bool update_tracking_and_measurements(RuntimeState* runtime, const SimConfig& co
                 return false;
             }
             MeasurementObservation reported_observation = observation;
-            if (config.measurement_noise_enabled &&
-                !apply_measurement_error(
-                    config.measurement_error, config.seed, measurement_error_context(config, scenario, signal.tracker),
-                    signal.tracker, observation, &signal.measurement_error, &reported_observation, error_message)) {
+            if (config.carrier_tracking.enabled &&
+                !apply_carrier_tracking_runtime_result(carrier_result, &reported_observation, error_message)) {
                 return false;
+            }
+            if (config.measurement_noise_enabled) {
+                if (config.carrier_tracking.enabled) {
+                    const MeasurementObservation measurement_error_input = reported_observation;
+                    if (!apply_measurement_error(config.measurement_error, config.seed,
+                                                 measurement_error_context(config, scenario, signal.tracker),
+                                                 signal.tracker, measurement_error_input, &signal.measurement_error,
+                                                 &reported_observation, error_message)) {
+                        return false;
+                    }
+                } else if (!apply_measurement_error(config.measurement_error, config.seed,
+                                                    measurement_error_context(config, scenario, signal.tracker),
+                                                    signal.tracker, observation, &signal.measurement_error,
+                                                    &reported_observation, error_message)) {
+                    return false;
+                }
             }
             measurements->push_back(reported_observation);
         }
@@ -1055,7 +1094,8 @@ bool run_simulator(const SimConfig& config, const SimulatorRunOptions& options, 
         load_truth_navigation(runtime.navigation, options.rinex_nav_path, error_message) &&
         make_static_receiver_truth(config.receiver, &runtime.receiver, error_message) &&
         build_truth_schedule(truth_navigation_store(runtime.navigation), &runtime.truth_schedule, error_message) &&
-        build_satellite_runtimes(runtime.truth_schedule, options.start_time, &runtime.satellites, error_message);
+        build_satellite_runtimes(runtime.truth_schedule, options.start_time, config.seed, &runtime.satellites,
+                                 error_message);
     if (!ok) {
         destroy_navigation_state(runtime.navigation);
         return false;

--- a/src/model/carrier_tracking.cpp
+++ b/src/model/carrier_tracking.cpp
@@ -1,0 +1,385 @@
+#include "model/carrier_tracking.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace gnss_sim {
+namespace {
+
+constexpr double kTwoPi = 6.283185307179586476925286766559;
+constexpr double kElapsedToleranceSec = 1e-12;
+constexpr double kMinimumCn0LinearHz = 1e-12;
+constexpr double kMaximumCn0LinearHz = 1e12;
+constexpr double kFllNoiseFactor = 1.0;
+
+bool fail(std::string* error_message, const char* message) {
+    if (error_message != nullptr) {
+        *error_message = message;
+    }
+    return false;
+}
+
+bool positive_finite(double value) {
+    return std::isfinite(value) && value > 0.0;
+}
+
+bool finite_value(double value) {
+    return std::isfinite(value);
+}
+
+bool elapsed_reached(double elapsed_sec, double threshold_sec) {
+    return elapsed_sec + kElapsedToleranceSec >= threshold_sec;
+}
+
+double cn0_dbhz_to_linear(double cn0_dbhz) {
+    const double exponent = cn0_dbhz / 10.0;
+    double value = std::pow(10.0, exponent);
+    if (!std::isfinite(value)) {
+        value = exponent > 0.0 ? kMaximumCn0LinearHz : kMinimumCn0LinearHz;
+    }
+    return std::clamp(value, kMinimumCn0LinearHz, kMaximumCn0LinearHz);
+}
+
+void clear_persistence(CarrierTrackingState* state) {
+    state->fll_enter_persistence_sec = 0.0;
+    state->fll_exit_persistence_sec = 0.0;
+    state->pll_enter_persistence_sec = 0.0;
+    state->pll_exit_persistence_sec = 0.0;
+}
+
+void enter_unlocked(CarrierTrackingState* state) {
+    state->mode = CarrierTrackingMode::kCarrierUnlocked;
+    state->fll_pull_in_active = false;
+    state->mode_age_sec = 0.0;
+    state->carrier_lock_age_sec = 0.0;
+    state->pll_age_sec = 0.0;
+    state->tracking_error_hz = 0.0;
+    clear_persistence(state);
+}
+
+void enter_fll_from_unlocked(CarrierTrackingState* state) {
+    state->mode = CarrierTrackingMode::kFllTrack;
+    state->fll_pull_in_active = true;
+    state->mode_age_sec = 0.0;
+    state->carrier_lock_age_sec = 0.0;
+    state->pll_age_sec = 0.0;
+    state->tracking_error_hz = 0.0;
+    clear_persistence(state);
+    ++state->carrier_segment_id;
+}
+
+void enter_fll_from_pll(CarrierTrackingState* state) {
+    state->mode = CarrierTrackingMode::kFllTrack;
+    state->fll_pull_in_active = false;
+    state->mode_age_sec = 0.0;
+    state->pll_age_sec = 0.0;
+    state->fll_enter_persistence_sec = 0.0;
+    state->fll_exit_persistence_sec = 0.0;
+    state->pll_enter_persistence_sec = 0.0;
+    state->pll_exit_persistence_sec = 0.0;
+}
+
+void enter_pll(CarrierTrackingState* state) {
+    state->mode = CarrierTrackingMode::kPllTrack;
+    state->fll_pull_in_active = false;
+    state->mode_age_sec = 0.0;
+    state->pll_age_sec = 0.0;
+    state->fll_enter_persistence_sec = 0.0;
+    state->fll_exit_persistence_sec = 0.0;
+    state->pll_enter_persistence_sec = 0.0;
+    state->pll_exit_persistence_sec = 0.0;
+}
+
+CarrierTrackingFllPhase fll_phase_from_state(const CarrierTrackingState& state) {
+    if (state.mode != CarrierTrackingMode::kFllTrack) {
+        return CarrierTrackingFllPhase::kNone;
+    }
+    return state.fll_pull_in_active ? CarrierTrackingFllPhase::kPullIn : CarrierTrackingFllPhase::kSteady;
+}
+
+void fill_unlocked_result(const CarrierTrackingState& state, bool mode_changed, CarrierTrackingResult* result) {
+    result->mode = state.mode;
+    result->fll_phase = CarrierTrackingFllPhase::kNone;
+    result->jitter = CarrierTrackingJitter{};
+    result->tracking_error_hz = 0.0;
+    result->tracking_error_mps = 0.0;
+    result->carrier_lock_age_sec = 0.0;
+    result->pll_age_sec = 0.0;
+    result->carrier_segment_id = state.carrier_segment_id;
+    result->doppler_valid = false;
+    result->adr_valid = false;
+    result->mode_changed = mode_changed;
+    result->new_carrier_segment = false;
+}
+
+} // namespace
+
+CarrierTrackingConfig default_carrier_tracking_config() {
+    CarrierTrackingConfig config{};
+    config.coherent_integration_sec = 0.020;
+    config.pll_noise_bandwidth_hz = 5.0;
+    config.fll_noise_bandwidth_hz = 4.0;
+    config.fll_pull_in_bandwidth_hz = 8.0;
+    config.fll_pull_in_duration_sec = 0.5;
+
+    config.pll_enter_cn0_dbhz = 30.0;
+    config.pll_exit_cn0_dbhz = 27.0;
+    config.pll_enter_persistence_sec = 1.0;
+    config.pll_exit_persistence_sec = 0.3;
+
+    config.fll_enter_cn0_dbhz = 22.0;
+    config.fll_exit_cn0_dbhz = 18.0;
+    config.fll_enter_persistence_sec = 0.2;
+    config.fll_exit_persistence_sec = 0.5;
+
+    config.doppler_valid_delay_sec = 0.2;
+    config.adr_valid_after_pll_sec = 1.0;
+    return config;
+}
+
+bool validate_carrier_tracking_config(const CarrierTrackingConfig& config, std::string* error_message) {
+    if (!positive_finite(config.coherent_integration_sec)) {
+        return fail(error_message, "carrier coherent integration time must be finite and positive");
+    }
+    if (!positive_finite(config.pll_noise_bandwidth_hz) || !positive_finite(config.fll_noise_bandwidth_hz) ||
+        !positive_finite(config.fll_pull_in_bandwidth_hz)) {
+        return fail(error_message, "carrier loop bandwidths must be finite and positive");
+    }
+    if (config.fll_pull_in_bandwidth_hz < config.fll_noise_bandwidth_hz) {
+        return fail(error_message, "FLL pull-in bandwidth must be at least the steady FLL bandwidth");
+    }
+    if (!positive_finite(config.fll_pull_in_duration_sec) || !positive_finite(config.pll_enter_persistence_sec) ||
+        !positive_finite(config.pll_exit_persistence_sec) || !positive_finite(config.fll_enter_persistence_sec) ||
+        !positive_finite(config.fll_exit_persistence_sec) || !positive_finite(config.doppler_valid_delay_sec) ||
+        !positive_finite(config.adr_valid_after_pll_sec)) {
+        return fail(error_message, "carrier tracking durations must be finite and positive");
+    }
+    if (!finite_value(config.pll_enter_cn0_dbhz) || !finite_value(config.pll_exit_cn0_dbhz) ||
+        !finite_value(config.fll_enter_cn0_dbhz) || !finite_value(config.fll_exit_cn0_dbhz)) {
+        return fail(error_message, "carrier tracking CN0 thresholds must be finite");
+    }
+    if (!(config.pll_enter_cn0_dbhz > config.pll_exit_cn0_dbhz &&
+          config.pll_exit_cn0_dbhz > config.fll_enter_cn0_dbhz &&
+          config.fll_enter_cn0_dbhz > config.fll_exit_cn0_dbhz)) {
+        return fail(error_message,
+                    "carrier tracking CN0 thresholds must satisfy PLL-enter > PLL-exit > FLL-enter > FLL-exit");
+    }
+    return true;
+}
+
+void reset_carrier_tracking_state(CarrierTrackingState* state) {
+    if (state == nullptr) {
+        return;
+    }
+    *state = CarrierTrackingState{};
+    state->mode = CarrierTrackingMode::kCarrierUnlocked;
+}
+
+bool compute_carrier_tracking_jitter(const CarrierTrackingConfig& config, CarrierTrackingMode mode,
+                                     bool fll_pull_in_active, double effective_cn0_dbhz, double wavelength_m,
+                                     double dt_sec, CarrierTrackingJitter* jitter, std::string* error_message) {
+    if (jitter == nullptr) {
+        return fail(error_message, "carrier tracking jitter output is null");
+    }
+    *jitter = CarrierTrackingJitter{};
+    if (!validate_carrier_tracking_config(config, error_message)) {
+        return false;
+    }
+    if (!finite_value(effective_cn0_dbhz)) {
+        return fail(error_message, "effective CN0 must be finite");
+    }
+    if (!positive_finite(wavelength_m)) {
+        return fail(error_message, "carrier wavelength must be finite and positive");
+    }
+    if (!positive_finite(dt_sec)) {
+        return fail(error_message, "carrier tracking dt must be finite and positive");
+    }
+    if (mode == CarrierTrackingMode::kCarrierUnlocked) {
+        return true;
+    }
+
+    const double cn0_linear_hz = cn0_dbhz_to_linear(effective_cn0_dbhz);
+    const double integration_sec = config.coherent_integration_sec;
+    double bandwidth_hz = config.pll_noise_bandwidth_hz;
+    double phase_sigma_rad = 0.0;
+    double sigma_hz = 0.0;
+
+    if (mode == CarrierTrackingMode::kFllTrack) {
+        bandwidth_hz = fll_pull_in_active ? config.fll_pull_in_bandwidth_hz : config.fll_noise_bandwidth_hz;
+        const double correction = 1.0 + 1.0 / (integration_sec * cn0_linear_hz);
+        const double variance_term = 4.0 * kFllNoiseFactor * bandwidth_hz / cn0_linear_hz * correction;
+        sigma_hz = std::sqrt(variance_term) / (kTwoPi * integration_sec);
+    } else if (mode == CarrierTrackingMode::kPllTrack) {
+        bandwidth_hz = config.pll_noise_bandwidth_hz;
+        const double correction = 1.0 + 1.0 / (2.0 * integration_sec * cn0_linear_hz);
+        const double phase_variance_rad2 = bandwidth_hz / cn0_linear_hz * correction;
+        phase_sigma_rad = std::sqrt(phase_variance_rad2);
+        sigma_hz = phase_sigma_rad / (kTwoPi * integration_sec);
+    } else {
+        return fail(error_message, "unsupported carrier tracking mode");
+    }
+
+    const double tau_sec = 1.0 / (kTwoPi * bandwidth_hz);
+    const double alpha = std::exp(-dt_sec / tau_sec);
+    const double sigma_mps = wavelength_m * sigma_hz;
+    if (!std::isfinite(phase_sigma_rad) || !std::isfinite(sigma_hz) || !std::isfinite(sigma_mps) ||
+        !std::isfinite(tau_sec) || !std::isfinite(alpha)) {
+        return fail(error_message, "carrier tracking jitter calculation produced a non-finite value");
+    }
+
+    jitter->cn0_linear_hz = cn0_linear_hz;
+    jitter->active_bandwidth_hz = bandwidth_hz;
+    jitter->phase_sigma_rad = phase_sigma_rad;
+    jitter->sigma_hz = sigma_hz;
+    jitter->sigma_mps = sigma_mps;
+    jitter->correlation_tau_sec = tau_sec;
+    jitter->correlation_alpha = alpha;
+    return true;
+}
+
+bool update_carrier_tracking(const CarrierTrackingConfig& config, const CarrierTrackingInput& input,
+                             CarrierTrackingState* state, CarrierTrackingResult* result, std::string* error_message) {
+    if (state == nullptr || result == nullptr) {
+        return fail(error_message, "carrier tracking state/result is null");
+    }
+    *result = CarrierTrackingResult{};
+    if (!validate_carrier_tracking_config(config, error_message)) {
+        return false;
+    }
+    if (!finite_value(input.effective_cn0_dbhz)) {
+        return fail(error_message, "effective CN0 must be finite");
+    }
+    if (!positive_finite(input.wavelength_m)) {
+        return fail(error_message, "carrier wavelength must be finite and positive");
+    }
+    if (!positive_finite(input.dt_sec)) {
+        return fail(error_message, "carrier tracking dt must be finite and positive");
+    }
+    if (!finite_value(input.standard_normal_sample)) {
+        return fail(error_message, "carrier tracking Gaussian input must be finite");
+    }
+
+    const CarrierTrackingMode previous_mode = state->mode;
+    bool new_carrier_segment = false;
+
+    if (!input.signal_available) {
+        enter_unlocked(state);
+        fill_unlocked_result(*state, previous_mode != state->mode, result);
+        return true;
+    }
+
+    switch (state->mode) {
+        case CarrierTrackingMode::kCarrierUnlocked:
+            if (input.effective_cn0_dbhz >= config.fll_enter_cn0_dbhz) {
+                state->fll_enter_persistence_sec += input.dt_sec;
+            } else {
+                state->fll_enter_persistence_sec = 0.0;
+            }
+            if (elapsed_reached(state->fll_enter_persistence_sec, config.fll_enter_persistence_sec)) {
+                enter_fll_from_unlocked(state);
+                new_carrier_segment = true;
+            }
+            break;
+
+        case CarrierTrackingMode::kFllTrack:
+            state->mode_age_sec += input.dt_sec;
+            state->carrier_lock_age_sec += input.dt_sec;
+            if (state->fll_pull_in_active && elapsed_reached(state->mode_age_sec, config.fll_pull_in_duration_sec)) {
+                state->fll_pull_in_active = false;
+            }
+
+            if (input.effective_cn0_dbhz < config.fll_exit_cn0_dbhz) {
+                state->fll_exit_persistence_sec += input.dt_sec;
+            } else {
+                state->fll_exit_persistence_sec = 0.0;
+            }
+            if (elapsed_reached(state->fll_exit_persistence_sec, config.fll_exit_persistence_sec)) {
+                enter_unlocked(state);
+                break;
+            }
+
+            if (input.effective_cn0_dbhz >= config.pll_enter_cn0_dbhz) {
+                state->pll_enter_persistence_sec += input.dt_sec;
+            } else {
+                state->pll_enter_persistence_sec = 0.0;
+            }
+            if (elapsed_reached(state->pll_enter_persistence_sec, config.pll_enter_persistence_sec)) {
+                enter_pll(state);
+            }
+            break;
+
+        case CarrierTrackingMode::kPllTrack:
+            state->mode_age_sec += input.dt_sec;
+            state->carrier_lock_age_sec += input.dt_sec;
+            state->pll_age_sec += input.dt_sec;
+            if (input.effective_cn0_dbhz < config.pll_exit_cn0_dbhz) {
+                state->pll_exit_persistence_sec += input.dt_sec;
+            } else {
+                state->pll_exit_persistence_sec = 0.0;
+            }
+            if (elapsed_reached(state->pll_exit_persistence_sec, config.pll_exit_persistence_sec)) {
+                enter_fll_from_pll(state);
+            }
+            break;
+    }
+
+    if (state->mode == CarrierTrackingMode::kCarrierUnlocked) {
+        fill_unlocked_result(*state, previous_mode != state->mode, result);
+        return true;
+    }
+
+    CarrierTrackingJitter jitter{};
+    if (!compute_carrier_tracking_jitter(config, state->mode, state->fll_pull_in_active, input.effective_cn0_dbhz,
+                                         input.wavelength_m, input.dt_sec, &jitter, error_message)) {
+        return false;
+    }
+
+    const double innovation_scale = std::sqrt(std::max(0.0, 1.0 - jitter.correlation_alpha * jitter.correlation_alpha));
+    state->tracking_error_hz = jitter.correlation_alpha * state->tracking_error_hz +
+                               jitter.sigma_hz * innovation_scale * input.standard_normal_sample;
+    if (!std::isfinite(state->tracking_error_hz)) {
+        return fail(error_message, "carrier tracking filtered error became non-finite");
+    }
+
+    result->mode = state->mode;
+    result->fll_phase = fll_phase_from_state(*state);
+    result->jitter = jitter;
+    result->tracking_error_hz = state->tracking_error_hz;
+    result->tracking_error_mps = input.wavelength_m * state->tracking_error_hz;
+    result->carrier_lock_age_sec = state->carrier_lock_age_sec;
+    result->pll_age_sec = state->pll_age_sec;
+    result->carrier_segment_id = state->carrier_segment_id;
+    result->doppler_valid = elapsed_reached(state->carrier_lock_age_sec, config.doppler_valid_delay_sec);
+    result->adr_valid = state->mode == CarrierTrackingMode::kPllTrack &&
+                        elapsed_reached(state->pll_age_sec, config.adr_valid_after_pll_sec);
+    result->mode_changed = previous_mode != state->mode;
+    result->new_carrier_segment = new_carrier_segment;
+    return true;
+}
+
+const char* carrier_tracking_mode_name(CarrierTrackingMode mode) {
+    switch (mode) {
+        case CarrierTrackingMode::kCarrierUnlocked:
+            return "CARRIER_UNLOCKED";
+        case CarrierTrackingMode::kFllTrack:
+            return "FLL_TRACK";
+        case CarrierTrackingMode::kPllTrack:
+            return "PLL_TRACK";
+    }
+    return "UNKNOWN";
+}
+
+const char* carrier_tracking_fll_phase_name(CarrierTrackingFllPhase phase) {
+    switch (phase) {
+        case CarrierTrackingFllPhase::kNone:
+            return "NONE";
+        case CarrierTrackingFllPhase::kPullIn:
+            return "PULL_IN";
+        case CarrierTrackingFllPhase::kSteady:
+            return "STEADY";
+    }
+    return "UNKNOWN";
+}
+
+} // namespace gnss_sim

--- a/src/model/carrier_tracking.h
+++ b/src/model/carrier_tracking.h
@@ -1,0 +1,117 @@
+#ifndef GNSS_SIM_SRC_MODEL_CARRIER_TRACKING_H_
+#define GNSS_SIM_SRC_MODEL_CARRIER_TRACKING_H_
+
+#include <cstdint>
+#include <string>
+
+namespace gnss_sim {
+
+enum class CarrierTrackingMode {
+    kCarrierUnlocked,
+    kFllTrack,
+    kPllTrack,
+};
+
+enum class CarrierTrackingFllPhase {
+    kNone,
+    kPullIn,
+    kSteady,
+};
+
+struct CarrierTrackingConfig {
+    double coherent_integration_sec;
+    double pll_noise_bandwidth_hz;
+    double fll_noise_bandwidth_hz;
+    double fll_pull_in_bandwidth_hz;
+    double fll_pull_in_duration_sec;
+
+    double pll_enter_cn0_dbhz;
+    double pll_exit_cn0_dbhz;
+    double pll_enter_persistence_sec;
+    double pll_exit_persistence_sec;
+
+    double fll_enter_cn0_dbhz;
+    double fll_exit_cn0_dbhz;
+    double fll_enter_persistence_sec;
+    double fll_exit_persistence_sec;
+
+    double doppler_valid_delay_sec;
+    double adr_valid_after_pll_sec;
+};
+
+struct CarrierTrackingState {
+    CarrierTrackingMode mode;
+    bool fll_pull_in_active;
+    double mode_age_sec;
+    double carrier_lock_age_sec;
+    double pll_age_sec;
+    double fll_enter_persistence_sec;
+    double fll_exit_persistence_sec;
+    double pll_enter_persistence_sec;
+    double pll_exit_persistence_sec;
+    double tracking_error_hz;
+    std::uint64_t carrier_segment_id;
+};
+
+struct CarrierTrackingInput {
+    bool signal_available;
+    double effective_cn0_dbhz;
+    double wavelength_m;
+    double dt_sec;
+    // One explicit N(0,1) draw owned by the caller. The core never owns or
+    // advances a random-number generator, so runtime integration can preserve
+    // deterministic per-signal RNG ordering.
+    double standard_normal_sample;
+};
+
+struct CarrierTrackingJitter {
+    double cn0_linear_hz;
+    double active_bandwidth_hz;
+    double phase_sigma_rad;
+    double sigma_hz;
+    double sigma_mps;
+    double correlation_tau_sec;
+    double correlation_alpha;
+};
+
+struct CarrierTrackingResult {
+    CarrierTrackingMode mode;
+    CarrierTrackingFllPhase fll_phase;
+    CarrierTrackingJitter jitter;
+    double tracking_error_hz;
+    double tracking_error_mps;
+    double carrier_lock_age_sec;
+    double pll_age_sec;
+    std::uint64_t carrier_segment_id;
+    bool doppler_valid;
+    bool adr_valid;
+    bool mode_changed;
+    bool new_carrier_segment;
+};
+
+CarrierTrackingConfig default_carrier_tracking_config();
+bool validate_carrier_tracking_config(const CarrierTrackingConfig& config, std::string* error_message);
+
+void reset_carrier_tracking_state(CarrierTrackingState* state);
+
+// Compute the thermal-jitter scale and loop-derived first-order correlation
+// coefficient for one active carrier-tracking mode. The FLL uses the standard
+// differential-phase thermal frequency-jitter expression with discriminator
+// factor F=1.0. For PLL mode, phase jitter from an arctangent PLL is converted
+// to an equivalent one-integration frequency jitter by sigma_f=sigma_phi/(2*pi*T).
+bool compute_carrier_tracking_jitter(const CarrierTrackingConfig& config, CarrierTrackingMode mode,
+                                     bool fll_pull_in_active, double effective_cn0_dbhz, double wavelength_m,
+                                     double dt_sec, CarrierTrackingJitter* jitter, std::string* error_message);
+
+// Advance one per-satellite/per-signal carrier tracker. State transitions are
+// driven by effective CN0 hysteresis/persistence. The supplied Gaussian sample
+// is filtered with alpha=exp(-dt/tau), tau=1/(2*pi*Bn).
+bool update_carrier_tracking(const CarrierTrackingConfig& config, const CarrierTrackingInput& input,
+                             CarrierTrackingState* state, CarrierTrackingResult* result, std::string* error_message);
+
+const char* carrier_tracking_mode_name(CarrierTrackingMode mode);
+const char* carrier_tracking_fll_phase_name(CarrierTrackingFllPhase phase);
+
+} // namespace gnss_sim
+
+#endif // GNSS_SIM_SRC_MODEL_CARRIER_TRACKING_H_

--- a/src/model/carrier_tracking_runtime.cpp
+++ b/src/model/carrier_tracking_runtime.cpp
@@ -1,0 +1,240 @@
+#include "model/carrier_tracking_runtime.h"
+
+#include "gnss_sim/sim_time.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace gnss_sim {
+namespace {
+
+constexpr double kTwoPi = 6.283185307179586476925286766559;
+constexpr double kMinimumUniform = 1.0 / 9007199254740992.0;
+constexpr double kNegativeInfinityCn0FloorDbhz = -120.0;
+constexpr std::uint64_t kSatelliteSalt = 0x9E3779B97F4A7C15ULL;
+constexpr std::uint64_t kSignalSalt = 0xBF58476D1CE4E5B9ULL;
+constexpr std::uint64_t kSequenceSalt = 0x94D049BB133111EBULL;
+constexpr std::uint64_t kAmbiguitySalt = 0xD6E8FEB86659FD93ULL;
+
+void set_error(std::string* error_message, const char* message) {
+    if (error_message != nullptr) {
+        *error_message = message;
+    }
+}
+
+std::uint64_t mix64(std::uint64_t value) {
+    value += 0x9E3779B97F4A7C15ULL;
+    value = (value ^ (value >> 30U)) * 0xBF58476D1CE4E5B9ULL;
+    value = (value ^ (value >> 27U)) * 0x94D049BB133111EBULL;
+    return value ^ (value >> 31U);
+}
+
+std::uint64_t signal_key(std::uint64_t simulator_seed, int satellite_number, SignalId signal_id) {
+    const std::uint64_t satellite = static_cast<std::uint64_t>(static_cast<std::uint32_t>(satellite_number));
+    const std::uint64_t signal = static_cast<std::uint64_t>(signal_id);
+    return mix64(simulator_seed ^ mix64(satellite + kSatelliteSalt) ^ mix64(signal + kSignalSalt));
+}
+
+double standard_normal_sample(DeterministicRng* rng) {
+    const double u1 = std::max(rng_uniform_01(rng), kMinimumUniform);
+    const double u2 = rng_uniform_01(rng);
+    return std::sqrt(-2.0 * std::log(u1)) * std::cos(kTwoPi * u2);
+}
+
+std::int64_t segment_cycle_offset(std::uint64_t ambiguity_key, std::uint64_t segment_id) {
+    if (segment_id == 0U) {
+        return 0;
+    }
+    const std::uint64_t mixed = mix64(ambiguity_key ^ mix64(segment_id + kAmbiguitySalt));
+    constexpr std::int64_t kSpan = 200001;
+    std::int64_t offset = static_cast<std::int64_t>(mixed % static_cast<std::uint64_t>(kSpan)) - 100000;
+    if (offset == 0) {
+        offset = 1;
+    }
+    return offset;
+}
+
+void fill_runtime_result(const CarrierTrackingRuntimeState& state, const CarrierTrackingResult& tracking,
+                         bool cycle_slip_event, CarrierTrackingRuntimeResult* result) {
+    result->tracking = tracking;
+    result->phase_segment_id = state.phase_segment_id;
+    result->adr_cycle_offset_cycles = state.adr_cycle_offset_cycles;
+    result->cycle_slip_event = cycle_slip_event;
+}
+
+CarrierTrackingResult unlocked_result(const CarrierTrackingRuntimeState& state) {
+    CarrierTrackingResult result{};
+    result.mode = CarrierTrackingMode::kCarrierUnlocked;
+    result.fll_phase = CarrierTrackingFllPhase::kNone;
+    result.carrier_segment_id = state.tracking.carrier_segment_id;
+    return result;
+}
+
+double normalized_cn0(double effective_cn0_dbhz) {
+    if (std::isinf(effective_cn0_dbhz) && effective_cn0_dbhz < 0.0) {
+        return kNegativeInfinityCn0FloorDbhz;
+    }
+    return effective_cn0_dbhz;
+}
+
+} // namespace
+
+CarrierTrackingConfig carrier_tracking_core_config(const CarrierTrackingReceiverConfig& config) {
+    CarrierTrackingConfig output{};
+    output.coherent_integration_sec = config.coherent_integration_sec;
+    output.pll_noise_bandwidth_hz = config.pll_noise_bandwidth_hz;
+    output.fll_noise_bandwidth_hz = config.fll_noise_bandwidth_hz;
+    output.fll_pull_in_bandwidth_hz = config.fll_pull_in_bandwidth_hz;
+    output.fll_pull_in_duration_sec = config.fll_pull_in_duration_sec;
+    output.pll_enter_cn0_dbhz = config.pll_enter_cn0_dbhz;
+    output.pll_exit_cn0_dbhz = config.pll_exit_cn0_dbhz;
+    output.pll_enter_persistence_sec = config.pll_enter_persistence_sec;
+    output.pll_exit_persistence_sec = config.pll_exit_persistence_sec;
+    output.fll_enter_cn0_dbhz = config.fll_enter_cn0_dbhz;
+    output.fll_exit_cn0_dbhz = config.fll_exit_cn0_dbhz;
+    output.fll_enter_persistence_sec = config.fll_enter_persistence_sec;
+    output.fll_exit_persistence_sec = config.fll_exit_persistence_sec;
+    output.doppler_valid_delay_sec = config.doppler_valid_delay_sec;
+    output.adr_valid_after_pll_sec = config.adr_valid_after_pll_sec;
+    return output;
+}
+
+void initialize_carrier_tracking_runtime_state(std::uint64_t simulator_seed, int satellite_number, SignalId signal_id,
+                                               CarrierTrackingRuntimeState* state) {
+    if (state == nullptr) {
+        return;
+    }
+    *state = CarrierTrackingRuntimeState{};
+    const std::uint64_t key = signal_key(simulator_seed, satellite_number, signal_id);
+    seed_rng(&state->rng, key, mix64(key ^ kSequenceSalt));
+    state->ambiguity_key = mix64(key ^ kAmbiguitySalt);
+    state->initialized = true;
+    reset_carrier_tracking_state(&state->tracking);
+}
+
+void reset_carrier_tracking_runtime_state(CarrierTrackingRuntimeState* state) {
+    if (state == nullptr || !state->initialized) {
+        return;
+    }
+    reset_carrier_tracking_state(&state->tracking);
+    state->last_update_time = SimTime{};
+    state->phase_segment_id = 0U;
+    state->adr_cycle_offset_cycles = 0;
+    state->time_initialized = false;
+}
+
+bool update_carrier_tracking_runtime(const CarrierTrackingReceiverConfig& config, const SimTime& current_time,
+                                     bool code_tracking, double effective_cn0_dbhz, double wavelength_m,
+                                     CarrierTrackingRuntimeState* state, CarrierTrackingRuntimeResult* result,
+                                     std::string* error_message) {
+    if (state == nullptr || result == nullptr || !state->initialized) {
+        set_error(error_message, "carrier tracking runtime state/result is invalid");
+        return false;
+    }
+    *result = CarrierTrackingRuntimeResult{};
+    const CarrierTrackingConfig core_config = carrier_tracking_core_config(config);
+    if (!validate_carrier_tracking_config(core_config, error_message)) {
+        return false;
+    }
+    if (!std::isfinite(wavelength_m) || wavelength_m <= 0.0) {
+        set_error(error_message, "carrier tracking runtime wavelength must be finite and positive");
+        return false;
+    }
+    const double cn0_dbhz = normalized_cn0(effective_cn0_dbhz);
+    if (!std::isfinite(cn0_dbhz)) {
+        set_error(error_message, "carrier tracking runtime effective CN0 is invalid");
+        return false;
+    }
+
+    if (!code_tracking) {
+        reset_carrier_tracking_runtime_state(state);
+        fill_runtime_result(*state, unlocked_result(*state), false, result);
+        return true;
+    }
+
+    if (!state->time_initialized) {
+        state->last_update_time = current_time;
+        state->time_initialized = true;
+        fill_runtime_result(*state, unlocked_result(*state), false, result);
+        return true;
+    }
+
+    std::int64_t elapsed_ns = 0;
+    if (!difference_time_ns(current_time, state->last_update_time, &elapsed_ns) || elapsed_ns <= 0) {
+        set_error(error_message, "carrier tracking runtime time must advance monotonically");
+        return false;
+    }
+
+    double remaining_sec = static_cast<double>(elapsed_ns) / static_cast<double>(NANOSECONDS_PER_SECOND);
+    CarrierTrackingResult tracking = unlocked_result(*state);
+    bool cycle_slip_event = false;
+    while (remaining_sec > 0.0) {
+        const double dt_sec = std::min(remaining_sec, core_config.coherent_integration_sec);
+        const CarrierTrackingMode previous_mode = state->tracking.mode;
+        CarrierTrackingInput input{};
+        input.signal_available = true;
+        input.effective_cn0_dbhz = cn0_dbhz;
+        input.wavelength_m = wavelength_m;
+        input.dt_sec = dt_sec;
+        input.standard_normal_sample = standard_normal_sample(&state->rng);
+        if (!update_carrier_tracking(core_config, input, &state->tracking, &tracking, error_message)) {
+            return false;
+        }
+        if (previous_mode == CarrierTrackingMode::kPllTrack && tracking.mode != CarrierTrackingMode::kPllTrack) {
+            ++state->phase_segment_id;
+            state->adr_cycle_offset_cycles = segment_cycle_offset(state->ambiguity_key, state->phase_segment_id);
+            cycle_slip_event = true;
+        }
+        remaining_sec -= dt_sec;
+        if (remaining_sec < std::numeric_limits<double>::epsilon()) {
+            remaining_sec = 0.0;
+        }
+    }
+
+    state->last_update_time = current_time;
+    fill_runtime_result(*state, tracking, cycle_slip_event, result);
+    return true;
+}
+
+bool apply_carrier_tracking_runtime_result(const CarrierTrackingRuntimeResult& carrier,
+                                           MeasurementObservation* observation, std::string* error_message) {
+    if (observation == nullptr || !std::isfinite(observation->wavelength_m) || observation->wavelength_m <= 0.0 ||
+        !std::isfinite(observation->range_rate_mps) || !std::isfinite(observation->doppler_hz) ||
+        !std::isfinite(observation->adr_cycles) || !std::isfinite(carrier.tracking.tracking_error_hz) ||
+        !std::isfinite(carrier.tracking.tracking_error_mps)) {
+        set_error(error_message, "carrier tracking measurement application has invalid arguments");
+        return false;
+    }
+
+    MeasurementObservation output = *observation;
+    if (carrier.tracking.mode != CarrierTrackingMode::kCarrierUnlocked) {
+        output.doppler_hz += carrier.tracking.tracking_error_hz;
+        output.range_rate_mps -= carrier.tracking.tracking_error_mps;
+    }
+
+    output.doppler_valid = output.doppler_valid && carrier.tracking.doppler_valid;
+    output.adr_valid = output.adr_valid && carrier.tracking.adr_valid;
+    if (output.adr_valid) {
+        if ((carrier.adr_cycle_offset_cycles > 0 &&
+             output.ambiguity_cycles > std::numeric_limits<std::int64_t>::max() - carrier.adr_cycle_offset_cycles) ||
+            (carrier.adr_cycle_offset_cycles < 0 &&
+             output.ambiguity_cycles < std::numeric_limits<std::int64_t>::min() - carrier.adr_cycle_offset_cycles)) {
+            set_error(error_message, "carrier tracking ambiguity offset overflow");
+            return false;
+        }
+        output.ambiguity_cycles += carrier.adr_cycle_offset_cycles;
+        output.adr_cycles += static_cast<double>(carrier.adr_cycle_offset_cycles);
+    }
+
+    if (!output.observation_available) {
+        output.pseudorange_valid = false;
+        output.doppler_valid = false;
+        output.adr_valid = false;
+    }
+
+    *observation = output;
+    return true;
+}
+
+} // namespace gnss_sim

--- a/src/model/carrier_tracking_runtime.h
+++ b/src/model/carrier_tracking_runtime.h
@@ -1,0 +1,61 @@
+#ifndef GNSS_SIM_SRC_MODEL_CARRIER_TRACKING_RUNTIME_H_
+#define GNSS_SIM_SRC_MODEL_CARRIER_TRACKING_RUNTIME_H_
+
+#include "core/deterministic_rng.h"
+#include "gnss_sim/sim_config.h"
+#include "gnss_sim/sim_types.h"
+#include "model/carrier_tracking.h"
+#include "model/measurement_model.h"
+
+#include <cstdint>
+#include <string>
+
+namespace gnss_sim {
+
+struct CarrierTrackingRuntimeState {
+    CarrierTrackingState tracking;
+    DeterministicRng rng;
+    SimTime last_update_time;
+    std::uint64_t ambiguity_key;
+    std::uint64_t phase_segment_id;
+    std::int64_t adr_cycle_offset_cycles;
+    bool initialized;
+    bool time_initialized;
+};
+
+struct CarrierTrackingRuntimeResult {
+    CarrierTrackingResult tracking;
+    std::uint64_t phase_segment_id;
+    std::int64_t adr_cycle_offset_cycles;
+    bool cycle_slip_event;
+};
+
+CarrierTrackingConfig carrier_tracking_core_config(const CarrierTrackingReceiverConfig& config);
+
+void initialize_carrier_tracking_runtime_state(std::uint64_t simulator_seed, int satellite_number, SignalId signal_id,
+                                               CarrierTrackingRuntimeState* state);
+
+// Hard-reset tracking/continuity state while intentionally preserving the
+// independent per-signal RNG stream. No legacy/global RNG is consumed here.
+void reset_carrier_tracking_runtime_state(CarrierTrackingRuntimeState* state);
+
+// Advance one carrier tracker from its previous runtime timestamp to
+// current_time. The interval is subdivided into steps no larger than the
+// configured coherent integration time so output rates below 50 Hz cannot skip
+// persistence/pull-in/validity timing boundaries.
+bool update_carrier_tracking_runtime(const CarrierTrackingReceiverConfig& config, const SimTime& current_time,
+                                     bool code_tracking, double effective_cn0_dbhz, double wavelength_m,
+                                     CarrierTrackingRuntimeState* state, CarrierTrackingRuntimeResult* result,
+                                     std::string* error_message);
+
+// Apply only the receiver carrier-tracking layer. The observation passed here
+// is already the clean/open-sky or urban-physical observation, including any
+// environmental_range_rate_mps term. Sign convention:
+//   D_measured = D_physical + tracking_error_hz
+//   range_rate_measured = range_rate_physical - wavelength * tracking_error_hz
+bool apply_carrier_tracking_runtime_result(const CarrierTrackingRuntimeResult& carrier,
+                                           MeasurementObservation* observation, std::string* error_message);
+
+} // namespace gnss_sim
+
+#endif // GNSS_SIM_SRC_MODEL_CARRIER_TRACKING_RUNTIME_H_

--- a/src/output/carrier_tracking_truth_writer.cpp
+++ b/src/output/carrier_tracking_truth_writer.cpp
@@ -1,0 +1,205 @@
+#include "output/carrier_tracking_truth_writer.h"
+
+#include "gnss_sim/sim_time.h"
+
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <locale>
+#include <new>
+#include <string>
+
+namespace gnss_sim {
+
+struct CarrierTrackingTruthWriter {
+    std::ofstream stream;
+    bool finalized;
+};
+
+namespace {
+
+void set_error(std::string* error_message, const std::string& message) {
+    if (error_message != nullptr) {
+        *error_message = message;
+    }
+}
+
+bool open_csv(std::ofstream* stream, const std::filesystem::path& path, const char* header,
+              std::string* error_message) {
+    stream->open(path, std::ios::binary | std::ios::trunc);
+    if (!*stream) {
+        set_error(error_message, std::string("cannot open carrier tracking truth CSV: ") + path.generic_string());
+        return false;
+    }
+    stream->imbue(std::locale::classic());
+    *stream << header << '\n';
+    if (!*stream) {
+        set_error(error_message,
+                  std::string("cannot write carrier tracking truth CSV header: ") + path.generic_string());
+        return false;
+    }
+    return true;
+}
+
+void write_time(std::ofstream& stream, const SimTime& time) {
+    stream << time.gps_week << ',' << time.tow_ns << ',' << std::fixed << std::setprecision(9)
+           << sim_time_sow_sec(time);
+}
+
+const char* acquisition_context_name(AcquisitionContext context) {
+    switch (context) {
+        case AcquisitionContext::kHot:
+            return "HOT";
+        case AcquisitionContext::kWarm:
+            return "WARM";
+        case AcquisitionContext::kCold:
+            return "COLD";
+        case AcquisitionContext::kReacquisition:
+            return "REACQUISITION";
+    }
+    return "UNKNOWN";
+}
+
+void write_observation(std::ofstream& output, bool snapshot_available, const MeasurementObservation& observation,
+                       bool range_rate_valid) {
+    output << (snapshot_available ? 1 : 0) << ',';
+    if (!snapshot_available) {
+        output << ",,,,,,,,";
+        return;
+    }
+    output << (observation.observation_available ? 1 : 0) << ',' << (observation.pseudorange_valid ? 1 : 0) << ','
+           << (observation.doppler_valid ? 1 : 0) << ',' << (observation.adr_valid ? 1 : 0) << ','
+           << (range_rate_valid ? 1 : 0) << ',' << std::scientific << std::setprecision(17)
+           << observation.range_rate_mps << ',' << observation.doppler_hz << ',' << observation.adr_cycles << ',';
+}
+
+} // namespace
+
+const char* carrier_tracking_truth_reset_reason_name(CarrierTrackingTruthResetReason reason) {
+    switch (reason) {
+        case CarrierTrackingTruthResetReason::kNone:
+            return "NONE";
+        case CarrierTrackingTruthResetReason::kFeatureDisabled:
+            return "FEATURE_DISABLED";
+        case CarrierTrackingTruthResetReason::kCodeNotTracking:
+            return "CODE_NOT_TRACKING";
+    }
+    return "UNKNOWN";
+}
+
+CarrierTrackingTruthWriter* create_carrier_tracking_truth_writer(const char* receiver_log_path,
+                                                                 std::string* error_message) {
+    if (receiver_log_path == nullptr || receiver_log_path[0] == '\0') {
+        set_error(error_message, "carrier tracking truth writer request has invalid output path");
+        return nullptr;
+    }
+    CarrierTrackingTruthWriter* writer = new (std::nothrow) CarrierTrackingTruthWriter{};
+    if (writer == nullptr) {
+        set_error(error_message, "cannot allocate carrier tracking truth writer");
+        return nullptr;
+    }
+    std::filesystem::path output_directory = std::filesystem::path(receiver_log_path).parent_path();
+    if (output_directory.empty()) {
+        output_directory = ".";
+    }
+    const char* header =
+        "carrier_truth_schema_version,gps_week,tow_ns,sow_sec,satellite_number,signal_id,signal_name,glonass_fcn,"
+        "tracking_phase,acquisition_context,signal_loss_reason,carrier_tracking_enabled,carrier_result_available,"
+        "carrier_reset_reason,coherent_integration_sec,effective_cn0_dbhz,cn0_linear_hz,carrier_mode,fll_phase,"
+        "active_bandwidth_hz,phase_sigma_rad,sigma_hz,sigma_mps,correlation_tau_sec,correlation_alpha,"
+        "tracking_error_hz,tracking_error_mps,mode_age_sec,carrier_lock_age_sec,pll_age_sec,"
+        "fll_enter_persistence_sec,fll_exit_persistence_sec,pll_enter_persistence_sec,pll_exit_persistence_sec,"
+        "carrier_segment_id,phase_segment_id,adr_cycle_offset_cycles,mode_changed,new_carrier_segment,cycle_slip_event,"
+        "environmental_range_rate_applicable,environmental_range_rate_valid,environmental_range_rate_mps,"
+        "physical_snapshot_available,physical_observation_available,physical_code_valid,physical_doppler_valid,"
+        "physical_adr_valid,physical_range_rate_valid,physical_range_rate_mps,physical_doppler_hz,physical_adr_cycles,"
+        "post_carrier_snapshot_available,post_carrier_observation_available,post_carrier_code_valid,"
+        "post_carrier_doppler_valid,post_carrier_adr_valid,post_carrier_range_rate_valid,post_carrier_range_rate_mps,"
+        "post_carrier_doppler_hz,post_carrier_adr_cycles";
+    if (!open_csv(&writer->stream, output_directory / "carrier_tracking_truth.csv", header, error_message)) {
+        delete writer;
+        return nullptr;
+    }
+    return writer;
+}
+
+void destroy_carrier_tracking_truth_writer(CarrierTrackingTruthWriter* writer) {
+    delete writer;
+}
+
+bool carrier_tracking_truth_writer_write_signal(CarrierTrackingTruthWriter* writer, const SatelliteGeometry& geometry,
+                                                const SignalDefinition& signal, int glonass_fcn,
+                                                const SignalTracker& tracker,
+                                                const CarrierTrackingTruthSnapshot& snapshot,
+                                                std::string* error_message) {
+    if (writer == nullptr || writer->finalized || geometry.satellite_number <= 0) {
+        set_error(error_message, "carrier tracking truth signal writer request is invalid");
+        return false;
+    }
+
+    std::ofstream& output = writer->stream;
+    output << CARRIER_TRACKING_TRUTH_SCHEMA_VERSION << ',';
+    write_time(output, geometry.receive_time);
+    output << ',' << geometry.satellite_number << ',' << static_cast<int>(signal.signal_id) << ',' << signal.name << ','
+           << glonass_fcn << ',' << signal_tracking_phase_name(tracker.phase) << ','
+           << acquisition_context_name(tracker.acquisition_context) << ','
+           << signal_tracking_loss_reason_name(tracker.loss_reason) << ','
+           << (snapshot.carrier_tracking_enabled ? 1 : 0) << ',' << (snapshot.result_available ? 1 : 0) << ','
+           << carrier_tracking_truth_reset_reason_name(snapshot.reset_reason) << ',' << std::scientific
+           << std::setprecision(17) << snapshot.coherent_integration_sec << ',';
+
+    if (snapshot.result_available) {
+        const CarrierTrackingResult& result = snapshot.runtime_result.tracking;
+        const CarrierTrackingJitter& jitter = result.jitter;
+        const CarrierTrackingState& state = snapshot.runtime_state;
+        output << snapshot.effective_cn0_dbhz << ',' << jitter.cn0_linear_hz << ','
+               << carrier_tracking_mode_name(result.mode) << ',' << carrier_tracking_fll_phase_name(result.fll_phase)
+               << ',' << jitter.active_bandwidth_hz << ',' << jitter.phase_sigma_rad << ',' << jitter.sigma_hz << ','
+               << jitter.sigma_mps << ',' << jitter.correlation_tau_sec << ',' << jitter.correlation_alpha << ','
+               << result.tracking_error_hz << ',' << result.tracking_error_mps << ',' << state.mode_age_sec << ','
+               << state.carrier_lock_age_sec << ',' << state.pll_age_sec << ',' << state.fll_enter_persistence_sec
+               << ',' << state.fll_exit_persistence_sec << ',' << state.pll_enter_persistence_sec << ','
+               << state.pll_exit_persistence_sec << ',' << result.carrier_segment_id << ','
+               << snapshot.runtime_result.phase_segment_id << ',' << snapshot.runtime_result.adr_cycle_offset_cycles
+               << ',' << (result.mode_changed ? 1 : 0) << ',' << (result.new_carrier_segment ? 1 : 0) << ','
+               << (snapshot.runtime_result.cycle_slip_event ? 1 : 0) << ',';
+    } else {
+        output << ",,,,,,,,,,,,,,,,,,,,,,,,,";
+    }
+
+    output << (snapshot.environmental_range_rate_applicable ? 1 : 0) << ','
+           << (snapshot.environmental_range_rate_valid ? 1 : 0) << ',';
+    if (snapshot.environmental_range_rate_valid) {
+        output << std::scientific << std::setprecision(17) << snapshot.environmental_range_rate_mps;
+    }
+    output << ',';
+
+    write_observation(output, snapshot.physical_snapshot_available, snapshot.physical_observation,
+                      snapshot.physical_range_rate_valid);
+    write_observation(output, snapshot.post_carrier_snapshot_available, snapshot.post_carrier_observation,
+                      snapshot.post_carrier_range_rate_valid);
+    output.seekp(-1, std::ios_base::cur);
+    output << '\n';
+    if (!output) {
+        set_error(error_message, "failed to write carrier_tracking_truth.csv");
+        return false;
+    }
+    return true;
+}
+
+bool finalize_carrier_tracking_truth_writer(CarrierTrackingTruthWriter* writer, std::string* error_message) {
+    if (writer == nullptr || writer->finalized) {
+        set_error(error_message, "carrier tracking truth writer finalization request is invalid");
+        return false;
+    }
+    writer->stream.flush();
+    if (!writer->stream) {
+        set_error(error_message, "failed to flush carrier_tracking_truth.csv");
+        return false;
+    }
+    writer->stream.close();
+    writer->finalized = true;
+    return true;
+}
+
+} // namespace gnss_sim

--- a/src/output/carrier_tracking_truth_writer.h
+++ b/src/output/carrier_tracking_truth_writer.h
@@ -1,0 +1,65 @@
+#ifndef GNSS_SIM_SRC_OUTPUT_CARRIER_TRACKING_TRUTH_WRITER_H_
+#define GNSS_SIM_SRC_OUTPUT_CARRIER_TRACKING_TRUTH_WRITER_H_
+
+#include "gnss/satellite_engine.h"
+#include "gnss/signal_definitions.h"
+#include "model/carrier_tracking_runtime.h"
+#include "model/measurement_model.h"
+#include "model/signal_tracking.h"
+
+#include <string>
+
+namespace gnss_sim {
+
+struct CarrierTrackingTruthWriter;
+
+constexpr int CARRIER_TRACKING_TRUTH_SCHEMA_VERSION = 1;
+
+enum class CarrierTrackingTruthResetReason {
+    kNone,
+    kFeatureDisabled,
+    kCodeNotTracking,
+};
+
+// Exact serialization snapshot assembled by the simulator at the carrier-layer
+// boundary. The writer must only serialize these values; it must not recompute
+// loop state, jitter, validity, propagation, or measurement effects.
+struct CarrierTrackingTruthSnapshot {
+    bool carrier_tracking_enabled;
+    bool result_available;
+    CarrierTrackingTruthResetReason reset_reason;
+    double coherent_integration_sec;
+    double effective_cn0_dbhz;
+    CarrierTrackingRuntimeResult runtime_result;
+    CarrierTrackingState runtime_state;
+
+    bool environmental_range_rate_applicable;
+    bool environmental_range_rate_valid;
+    double environmental_range_rate_mps;
+
+    bool physical_snapshot_available;
+    MeasurementObservation physical_observation;
+    bool physical_range_rate_valid;
+
+    bool post_carrier_snapshot_available;
+    MeasurementObservation post_carrier_observation;
+    bool post_carrier_range_rate_valid;
+};
+
+CarrierTrackingTruthWriter* create_carrier_tracking_truth_writer(const char* receiver_log_path,
+                                                                 std::string* error_message);
+void destroy_carrier_tracking_truth_writer(CarrierTrackingTruthWriter* writer);
+
+bool carrier_tracking_truth_writer_write_signal(CarrierTrackingTruthWriter* writer, const SatelliteGeometry& geometry,
+                                                const SignalDefinition& signal, int glonass_fcn,
+                                                const SignalTracker& tracker,
+                                                const CarrierTrackingTruthSnapshot& snapshot,
+                                                std::string* error_message);
+
+bool finalize_carrier_tracking_truth_writer(CarrierTrackingTruthWriter* writer, std::string* error_message);
+
+const char* carrier_tracking_truth_reset_reason_name(CarrierTrackingTruthResetReason reason);
+
+} // namespace gnss_sim
+
+#endif // GNSS_SIM_SRC_OUTPUT_CARRIER_TRACKING_TRUTH_WRITER_H_

--- a/tests/integration/test_carrier_tracking_authentic_validation.cpp
+++ b/tests/integration/test_carrier_tracking_authentic_validation.cpp
@@ -1,0 +1,985 @@
+#include "gnss_sim/sim_config.h"
+#include "gnss_sim/sim_time.h"
+#include "gnss_sim/simulator.h"
+#include "model/carrier_tracking.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <map>
+#include <set>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+constexpr double kTruthLatitudeDeg = 20.0;
+constexpr double kTruthLongitudeDeg = 120.0;
+constexpr double kTruthHeightM = 100.0;
+constexpr std::int64_t kStaticDurationSeconds = 12;
+constexpr const char* kFilteredNavName = "brd400dlr_beidou_verbatim_nav.rnx";
+
+std::string source_nav_path() {
+    return std::string(GNSS_SIM_TEST_DATA_DIR) + "/brd400dlr_rinex4_acceptance_nav.rnx";
+}
+
+gnss_sim::SimTime start_time() {
+    gnss_sim::SimTime time{};
+    EXPECT_TRUE(gnss_sim::sim_time_from_week_sow(2347, 436500.0, &time));
+    return time;
+}
+
+std::string read_file(const std::filesystem::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    return std::string((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
+}
+
+std::vector<std::string> parse_csv_line(const std::string& line) {
+    std::vector<std::string> fields;
+    std::string field;
+    bool quoted = false;
+    for (std::size_t index = 0; index < line.size(); ++index) {
+        const char character = line[index];
+        if (quoted) {
+            if (character == '"' && index + 1U < line.size() && line[index + 1U] == '"') {
+                field.push_back('"');
+                ++index;
+            } else if (character == '"') {
+                quoted = false;
+            } else {
+                field.push_back(character);
+            }
+        } else if (character == '"') {
+            quoted = true;
+        } else if (character == ',') {
+            fields.push_back(field);
+            field.clear();
+        } else {
+            field.push_back(character);
+        }
+    }
+    fields.push_back(field);
+    return fields;
+}
+
+std::vector<std::vector<std::string>> read_csv(const std::filesystem::path& path) {
+    std::vector<std::vector<std::string>> rows;
+    std::ifstream input(path, std::ios::binary);
+    std::string line;
+    while (std::getline(input, line)) {
+        if (!line.empty() && line.back() == '\r') {
+            line.pop_back();
+        }
+        rows.push_back(parse_csv_line(line));
+    }
+    return rows;
+}
+
+int column_index(const std::vector<std::string>& header, const char* name) {
+    for (std::size_t index = 0; index < header.size(); ++index) {
+        if (header[index] == name) {
+            return static_cast<int>(index);
+        }
+    }
+    return -1;
+}
+
+std::string observation_key(int week, std::int64_t tow_ns, int satellite_number, int signal_id) {
+    return std::to_string(week) + ":" + std::to_string(tow_ns) + ":" + std::to_string(satellite_number) + ":" +
+           std::to_string(signal_id);
+}
+
+std::string signal_key(int satellite_number, int signal_id) {
+    return std::to_string(satellite_number) + ":" + std::to_string(signal_id);
+}
+
+bool materialize_verbatim_beidou_nav(const std::filesystem::path& destination, std::string* error_message) {
+    const std::string source = read_file(source_nav_path());
+    if (source.empty() || source.find('\r') != std::string::npos) {
+        if (error_message != nullptr) {
+            *error_message = "BRD400DLR source fixture is empty or is not LF-normalized";
+        }
+        return false;
+    }
+    std::istringstream input(source);
+    std::ofstream output(destination, std::ios::binary | std::ios::trunc);
+    if (!output) {
+        if (error_message != nullptr) {
+            *error_message = "cannot create verbatim BeiDou NAV subset";
+        }
+        return false;
+    }
+    bool header = true;
+    bool keep_record = false;
+    bool saw_header_end = false;
+    int ephemeris_records = 0;
+    std::set<std::string> satellites;
+    std::string line;
+    while (std::getline(input, line)) {
+        if (header) {
+            output << line << '\n';
+            if (line.find("END OF HEADER") != std::string::npos) {
+                header = false;
+                saw_header_end = true;
+            }
+            continue;
+        }
+        if (line.rfind("> ", 0) == 0) {
+            keep_record = line.rfind("> EPH C", 0) == 0;
+            if (keep_record) {
+                ++ephemeris_records;
+                if (line.size() >= 9U) {
+                    satellites.insert(line.substr(6, 3));
+                }
+            }
+        }
+        if (keep_record) {
+            output << line << '\n';
+        }
+    }
+    output.close();
+    if (!saw_header_end || ephemeris_records < 4 || satellites.size() < 4U || !output) {
+        if (error_message != nullptr) {
+            *error_message = "verbatim BeiDou NAV subset does not contain enough authentic ephemerides";
+        }
+        return false;
+    }
+    return true;
+}
+
+gnss_sim::SimConfig static_config(int sampling_rate_hz, bool carrier_tracking_enabled) {
+    gnss_sim::SimConfig config = gnss_sim::default_sim_config();
+    config.scenario = gnss_sim::ScenarioType::KS;
+    config.duration_ns = kStaticDurationSeconds * gnss_sim::NANOSECONDS_PER_SECOND;
+    config.sampling_rate_hz = sampling_rate_hz;
+    config.elevation_mask_deg = 0.0;
+    config.solution_elevation_mask_deg = 5.0;
+    config.output_eph = false;
+    config.output_ion = false;
+    config.measurement_noise_enabled = false;
+    config.multipath_enabled = true;
+    config.atmosphere_mode = gnss_sim::AtmosphereMode::NONE;
+    config.receiver = {kTruthLatitudeDeg, kTruthLongitudeDeg, kTruthHeightM};
+    config.seed = 0x163U;
+    config.carrier_tracking.enabled = carrier_tracking_enabled;
+    return config;
+}
+
+gnss_sim::SimConfig reacquisition_config() {
+    gnss_sim::SimConfig config = static_config(10, true);
+    config.scenario = gnss_sim::ScenarioType::REA;
+    config.rea.signal_on_ns = 6LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    config.rea.signal_off_ns = 2LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    config.duration_ns = 14LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    return config;
+}
+
+bool run_in_directory(const std::filesystem::path& directory, const gnss_sim::SimConfig& config,
+                      gnss_sim::SimulatorRunSummary* summary, std::string* error_message) {
+    std::error_code filesystem_error;
+    std::filesystem::remove_all(directory, filesystem_error);
+    filesystem_error.clear();
+    if (!std::filesystem::create_directories(directory, filesystem_error) || filesystem_error) {
+        if (error_message != nullptr) {
+            *error_message = "cannot create carrier validation directory";
+        }
+        return false;
+    }
+    const std::filesystem::path nav_path = directory / kFilteredNavName;
+    if (!materialize_verbatim_beidou_nav(nav_path, error_message)) {
+        return false;
+    }
+    const std::string input_path = nav_path.string();
+    const std::string output_path = (directory / "simulated.log").string();
+    const gnss_sim::SimulatorRunOptions options{input_path.c_str(), output_path.c_str(), start_time()};
+    return gnss_sim::run_simulator(config, options, summary, error_message);
+}
+
+void cleanup(const std::filesystem::path& directory) {
+    std::error_code error;
+    std::filesystem::remove_all(directory, error);
+}
+
+struct DistributionMetrics {
+    std::uint64_t count = 0;
+    double rms = 0.0;
+    double p50 = 0.0;
+    double p95 = 0.0;
+    double p99 = 0.0;
+    double maximum = 0.0;
+};
+
+double percentile(std::vector<double> values, double probability) {
+    if (values.empty()) {
+        return 0.0;
+    }
+    std::sort(values.begin(), values.end());
+    std::size_t rank = static_cast<std::size_t>(std::ceil(probability * static_cast<double>(values.size())));
+    rank = std::max<std::size_t>(1U, std::min(rank, values.size()));
+    return values[rank - 1U];
+}
+
+DistributionMetrics metrics(const std::vector<double>& values) {
+    DistributionMetrics result{};
+    result.count = static_cast<std::uint64_t>(values.size());
+    if (values.empty()) {
+        return result;
+    }
+    double sum_squares = 0.0;
+    std::vector<double> absolute;
+    absolute.reserve(values.size());
+    for (double value : values) {
+        sum_squares += value * value;
+        absolute.push_back(std::abs(value));
+        result.maximum = std::max(result.maximum, std::abs(value));
+    }
+    result.rms = std::sqrt(sum_squares / static_cast<double>(values.size()));
+    result.p50 = percentile(absolute, 0.50);
+    result.p95 = percentile(absolute, 0.95);
+    result.p99 = percentile(absolute, 0.99);
+    return result;
+}
+
+struct CarrierSample {
+    int week = 0;
+    std::int64_t tow_ns = 0;
+    int satellite_number = 0;
+    int signal_id = 0;
+    std::string signal_name;
+    std::string acquisition_context;
+    std::string reset_reason;
+    std::string mode;
+    std::string fll_phase;
+    bool result_available = false;
+    double effective_cn0_dbhz = 0.0;
+    double coherent_integration_sec = 0.0;
+    double active_bandwidth_hz = 0.0;
+    double sigma_hz = 0.0;
+    double sigma_mps = 0.0;
+    double tracking_error_hz = 0.0;
+    double tracking_error_mps = 0.0;
+    double carrier_lock_age_sec = 0.0;
+    double pll_age_sec = 0.0;
+    bool mode_changed = false;
+    bool new_carrier_segment = false;
+    bool cycle_slip_event = false;
+    bool environmental_range_rate_valid = false;
+    double environmental_range_rate_mps = 0.0;
+    bool physical_snapshot_available = false;
+    double physical_range_rate_mps = 0.0;
+    double physical_doppler_hz = 0.0;
+    bool post_snapshot_available = false;
+    bool post_code_valid = false;
+    bool post_doppler_valid = false;
+    bool post_adr_valid = false;
+    double post_range_rate_mps = 0.0;
+    double post_doppler_hz = 0.0;
+    double post_adr_cycles = 0.0;
+};
+
+bool parse_carrier_samples(const std::filesystem::path& path, std::vector<CarrierSample>* output) {
+    if (output == nullptr) {
+        return false;
+    }
+    const auto rows = read_csv(path);
+    if (rows.size() <= 1U) {
+        return false;
+    }
+    const auto& header = rows.front();
+    const int week = column_index(header, "gps_week");
+    const int tow = column_index(header, "tow_ns");
+    const int satellite = column_index(header, "satellite_number");
+    const int signal = column_index(header, "signal_id");
+    const int signal_name = column_index(header, "signal_name");
+    const int acquisition = column_index(header, "acquisition_context");
+    const int result_available = column_index(header, "carrier_result_available");
+    const int reset_reason = column_index(header, "carrier_reset_reason");
+    const int coherent = column_index(header, "coherent_integration_sec");
+    const int cn0 = column_index(header, "effective_cn0_dbhz");
+    const int mode = column_index(header, "carrier_mode");
+    const int fll_phase = column_index(header, "fll_phase");
+    const int bandwidth = column_index(header, "active_bandwidth_hz");
+    const int sigma_hz = column_index(header, "sigma_hz");
+    const int sigma_mps = column_index(header, "sigma_mps");
+    const int error_hz = column_index(header, "tracking_error_hz");
+    const int error_mps = column_index(header, "tracking_error_mps");
+    const int carrier_age = column_index(header, "carrier_lock_age_sec");
+    const int pll_age = column_index(header, "pll_age_sec");
+    const int mode_changed = column_index(header, "mode_changed");
+    const int new_segment = column_index(header, "new_carrier_segment");
+    const int slip = column_index(header, "cycle_slip_event");
+    const int environmental_valid = column_index(header, "environmental_range_rate_valid");
+    const int environmental_rate = column_index(header, "environmental_range_rate_mps");
+    const int physical_snapshot = column_index(header, "physical_snapshot_available");
+    const int physical_rate = column_index(header, "physical_range_rate_mps");
+    const int physical_doppler = column_index(header, "physical_doppler_hz");
+    const int post_snapshot = column_index(header, "post_carrier_snapshot_available");
+    const int post_code = column_index(header, "post_carrier_code_valid");
+    const int post_doppler_valid = column_index(header, "post_carrier_doppler_valid");
+    const int post_adr_valid = column_index(header, "post_carrier_adr_valid");
+    const int post_rate = column_index(header, "post_carrier_range_rate_mps");
+    const int post_doppler = column_index(header, "post_carrier_doppler_hz");
+    const int post_adr = column_index(header, "post_carrier_adr_cycles");
+    if (week < 0 || tow < 0 || satellite < 0 || signal < 0 || signal_name < 0 || acquisition < 0 ||
+        result_available < 0 || reset_reason < 0 || coherent < 0 || cn0 < 0 || mode < 0 || fll_phase < 0 ||
+        bandwidth < 0 || sigma_hz < 0 || sigma_mps < 0 || error_hz < 0 || error_mps < 0 || carrier_age < 0 ||
+        pll_age < 0 || mode_changed < 0 || new_segment < 0 || slip < 0 || environmental_valid < 0 ||
+        environmental_rate < 0 || physical_snapshot < 0 || physical_rate < 0 || physical_doppler < 0 ||
+        post_snapshot < 0 || post_code < 0 || post_doppler_valid < 0 || post_adr_valid < 0 || post_rate < 0 ||
+        post_doppler < 0 || post_adr < 0) {
+        return false;
+    }
+
+    std::vector<CarrierSample> samples;
+    samples.reserve(rows.size() - 1U);
+    for (std::size_t index = 1; index < rows.size(); ++index) {
+        const auto& row = rows[index];
+        if (row.size() != header.size()) {
+            return false;
+        }
+        CarrierSample sample{};
+        sample.week = std::stoi(row[static_cast<std::size_t>(week)]);
+        sample.tow_ns = std::stoll(row[static_cast<std::size_t>(tow)]);
+        sample.satellite_number = std::stoi(row[static_cast<std::size_t>(satellite)]);
+        sample.signal_id = std::stoi(row[static_cast<std::size_t>(signal)]);
+        sample.signal_name = row[static_cast<std::size_t>(signal_name)];
+        sample.acquisition_context = row[static_cast<std::size_t>(acquisition)];
+        sample.result_available = row[static_cast<std::size_t>(result_available)] == "1";
+        sample.reset_reason = row[static_cast<std::size_t>(reset_reason)];
+        sample.coherent_integration_sec = std::stod(row[static_cast<std::size_t>(coherent)]);
+        sample.environmental_range_rate_valid = row[static_cast<std::size_t>(environmental_valid)] == "1";
+        if (sample.environmental_range_rate_valid && !row[static_cast<std::size_t>(environmental_rate)].empty()) {
+            sample.environmental_range_rate_mps = std::stod(row[static_cast<std::size_t>(environmental_rate)]);
+        }
+        sample.physical_snapshot_available = row[static_cast<std::size_t>(physical_snapshot)] == "1";
+        if (sample.physical_snapshot_available) {
+            sample.physical_range_rate_mps = std::stod(row[static_cast<std::size_t>(physical_rate)]);
+            sample.physical_doppler_hz = std::stod(row[static_cast<std::size_t>(physical_doppler)]);
+        }
+        sample.post_snapshot_available = row[static_cast<std::size_t>(post_snapshot)] == "1";
+        if (sample.post_snapshot_available) {
+            sample.post_code_valid = row[static_cast<std::size_t>(post_code)] == "1";
+            sample.post_doppler_valid = row[static_cast<std::size_t>(post_doppler_valid)] == "1";
+            sample.post_adr_valid = row[static_cast<std::size_t>(post_adr_valid)] == "1";
+            sample.post_range_rate_mps = std::stod(row[static_cast<std::size_t>(post_rate)]);
+            sample.post_doppler_hz = std::stod(row[static_cast<std::size_t>(post_doppler)]);
+            sample.post_adr_cycles = std::stod(row[static_cast<std::size_t>(post_adr)]);
+        }
+        if (sample.result_available) {
+            sample.effective_cn0_dbhz = std::stod(row[static_cast<std::size_t>(cn0)]);
+            sample.mode = row[static_cast<std::size_t>(mode)];
+            sample.fll_phase = row[static_cast<std::size_t>(fll_phase)];
+            sample.active_bandwidth_hz = std::stod(row[static_cast<std::size_t>(bandwidth)]);
+            sample.sigma_hz = std::stod(row[static_cast<std::size_t>(sigma_hz)]);
+            sample.sigma_mps = std::stod(row[static_cast<std::size_t>(sigma_mps)]);
+            sample.tracking_error_hz = std::stod(row[static_cast<std::size_t>(error_hz)]);
+            sample.tracking_error_mps = std::stod(row[static_cast<std::size_t>(error_mps)]);
+            sample.carrier_lock_age_sec = std::stod(row[static_cast<std::size_t>(carrier_age)]);
+            sample.pll_age_sec = std::stod(row[static_cast<std::size_t>(pll_age)]);
+            sample.mode_changed = row[static_cast<std::size_t>(mode_changed)] == "1";
+            sample.new_carrier_segment = row[static_cast<std::size_t>(new_segment)] == "1";
+            sample.cycle_slip_event = row[static_cast<std::size_t>(slip)] == "1";
+        }
+        samples.push_back(sample);
+    }
+    *output = samples;
+    return true;
+}
+
+struct UrbanContext {
+    bool range_rate_valid = false;
+    double range_rate_mps = 0.0;
+    std::string state;
+    std::string wall;
+    int path_count = 0;
+    int reflection_count = 0;
+};
+
+using UrbanContextMap = std::map<std::string, UrbanContext>;
+
+bool parse_urban_contexts(const std::filesystem::path& path, UrbanContextMap* output) {
+    if (output == nullptr) {
+        return false;
+    }
+    const auto rows = read_csv(path);
+    if (rows.size() <= 1U) {
+        return false;
+    }
+    const auto& header = rows.front();
+    const int week = column_index(header, "gps_week");
+    const int tow = column_index(header, "tow_ns");
+    const int satellite = column_index(header, "satellite_number");
+    const int signal = column_index(header, "signal_id");
+    const int valid = column_index(header, "environmental_range_rate_valid");
+    const int rate = column_index(header, "environmental_range_rate_mps");
+    const int state = column_index(header, "urban_state");
+    const int wall = column_index(header, "blocking_wall");
+    const int paths = column_index(header, "received_path_count");
+    const int reflections = column_index(header, "reflection_count");
+    if (week < 0 || tow < 0 || satellite < 0 || signal < 0 || valid < 0 || rate < 0 || state < 0 || wall < 0 ||
+        paths < 0 || reflections < 0) {
+        return false;
+    }
+    UrbanContextMap result;
+    for (std::size_t index = 1; index < rows.size(); ++index) {
+        const auto& row = rows[index];
+        if (row.size() != header.size()) {
+            return false;
+        }
+        const int gps_week = std::stoi(row[static_cast<std::size_t>(week)]);
+        const std::int64_t tow_ns = std::stoll(row[static_cast<std::size_t>(tow)]);
+        const int satellite_number = std::stoi(row[static_cast<std::size_t>(satellite)]);
+        const int signal_id = std::stoi(row[static_cast<std::size_t>(signal)]);
+        UrbanContext context{};
+        context.range_rate_valid = row[static_cast<std::size_t>(valid)] == "1";
+        if (!row[static_cast<std::size_t>(rate)].empty()) {
+            context.range_rate_mps = std::stod(row[static_cast<std::size_t>(rate)]);
+        }
+        context.state = row[static_cast<std::size_t>(state)];
+        context.wall = row[static_cast<std::size_t>(wall)];
+        context.path_count = std::stoi(row[static_cast<std::size_t>(paths)]);
+        context.reflection_count = std::stoi(row[static_cast<std::size_t>(reflections)]);
+        result[observation_key(gps_week, tow_ns, satellite_number, signal_id)] = context;
+    }
+    *output = result;
+    return true;
+}
+
+struct VelocityStats {
+    std::vector<double> error_3d_mps;
+    std::vector<double> clock_drift_error_mps;
+};
+
+bool parse_velocity_stats(const std::filesystem::path& path, double truth_clock_drift_mps, VelocityStats* output) {
+    if (output == nullptr) {
+        return false;
+    }
+    const auto rows = read_csv(path);
+    if (rows.size() <= 1U) {
+        return false;
+    }
+    const auto& header = rows.front();
+    const int valid = column_index(header, "velocity_valid");
+    const int vx = column_index(header, "velocity_x_mps");
+    const int vy = column_index(header, "velocity_y_mps");
+    const int vz = column_index(header, "velocity_z_mps");
+    const int clock_drift = column_index(header, "receiver_clock_drift_mps");
+    if (valid < 0 || vx < 0 || vy < 0 || vz < 0 || clock_drift < 0) {
+        return false;
+    }
+    VelocityStats result;
+    for (std::size_t index = 1; index < rows.size(); ++index) {
+        const auto& row = rows[index];
+        if (row.size() != header.size() || row[static_cast<std::size_t>(valid)] != "1") {
+            continue;
+        }
+        const double x = std::stod(row[static_cast<std::size_t>(vx)]);
+        const double y = std::stod(row[static_cast<std::size_t>(vy)]);
+        const double z = std::stod(row[static_cast<std::size_t>(vz)]);
+        result.error_3d_mps.push_back(std::sqrt(x * x + y * y + z * z));
+        result.clock_drift_error_mps.push_back(std::stod(row[static_cast<std::size_t>(clock_drift)]) -
+                                               truth_clock_drift_mps);
+    }
+    *output = result;
+    return true;
+}
+
+const char* cn0_bin(double cn0_dbhz) {
+    if (cn0_dbhz < 18.0) {
+        return "LT18";
+    }
+    if (cn0_dbhz < 22.0) {
+        return "18_22";
+    }
+    if (cn0_dbhz < 27.0) {
+        return "22_27";
+    }
+    if (cn0_dbhz < 30.0) {
+        return "27_30";
+    }
+    return "GE30";
+}
+
+struct TrackingDistribution {
+    std::uint64_t rows = 0;
+    std::uint64_t valid_doppler_rows = 0;
+    std::vector<double> error_hz;
+    std::vector<double> error_mps;
+    std::vector<double> sigma_hz;
+    std::vector<double> normalized_error;
+};
+
+void print_tracking_distribution(const char* category, const std::string& name,
+                                 const TrackingDistribution& distribution) {
+    const DistributionMetrics error_hz = metrics(distribution.error_hz);
+    const DistributionMetrics error_mps = metrics(distribution.error_mps);
+    const DistributionMetrics sigma_hz = metrics(distribution.sigma_hz);
+    const DistributionMetrics normalized = metrics(distribution.normalized_error);
+    std::cout << "CARRIER_AUTH_" << category << " name=" << name << " rows=" << distribution.rows
+              << " valid=" << distribution.valid_doppler_rows << " error_rms_hz=" << error_hz.rms
+              << " error_p50_hz=" << error_hz.p50 << " error_p95_hz=" << error_hz.p95
+              << " error_p99_hz=" << error_hz.p99 << " error_max_hz=" << error_hz.maximum
+              << " error_rms_mps=" << error_mps.rms << " error_p95_mps=" << error_mps.p95
+              << " error_max_mps=" << error_mps.maximum << " sigma_rms_hz=" << sigma_hz.rms
+              << " normalized_error_rms=" << normalized.rms << '\n';
+}
+
+TEST(CarrierTrackingAuthenticValidation, AuthenticNavObservationStatisticsCompatibilityAndVelocity) {
+    const std::filesystem::path enabled_a_directory = "gnss_sim_carrier_auth_enabled_a";
+    const std::filesystem::path enabled_b_directory = "gnss_sim_carrier_auth_enabled_b";
+    const std::filesystem::path disabled_a_directory = "gnss_sim_carrier_auth_disabled_a";
+    const std::filesystem::path disabled_b_directory = "gnss_sim_carrier_auth_disabled_b";
+    const gnss_sim::SimConfig enabled = static_config(10, true);
+    const gnss_sim::SimConfig disabled_a = static_config(10, false);
+    gnss_sim::SimConfig disabled_b = disabled_a;
+    disabled_b.carrier_tracking.pll_noise_bandwidth_hz = 6.0;
+    disabled_b.carrier_tracking.fll_noise_bandwidth_hz = 5.0;
+    disabled_b.carrier_tracking.fll_pull_in_bandwidth_hz = 9.0;
+
+    gnss_sim::SimulatorRunSummary enabled_a_summary{};
+    gnss_sim::SimulatorRunSummary enabled_b_summary{};
+    gnss_sim::SimulatorRunSummary disabled_a_summary{};
+    gnss_sim::SimulatorRunSummary disabled_b_summary{};
+    std::string error_message;
+    ASSERT_TRUE(run_in_directory(enabled_a_directory, enabled, &enabled_a_summary, &error_message)) << error_message;
+    ASSERT_TRUE(run_in_directory(enabled_b_directory, enabled, &enabled_b_summary, &error_message)) << error_message;
+    ASSERT_TRUE(run_in_directory(disabled_a_directory, disabled_a, &disabled_a_summary, &error_message))
+        << error_message;
+    ASSERT_TRUE(run_in_directory(disabled_b_directory, disabled_b, &disabled_b_summary, &error_message))
+        << error_message;
+
+    EXPECT_EQ(read_file(enabled_a_directory / "simulated.log"), read_file(enabled_b_directory / "simulated.log"));
+    EXPECT_EQ(read_file(enabled_a_directory / "carrier_tracking_truth.csv"),
+              read_file(enabled_b_directory / "carrier_tracking_truth.csv"));
+    EXPECT_EQ(read_file(disabled_a_directory / "simulated.log"), read_file(disabled_b_directory / "simulated.log"));
+    EXPECT_EQ(read_file(disabled_a_directory / "observation_truth.csv"),
+              read_file(disabled_b_directory / "observation_truth.csv"));
+    EXPECT_EQ(read_file(disabled_a_directory / "urban_signal_truth.csv"),
+              read_file(disabled_b_directory / "urban_signal_truth.csv"));
+    EXPECT_EQ(read_file(enabled_a_directory / "observation_truth.csv"),
+              read_file(disabled_a_directory / "observation_truth.csv"));
+    EXPECT_EQ(read_file(enabled_a_directory / "urban_signal_truth.csv"),
+              read_file(disabled_a_directory / "urban_signal_truth.csv"));
+    EXPECT_EQ(read_file(enabled_a_directory / "simulated.log").find("carrier_mode"), std::string::npos);
+    EXPECT_EQ(read_file(enabled_a_directory / "simulated.log").find("tracking_error_hz"), std::string::npos);
+
+    std::vector<CarrierSample> samples;
+    UrbanContextMap urban_contexts;
+    ASSERT_TRUE(parse_carrier_samples(enabled_a_directory / "carrier_tracking_truth.csv", &samples));
+    ASSERT_TRUE(parse_urban_contexts(enabled_a_directory / "urban_signal_truth.csv", &urban_contexts));
+
+    std::map<std::string, TrackingDistribution> modes;
+    std::map<std::string, TrackingDistribution> cn0_bins;
+    std::map<std::string, std::uint64_t> validity_combinations;
+    std::vector<double> environmental_rates;
+    std::uint64_t result_rows = 0;
+    std::uint64_t valid_doppler_rows = 0;
+    std::uint64_t fll_code_doppler_no_adr = 0;
+    std::uint64_t unlocked_code_only = 0;
+    std::uint64_t pull_in_rows = 0;
+    std::uint64_t mode_changes = 0;
+    std::uint64_t new_segments = 0;
+    std::uint64_t cycle_slips = 0;
+    double max_doppler_mapping_mismatch_hz = 0.0;
+    double max_range_rate_mapping_mismatch_mps = 0.0;
+    double max_environmental_truth_mismatch_mps = 0.0;
+    double worst_error_mps = 0.0;
+    CarrierSample worst_sample{};
+    UrbanContext worst_context{};
+
+    for (const CarrierSample& sample : samples) {
+        const std::string key = observation_key(sample.week, sample.tow_ns, sample.satellite_number, sample.signal_id);
+        if (sample.environmental_range_rate_valid) {
+            environmental_rates.push_back(sample.environmental_range_rate_mps);
+            const auto urban = urban_contexts.find(key);
+            ASSERT_NE(urban, urban_contexts.end());
+            EXPECT_TRUE(urban->second.range_rate_valid);
+            max_environmental_truth_mismatch_mps =
+                std::max(max_environmental_truth_mismatch_mps,
+                         std::abs(sample.environmental_range_rate_mps - urban->second.range_rate_mps));
+        }
+        if (!sample.result_available) {
+            continue;
+        }
+        ++result_rows;
+        TrackingDistribution& mode_distribution = modes[sample.mode];
+        TrackingDistribution& bin_distribution = cn0_bins[cn0_bin(sample.effective_cn0_dbhz)];
+        ++mode_distribution.rows;
+        ++bin_distribution.rows;
+        if (sample.mode_changed) {
+            ++mode_changes;
+        }
+        if (sample.new_carrier_segment) {
+            ++new_segments;
+        }
+        if (sample.cycle_slip_event) {
+            ++cycle_slips;
+        }
+        if (sample.fll_phase == "PULL_IN") {
+            ++pull_in_rows;
+        }
+        if (sample.post_snapshot_available) {
+            const std::string validity = std::string(sample.post_code_valid ? "1" : "0") +
+                                         (sample.post_doppler_valid ? "1" : "0") + (sample.post_adr_valid ? "1" : "0");
+            ++validity_combinations[validity];
+            if (sample.mode == "FLL_TRACK" && sample.post_code_valid && sample.post_doppler_valid &&
+                !sample.post_adr_valid) {
+                ++fll_code_doppler_no_adr;
+            }
+            if (sample.mode == "CARRIER_UNLOCKED" && sample.post_code_valid && !sample.post_doppler_valid &&
+                !sample.post_adr_valid) {
+                ++unlocked_code_only;
+            }
+        }
+        if (sample.physical_snapshot_available && sample.post_snapshot_available) {
+            max_doppler_mapping_mismatch_hz =
+                std::max(max_doppler_mapping_mismatch_hz,
+                         std::abs((sample.post_doppler_hz - sample.physical_doppler_hz) - sample.tracking_error_hz));
+            max_range_rate_mapping_mismatch_mps = std::max(
+                max_range_rate_mapping_mismatch_mps,
+                std::abs((sample.post_range_rate_mps - sample.physical_range_rate_mps) + sample.tracking_error_mps));
+        }
+        if (!sample.post_doppler_valid) {
+            continue;
+        }
+        ++valid_doppler_rows;
+        ++mode_distribution.valid_doppler_rows;
+        ++bin_distribution.valid_doppler_rows;
+        mode_distribution.error_hz.push_back(sample.tracking_error_hz);
+        mode_distribution.error_mps.push_back(sample.tracking_error_mps);
+        mode_distribution.sigma_hz.push_back(sample.sigma_hz);
+        bin_distribution.error_hz.push_back(sample.tracking_error_hz);
+        bin_distribution.error_mps.push_back(sample.tracking_error_mps);
+        bin_distribution.sigma_hz.push_back(sample.sigma_hz);
+        if (sample.sigma_hz > 0.0) {
+            mode_distribution.normalized_error.push_back(sample.tracking_error_hz / sample.sigma_hz);
+            bin_distribution.normalized_error.push_back(sample.tracking_error_hz / sample.sigma_hz);
+        }
+        if (std::abs(sample.tracking_error_mps) >= worst_error_mps) {
+            worst_error_mps = std::abs(sample.tracking_error_mps);
+            worst_sample = sample;
+            const auto urban = urban_contexts.find(key);
+            if (urban != urban_contexts.end()) {
+                worst_context = urban->second;
+            }
+        }
+    }
+
+    const DistributionMetrics environmental = metrics(environmental_rates);
+    std::cout << "CARRIER_AUTH_SUMMARY result_rows=" << result_rows << " valid_doppler_rows=" << valid_doppler_rows
+              << " fll_code_doppler_no_adr=" << fll_code_doppler_no_adr << " unlocked_code_only=" << unlocked_code_only
+              << " pull_in_rows=" << pull_in_rows << " mode_changes=" << mode_changes
+              << " new_segments=" << new_segments << " cycle_slips=" << cycle_slips
+              << " env_rate_rms_mps=" << environmental.rms << " env_rate_p95_mps=" << environmental.p95
+              << " env_rate_max_mps=" << environmental.maximum << '\n'
+              << "CARRIER_AUTH_MAPPING max_doppler_mismatch_hz=" << max_doppler_mapping_mismatch_hz
+              << " max_range_rate_mismatch_mps=" << max_range_rate_mapping_mismatch_mps
+              << " max_environmental_truth_mismatch_mps=" << max_environmental_truth_mismatch_mps << '\n'
+              << "CARRIER_AUTH_VALIDITY code_doppler_adr_111=" << validity_combinations["111"]
+              << " code_doppler_adr_110=" << validity_combinations["110"]
+              << " code_doppler_adr_100=" << validity_combinations["100"] << '\n'
+              << "CARRIER_AUTH_WORST gpst=" << worst_sample.week << ':' << worst_sample.tow_ns
+              << " sat=" << worst_sample.satellite_number << " signal=" << worst_sample.signal_name
+              << " cn0_dbhz=" << worst_sample.effective_cn0_dbhz << " mode=" << worst_sample.mode
+              << " fll_phase=" << worst_sample.fll_phase << " sigma_hz=" << worst_sample.sigma_hz
+              << " error_hz=" << worst_sample.tracking_error_hz << " error_mps=" << worst_sample.tracking_error_mps
+              << " environmental_range_rate_mps=" << worst_sample.environmental_range_rate_mps
+              << " urban_state=" << worst_context.state << " wall=" << worst_context.wall
+              << " paths=" << worst_context.path_count << " reflections=" << worst_context.reflection_count << '\n';
+    for (const auto& entry : modes) {
+        print_tracking_distribution("MODE", entry.first, entry.second);
+    }
+    for (const char* bin : {"LT18", "18_22", "22_27", "27_30", "GE30"}) {
+        print_tracking_distribution("CN0", bin, cn0_bins[bin]);
+    }
+
+    VelocityStats enabled_velocity;
+    VelocityStats disabled_velocity;
+    ASSERT_TRUE(parse_velocity_stats(enabled_a_directory / "solution_truth.csv", enabled.receiver_clock_drift_mps,
+                                     &enabled_velocity));
+    ASSERT_TRUE(parse_velocity_stats(disabled_a_directory / "solution_truth.csv", disabled_a.receiver_clock_drift_mps,
+                                     &disabled_velocity));
+    const DistributionMetrics enabled_velocity_3d = metrics(enabled_velocity.error_3d_mps);
+    const DistributionMetrics disabled_velocity_3d = metrics(disabled_velocity.error_3d_mps);
+    const DistributionMetrics enabled_clock = metrics(enabled_velocity.clock_drift_error_mps);
+    const DistributionMetrics disabled_clock = metrics(disabled_velocity.clock_drift_error_mps);
+    std::cout << "CARRIER_AUTH_VELOCITY on_valid=" << enabled_velocity_3d.count
+              << " on_rms_3d_mps=" << enabled_velocity_3d.rms << " on_p95_3d_mps=" << enabled_velocity_3d.p95
+              << " on_max_3d_mps=" << enabled_velocity_3d.maximum << " off_valid=" << disabled_velocity_3d.count
+              << " off_rms_3d_mps=" << disabled_velocity_3d.rms << " off_p95_3d_mps=" << disabled_velocity_3d.p95
+              << " off_max_3d_mps=" << disabled_velocity_3d.maximum << " on_clock_rms_mps=" << enabled_clock.rms
+              << " on_clock_max_mps=" << enabled_clock.maximum << " off_clock_rms_mps=" << disabled_clock.rms
+              << " off_clock_max_mps=" << disabled_clock.maximum << '\n';
+
+    EXPECT_GT(result_rows, 100U);
+    EXPECT_GT(valid_doppler_rows, 100U);
+    EXPECT_GT(fll_code_doppler_no_adr, 0U);
+    EXPECT_GT(unlocked_code_only, 0U);
+    EXPECT_GT(pull_in_rows, 0U);
+    EXPECT_GT(modes["FLL_TRACK"].rows, 0U);
+    EXPECT_GT(modes["PLL_TRACK"].rows, 0U);
+    EXPECT_GT(modes["CARRIER_UNLOCKED"].rows, 0U);
+    EXPECT_LT(max_doppler_mapping_mismatch_hz, 1.0e-10);
+    EXPECT_LT(max_range_rate_mapping_mismatch_mps, 1.0e-10);
+    EXPECT_LT(max_environmental_truth_mismatch_mps, 1.0e-12);
+    EXPECT_GT(enabled_velocity_3d.count, 0U);
+    EXPECT_GT(disabled_velocity_3d.count, 0U);
+
+    cleanup(enabled_a_directory);
+    cleanup(enabled_b_directory);
+    cleanup(disabled_a_directory);
+    cleanup(disabled_b_directory);
+}
+
+TEST(CarrierTrackingAuthenticValidation, FrozenThermalJitterRespondsToCn0BandwidthIntegrationAndWavelength) {
+    const gnss_sim::CarrierTrackingConfig base = gnss_sim::default_carrier_tracking_config();
+    gnss_sim::CarrierTrackingJitter cn0_low{};
+    gnss_sim::CarrierTrackingJitter cn0_high{};
+    gnss_sim::CarrierTrackingJitter wide_band{};
+    gnss_sim::CarrierTrackingJitter long_integration{};
+    gnss_sim::CarrierTrackingJitter long_wavelength{};
+    gnss_sim::CarrierTrackingJitter base_35{};
+    std::string error_message;
+
+    ASSERT_TRUE(gnss_sim::compute_carrier_tracking_jitter(base, gnss_sim::CarrierTrackingMode::kFllTrack, false, 20.0,
+                                                          0.19, 0.02, &cn0_low, &error_message))
+        << error_message;
+    ASSERT_TRUE(gnss_sim::compute_carrier_tracking_jitter(base, gnss_sim::CarrierTrackingMode::kFllTrack, false, 40.0,
+                                                          0.19, 0.02, &cn0_high, &error_message))
+        << error_message;
+    ASSERT_TRUE(gnss_sim::compute_carrier_tracking_jitter(base, gnss_sim::CarrierTrackingMode::kFllTrack, false, 35.0,
+                                                          0.19, 0.02, &base_35, &error_message))
+        << error_message;
+
+    gnss_sim::CarrierTrackingConfig wider = base;
+    wider.fll_noise_bandwidth_hz = 8.0;
+    ASSERT_TRUE(gnss_sim::compute_carrier_tracking_jitter(wider, gnss_sim::CarrierTrackingMode::kFllTrack, false, 35.0,
+                                                          0.19, 0.02, &wide_band, &error_message))
+        << error_message;
+
+    gnss_sim::CarrierTrackingConfig longer = base;
+    longer.coherent_integration_sec = 0.04;
+    ASSERT_TRUE(gnss_sim::compute_carrier_tracking_jitter(longer, gnss_sim::CarrierTrackingMode::kFllTrack, false, 35.0,
+                                                          0.19, 0.02, &long_integration, &error_message))
+        << error_message;
+    ASSERT_TRUE(gnss_sim::compute_carrier_tracking_jitter(base, gnss_sim::CarrierTrackingMode::kFllTrack, false, 35.0,
+                                                          0.38, 0.02, &long_wavelength, &error_message))
+        << error_message;
+
+    std::cout << "CARRIER_JITTER_RESPONSE cn0_20_sigma_hz=" << cn0_low.sigma_hz
+              << " cn0_40_sigma_hz=" << cn0_high.sigma_hz << " base_35_sigma_hz=" << base_35.sigma_hz
+              << " wide_8hz_sigma_hz=" << wide_band.sigma_hz
+              << " integration_40ms_sigma_hz=" << long_integration.sigma_hz
+              << " wavelength_0p19_sigma_mps=" << base_35.sigma_mps
+              << " wavelength_0p38_sigma_mps=" << long_wavelength.sigma_mps << '\n';
+
+    EXPECT_LT(cn0_high.sigma_hz, cn0_low.sigma_hz);
+    EXPECT_GT(wide_band.sigma_hz, base_35.sigma_hz);
+    EXPECT_LT(long_integration.sigma_hz, base_35.sigma_hz);
+    EXPECT_NEAR(long_wavelength.sigma_hz, base_35.sigma_hz, 1.0e-12);
+    EXPECT_NEAR(long_wavelength.sigma_mps / base_35.sigma_mps, 2.0, 1.0e-12);
+}
+
+TEST(CarrierTrackingAuthenticValidation, AuthenticNavOneAndTenHertzHaveConsistentLoopScale) {
+    const std::filesystem::path one_hz_directory = "gnss_sim_carrier_auth_1hz";
+    const std::filesystem::path ten_hz_directory = "gnss_sim_carrier_auth_10hz";
+    const gnss_sim::SimConfig one_hz = static_config(1, true);
+    const gnss_sim::SimConfig ten_hz = static_config(10, true);
+    gnss_sim::SimulatorRunSummary one_hz_summary{};
+    gnss_sim::SimulatorRunSummary ten_hz_summary{};
+    std::string error_message;
+    ASSERT_TRUE(run_in_directory(one_hz_directory, one_hz, &one_hz_summary, &error_message)) << error_message;
+    ASSERT_TRUE(run_in_directory(ten_hz_directory, ten_hz, &ten_hz_summary, &error_message)) << error_message;
+
+    std::vector<CarrierSample> one_samples;
+    std::vector<CarrierSample> ten_samples;
+    ASSERT_TRUE(parse_carrier_samples(one_hz_directory / "carrier_tracking_truth.csv", &one_samples));
+    ASSERT_TRUE(parse_carrier_samples(ten_hz_directory / "carrier_tracking_truth.csv", &ten_samples));
+
+    std::map<std::string, CarrierSample> ten_by_key;
+    for (const CarrierSample& sample : ten_samples) {
+        ten_by_key[observation_key(sample.week, sample.tow_ns, sample.satellite_number, sample.signal_id)] = sample;
+    }
+
+    std::vector<double> one_errors;
+    std::vector<double> ten_errors;
+    std::uint64_t matched_scale = 0;
+    double max_sigma_mismatch_hz = 0.0;
+    for (const CarrierSample& one : one_samples) {
+        if (!one.result_available || !one.post_doppler_valid || one.mode != "PLL_TRACK") {
+            continue;
+        }
+        const auto ten = ten_by_key.find(observation_key(one.week, one.tow_ns, one.satellite_number, one.signal_id));
+        if (ten == ten_by_key.end() || !ten->second.result_available || !ten->second.post_doppler_valid ||
+            ten->second.mode != one.mode) {
+            continue;
+        }
+        ++matched_scale;
+        max_sigma_mismatch_hz = std::max(max_sigma_mismatch_hz, std::abs(one.sigma_hz - ten->second.sigma_hz));
+        one_errors.push_back(one.tracking_error_hz);
+        ten_errors.push_back(ten->second.tracking_error_hz);
+    }
+    const DistributionMetrics one_metric = metrics(one_errors);
+    const DistributionMetrics ten_metric = metrics(ten_errors);
+    const double rms_ratio = ten_metric.rms > 0.0 ? one_metric.rms / ten_metric.rms : 0.0;
+
+    std::cout << "CARRIER_RATE_SANITY matched_pll=" << matched_scale
+              << " max_sigma_mismatch_hz=" << max_sigma_mismatch_hz << " one_hz_error_rms_hz=" << one_metric.rms
+              << " ten_hz_error_rms_hz=" << ten_metric.rms << " rms_ratio=" << rms_ratio << '\n';
+
+    EXPECT_GT(matched_scale, 10U);
+    EXPECT_LT(max_sigma_mismatch_hz, 1.0e-10);
+    EXPECT_GT(one_metric.rms, 0.0);
+    EXPECT_GT(ten_metric.rms, 0.0);
+    EXPECT_GT(rms_ratio, 0.1);
+    EXPECT_LT(rms_ratio, 10.0);
+
+    cleanup(one_hz_directory);
+    cleanup(ten_hz_directory);
+}
+
+TEST(CarrierTrackingAuthenticValidation, AuthenticNavReacquisitionExercisesPersistenceAndValidity) {
+    const std::filesystem::path directory = "gnss_sim_carrier_auth_reacquisition";
+    const gnss_sim::SimConfig config = reacquisition_config();
+    const gnss_sim::SimTime validation_start = start_time();
+    gnss_sim::SimulatorRunSummary summary{};
+    std::string error_message;
+    ASSERT_TRUE(run_in_directory(directory, config, &summary, &error_message)) << error_message;
+
+    std::vector<CarrierSample> samples;
+    ASSERT_TRUE(parse_carrier_samples(directory / "carrier_tracking_truth.csv", &samples));
+
+    std::uint64_t reset_rows = 0;
+    std::uint64_t reacquisition_result_rows = 0;
+    std::uint64_t reacquisition_unlocked_code_only = 0;
+    std::uint64_t reacquisition_fll_valid_no_adr = 0;
+    std::uint64_t reacquisition_new_segments = 0;
+    for (const CarrierSample& sample : samples) {
+        if (sample.reset_reason == "CODE_NOT_TRACKING") {
+            ++reset_rows;
+        }
+        if (sample.acquisition_context != "REACQUISITION" || !sample.result_available) {
+            continue;
+        }
+        ++reacquisition_result_rows;
+        if (sample.mode == "CARRIER_UNLOCKED" && sample.post_code_valid && !sample.post_doppler_valid &&
+            !sample.post_adr_valid) {
+            ++reacquisition_unlocked_code_only;
+        }
+        if (sample.mode == "FLL_TRACK" && sample.post_code_valid && sample.post_doppler_valid &&
+            !sample.post_adr_valid) {
+            ++reacquisition_fll_valid_no_adr;
+        }
+        if (sample.new_carrier_segment) {
+            ++reacquisition_new_segments;
+        }
+    }
+
+    std::map<std::string, std::vector<CarrierSample>> groups;
+    for (const CarrierSample& sample : samples) {
+        groups[signal_key(sample.satellite_number, sample.signal_id)].push_back(sample);
+    }
+
+    bool found_full_sequence = false;
+    std::string selected_key;
+    double first_result_sec = 0.0;
+    double first_fll_sec = 0.0;
+    double first_fll_bandwidth_hz = 0.0;
+    double first_doppler_valid_sec = 0.0;
+    double first_pll_sec = 0.0;
+    double first_adr_valid_sec = 0.0;
+    double adr_jump_cycles = 0.0;
+    for (const auto& entry : groups) {
+        bool have_pre_adr = false;
+        double last_pre_adr = 0.0;
+        bool have_first_result = false;
+        bool have_fll = false;
+        bool have_doppler = false;
+        bool have_pll = false;
+        bool have_adr = false;
+        double local_first_result = 0.0;
+        double local_fll = 0.0;
+        double local_fll_bandwidth = 0.0;
+        double local_doppler = 0.0;
+        double local_pll = 0.0;
+        double local_adr = 0.0;
+        double first_post_adr = 0.0;
+
+        for (const CarrierSample& sample : entry.second) {
+            const double elapsed_sec = static_cast<double>(sample.tow_ns - validation_start.tow_ns) /
+                                       static_cast<double>(gnss_sim::NANOSECONDS_PER_SECOND);
+            if (elapsed_sec < 6.0 && sample.post_snapshot_available && sample.post_adr_valid) {
+                have_pre_adr = true;
+                last_pre_adr = sample.post_adr_cycles;
+            }
+            if (sample.acquisition_context != "REACQUISITION" || !sample.result_available) {
+                continue;
+            }
+            if (!have_first_result) {
+                have_first_result = true;
+                local_first_result = elapsed_sec;
+            }
+            if (!have_fll && sample.mode == "FLL_TRACK") {
+                have_fll = true;
+                local_fll = elapsed_sec;
+                local_fll_bandwidth = sample.active_bandwidth_hz;
+            }
+            if (!have_doppler && sample.post_doppler_valid) {
+                have_doppler = true;
+                local_doppler = elapsed_sec;
+            }
+            if (!have_pll && sample.mode == "PLL_TRACK") {
+                have_pll = true;
+                local_pll = elapsed_sec;
+            }
+            if (!have_adr && sample.post_adr_valid) {
+                have_adr = true;
+                local_adr = elapsed_sec;
+                first_post_adr = sample.post_adr_cycles;
+            }
+        }
+        if (have_pre_adr && have_first_result && have_fll && have_doppler && have_pll && have_adr) {
+            found_full_sequence = true;
+            selected_key = entry.first;
+            first_result_sec = local_first_result;
+            first_fll_sec = local_fll;
+            first_fll_bandwidth_hz = local_fll_bandwidth;
+            first_doppler_valid_sec = local_doppler;
+            first_pll_sec = local_pll;
+            first_adr_valid_sec = local_adr;
+            adr_jump_cycles = first_post_adr - last_pre_adr;
+            break;
+        }
+    }
+
+    std::cout << "CARRIER_REACQUISITION reset_rows=" << reset_rows << " result_rows=" << reacquisition_result_rows
+              << " unlocked_code_only=" << reacquisition_unlocked_code_only
+              << " fll_valid_no_adr=" << reacquisition_fll_valid_no_adr
+              << " new_segments=" << reacquisition_new_segments << " selected=" << selected_key
+              << " first_result_s=" << first_result_sec << " first_fll_s=" << first_fll_sec
+              << " first_fll_bandwidth_hz=" << first_fll_bandwidth_hz
+              << " first_doppler_valid_s=" << first_doppler_valid_sec << " first_pll_s=" << first_pll_sec
+              << " first_adr_valid_s=" << first_adr_valid_sec << " adr_jump_cycles=" << adr_jump_cycles << '\n';
+
+    EXPECT_GT(reset_rows, 0U);
+    EXPECT_GT(reacquisition_result_rows, 0U);
+    EXPECT_GT(reacquisition_unlocked_code_only, 0U);
+    EXPECT_GT(reacquisition_fll_valid_no_adr, 0U);
+    EXPECT_GT(reacquisition_new_segments, 0U);
+    ASSERT_TRUE(found_full_sequence);
+    EXPECT_GE(first_fll_sec - first_result_sec, 0.1);
+    EXPECT_NEAR(first_fll_bandwidth_hz, config.carrier_tracking.fll_pull_in_bandwidth_hz, 1.0e-12);
+    EXPECT_GE(first_doppler_valid_sec - first_fll_sec, 0.1);
+    EXPECT_GE(first_adr_valid_sec - first_pll_sec, 0.9);
+    EXPECT_NE(adr_jump_cycles, 0.0);
+
+    cleanup(directory);
+}
+
+} // namespace

--- a/tests/integration/test_carrier_tracking_runtime.cpp
+++ b/tests/integration/test_carrier_tracking_runtime.cpp
@@ -1,0 +1,334 @@
+#include "gnss/signal_definitions.h"
+#include "gnss_sim/sim_config.h"
+#include "gnss_sim/sim_time.h"
+#include "gnss_sim/simulator.h"
+#include "model/carrier_tracking_runtime.h"
+
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <string>
+
+namespace {
+
+constexpr double kWavelengthM = 0.190293672798365;
+
+std::string nav_path() {
+    return std::string(GNSS_SIM_TEST_DATA_DIR) + "/gps_loopback_nav.rnx";
+}
+
+gnss_sim::SimTime make_time(double sow_sec) {
+    gnss_sim::SimTime time{};
+    EXPECT_TRUE(gnss_sim::sim_time_from_week_sow(2253, sow_sec, &time));
+    return time;
+}
+
+std::string read_file(const std::filesystem::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    return std::string((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
+}
+
+bool run_sim(const std::filesystem::path& directory, const gnss_sim::SimConfig& config,
+             gnss_sim::SimulatorRunSummary* summary, std::string* error_message) {
+    std::error_code error;
+    std::filesystem::remove_all(directory, error);
+    error.clear();
+    if (!std::filesystem::create_directories(directory, error) || error) {
+        if (error_message != nullptr) {
+            *error_message = "cannot create carrier tracking runtime test directory";
+        }
+        return false;
+    }
+    const std::filesystem::path output_path = directory / "simulated.log";
+    const std::string nav = nav_path();
+    const std::string output = output_path.string();
+    const gnss_sim::SimulatorRunOptions options{nav.c_str(), output.c_str(), make_time(172900.0), nullptr};
+    return gnss_sim::run_simulator(config, options, summary, error_message);
+}
+
+void cleanup(const std::filesystem::path& path) {
+    std::error_code error;
+    std::filesystem::remove_all(path, error);
+}
+
+TEST(CarrierTrackingRuntime, SubstepsLowRateOutputAcrossPersistenceBoundaries) {
+    gnss_sim::CarrierTrackingRuntimeState state{};
+    gnss_sim::initialize_carrier_tracking_runtime_state(7U, 1, gnss_sim::SignalId::kGpsL1Ca, &state);
+    const gnss_sim::CarrierTrackingReceiverConfig config = gnss_sim::default_sim_config().carrier_tracking;
+    gnss_sim::CarrierTrackingRuntimeResult result{};
+    std::string error_message;
+
+    ASSERT_TRUE(gnss_sim::update_carrier_tracking_runtime(config, make_time(100.0), true, 35.0, kWavelengthM, &state,
+                                                          &result, &error_message))
+        << error_message;
+    EXPECT_EQ(result.tracking.mode, gnss_sim::CarrierTrackingMode::kCarrierUnlocked);
+    EXPECT_FALSE(result.tracking.doppler_valid);
+
+    ASSERT_TRUE(gnss_sim::update_carrier_tracking_runtime(config, make_time(100.2), true, 35.0, kWavelengthM, &state,
+                                                          &result, &error_message))
+        << error_message;
+    EXPECT_EQ(result.tracking.mode, gnss_sim::CarrierTrackingMode::kFllTrack);
+    EXPECT_EQ(result.tracking.fll_phase, gnss_sim::CarrierTrackingFllPhase::kPullIn);
+    EXPECT_FALSE(result.tracking.doppler_valid);
+
+    ASSERT_TRUE(gnss_sim::update_carrier_tracking_runtime(config, make_time(100.4), true, 35.0, kWavelengthM, &state,
+                                                          &result, &error_message))
+        << error_message;
+    EXPECT_EQ(result.tracking.mode, gnss_sim::CarrierTrackingMode::kFllTrack);
+    EXPECT_TRUE(result.tracking.doppler_valid);
+    EXPECT_FALSE(result.tracking.adr_valid);
+
+    ASSERT_TRUE(gnss_sim::update_carrier_tracking_runtime(config, make_time(101.2), true, 35.0, kWavelengthM, &state,
+                                                          &result, &error_message))
+        << error_message;
+    EXPECT_EQ(result.tracking.mode, gnss_sim::CarrierTrackingMode::kPllTrack);
+    EXPECT_FALSE(result.tracking.adr_valid);
+
+    ASSERT_TRUE(gnss_sim::update_carrier_tracking_runtime(config, make_time(102.2), true, 35.0, kWavelengthM, &state,
+                                                          &result, &error_message))
+        << error_message;
+    EXPECT_EQ(result.tracking.mode, gnss_sim::CarrierTrackingMode::kPllTrack);
+    EXPECT_TRUE(result.tracking.doppler_valid);
+    EXPECT_TRUE(result.tracking.adr_valid);
+}
+
+TEST(CarrierTrackingRuntime, PllLossImmediatelyBreaksAdrAndStartsNewPhaseSegment) {
+    gnss_sim::CarrierTrackingRuntimeState state{};
+    gnss_sim::initialize_carrier_tracking_runtime_state(11U, 3, gnss_sim::SignalId::kGpsL1Ca, &state);
+    const gnss_sim::CarrierTrackingReceiverConfig config = gnss_sim::default_sim_config().carrier_tracking;
+    gnss_sim::CarrierTrackingRuntimeResult result{};
+    std::string error_message;
+
+    ASSERT_TRUE(gnss_sim::update_carrier_tracking_runtime(config, make_time(200.0), true, 35.0, kWavelengthM, &state,
+                                                          &result, &error_message));
+    ASSERT_TRUE(gnss_sim::update_carrier_tracking_runtime(config, make_time(202.2), true, 35.0, kWavelengthM, &state,
+                                                          &result, &error_message))
+        << error_message;
+    ASSERT_EQ(result.tracking.mode, gnss_sim::CarrierTrackingMode::kPllTrack);
+    ASSERT_TRUE(result.tracking.adr_valid);
+    EXPECT_EQ(result.phase_segment_id, 0U);
+    EXPECT_EQ(result.adr_cycle_offset_cycles, 0);
+
+    ASSERT_TRUE(gnss_sim::update_carrier_tracking_runtime(config, make_time(202.5), true, 26.0, kWavelengthM, &state,
+                                                          &result, &error_message))
+        << error_message;
+    EXPECT_EQ(result.tracking.mode, gnss_sim::CarrierTrackingMode::kFllTrack);
+    EXPECT_FALSE(result.tracking.adr_valid);
+    EXPECT_TRUE(result.cycle_slip_event);
+    EXPECT_EQ(result.phase_segment_id, 1U);
+    EXPECT_NE(result.adr_cycle_offset_cycles, 0);
+
+    ASSERT_TRUE(gnss_sim::update_carrier_tracking_runtime(config, make_time(203.5), true, 35.0, kWavelengthM, &state,
+                                                          &result, &error_message))
+        << error_message;
+    EXPECT_EQ(result.tracking.mode, gnss_sim::CarrierTrackingMode::kPllTrack);
+    EXPECT_FALSE(result.tracking.adr_valid);
+
+    ASSERT_TRUE(gnss_sim::update_carrier_tracking_runtime(config, make_time(204.5), true, 35.0, kWavelengthM, &state,
+                                                          &result, &error_message))
+        << error_message;
+    EXPECT_TRUE(result.tracking.adr_valid);
+    EXPECT_EQ(result.phase_segment_id, 1U);
+    EXPECT_NE(result.adr_cycle_offset_cycles, 0);
+}
+
+TEST(CarrierTrackingRuntime, MeasurementApplicationPreservesDopplerRangeRateSignConvention) {
+    gnss_sim::MeasurementObservation observation{};
+    observation.wavelength_m = 0.2;
+    observation.range_rate_mps = 12.0;
+    observation.doppler_hz = -50.0;
+    observation.adr_cycles = 1234.0;
+    observation.ambiguity_cycles = 100;
+    observation.observation_available = true;
+    observation.pseudorange_valid = true;
+    observation.doppler_valid = true;
+    observation.adr_valid = true;
+
+    gnss_sim::CarrierTrackingRuntimeResult carrier{};
+    carrier.tracking.mode = gnss_sim::CarrierTrackingMode::kFllTrack;
+    carrier.tracking.tracking_error_hz = 3.0;
+    carrier.tracking.tracking_error_mps = 0.6;
+    carrier.tracking.doppler_valid = true;
+    carrier.tracking.adr_valid = false;
+
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::apply_carrier_tracking_runtime_result(carrier, &observation, &error_message))
+        << error_message;
+    EXPECT_DOUBLE_EQ(observation.doppler_hz, -47.0);
+    EXPECT_DOUBLE_EQ(observation.range_rate_mps, 11.4);
+    EXPECT_TRUE(observation.pseudorange_valid);
+    EXPECT_TRUE(observation.doppler_valid);
+    EXPECT_FALSE(observation.adr_valid);
+}
+
+TEST(CarrierTrackingRuntime, CarrierUnlockedKeepsCodeButInvalidatesDopplerAndAdr) {
+    gnss_sim::MeasurementObservation observation{};
+    observation.wavelength_m = 0.2;
+    observation.range_rate_mps = 12.0;
+    observation.doppler_hz = -50.0;
+    observation.adr_cycles = 1234.0;
+    observation.observation_available = true;
+    observation.pseudorange_valid = true;
+    observation.doppler_valid = true;
+    observation.adr_valid = true;
+
+    gnss_sim::CarrierTrackingRuntimeResult carrier{};
+    carrier.tracking.mode = gnss_sim::CarrierTrackingMode::kCarrierUnlocked;
+    carrier.tracking.doppler_valid = false;
+    carrier.tracking.adr_valid = false;
+
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::apply_carrier_tracking_runtime_result(carrier, &observation, &error_message))
+        << error_message;
+    EXPECT_DOUBLE_EQ(observation.doppler_hz, -50.0);
+    EXPECT_DOUBLE_EQ(observation.range_rate_mps, 12.0);
+    EXPECT_TRUE(observation.pseudorange_valid);
+    EXPECT_FALSE(observation.doppler_valid);
+    EXPECT_FALSE(observation.adr_valid);
+}
+
+TEST(CarrierTrackingRuntime, NewPllSegmentUsesDifferentIntegerAmbiguityOffset) {
+    gnss_sim::MeasurementObservation observation{};
+    observation.wavelength_m = 0.2;
+    observation.range_rate_mps = 0.0;
+    observation.doppler_hz = 0.0;
+    observation.adr_cycles = 1000.25;
+    observation.ambiguity_cycles = 500;
+    observation.observation_available = true;
+    observation.pseudorange_valid = true;
+    observation.doppler_valid = true;
+    observation.adr_valid = true;
+
+    gnss_sim::CarrierTrackingRuntimeResult carrier{};
+    carrier.tracking.mode = gnss_sim::CarrierTrackingMode::kPllTrack;
+    carrier.tracking.doppler_valid = true;
+    carrier.tracking.adr_valid = true;
+    carrier.adr_cycle_offset_cycles = 37;
+    carrier.phase_segment_id = 1U;
+
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::apply_carrier_tracking_runtime_result(carrier, &observation, &error_message))
+        << error_message;
+    EXPECT_EQ(observation.ambiguity_cycles, 537);
+    EXPECT_DOUBLE_EQ(observation.adr_cycles, 1037.25);
+}
+
+TEST(CarrierTrackingRuntime, SamePerSignalSeedAndInputsAreDeterministic) {
+    gnss_sim::CarrierTrackingRuntimeState first{};
+    gnss_sim::CarrierTrackingRuntimeState second{};
+    gnss_sim::initialize_carrier_tracking_runtime_state(42U, 5, gnss_sim::SignalId::kGpsL1Ca, &first);
+    gnss_sim::initialize_carrier_tracking_runtime_state(42U, 5, gnss_sim::SignalId::kGpsL1Ca, &second);
+    const gnss_sim::CarrierTrackingReceiverConfig config = gnss_sim::default_sim_config().carrier_tracking;
+    std::string first_error;
+    std::string second_error;
+
+    for (int index = 0; index <= 30; ++index) {
+        const double cn0 = index < 18 ? 35.0 : 26.0;
+        gnss_sim::CarrierTrackingRuntimeResult first_result{};
+        gnss_sim::CarrierTrackingRuntimeResult second_result{};
+        ASSERT_TRUE(gnss_sim::update_carrier_tracking_runtime(config, make_time(300.0 + 0.1 * index), true, cn0,
+                                                              kWavelengthM, &first, &first_result, &first_error))
+            << first_error;
+        ASSERT_TRUE(gnss_sim::update_carrier_tracking_runtime(config, make_time(300.0 + 0.1 * index), true, cn0,
+                                                              kWavelengthM, &second, &second_result, &second_error))
+            << second_error;
+        EXPECT_EQ(first_result.tracking.mode, second_result.tracking.mode);
+        EXPECT_DOUBLE_EQ(first_result.tracking.tracking_error_hz, second_result.tracking.tracking_error_hz);
+        EXPECT_DOUBLE_EQ(first_result.tracking.tracking_error_mps, second_result.tracking.tracking_error_mps);
+        EXPECT_EQ(first_result.tracking.doppler_valid, second_result.tracking.doppler_valid);
+        EXPECT_EQ(first_result.tracking.adr_valid, second_result.tracking.adr_valid);
+        EXPECT_EQ(first_result.phase_segment_id, second_result.phase_segment_id);
+        EXPECT_EQ(first_result.adr_cycle_offset_cycles, second_result.adr_cycle_offset_cycles);
+    }
+}
+
+TEST(CarrierTrackingRuntime, HardResetClearsTrackingAndContinuityState) {
+    gnss_sim::CarrierTrackingRuntimeState state{};
+    gnss_sim::initialize_carrier_tracking_runtime_state(19U, 7, gnss_sim::SignalId::kGpsL1Ca, &state);
+    const gnss_sim::CarrierTrackingReceiverConfig config = gnss_sim::default_sim_config().carrier_tracking;
+    gnss_sim::CarrierTrackingRuntimeResult result{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::update_carrier_tracking_runtime(config, make_time(400.0), true, 35.0, kWavelengthM, &state,
+                                                          &result, &error_message));
+    ASSERT_TRUE(gnss_sim::update_carrier_tracking_runtime(config, make_time(402.2), true, 35.0, kWavelengthM, &state,
+                                                          &result, &error_message));
+    ASSERT_TRUE(result.tracking.adr_valid);
+
+    gnss_sim::reset_carrier_tracking_runtime_state(&state);
+    EXPECT_EQ(state.tracking.mode, gnss_sim::CarrierTrackingMode::kCarrierUnlocked);
+    EXPECT_FALSE(state.time_initialized);
+    EXPECT_EQ(state.phase_segment_id, 0U);
+    EXPECT_EQ(state.adr_cycle_offset_cycles, 0);
+
+    ASSERT_TRUE(gnss_sim::update_carrier_tracking_runtime(config, make_time(500.0), true, 35.0, kWavelengthM, &state,
+                                                          &result, &error_message));
+    EXPECT_EQ(result.tracking.mode, gnss_sim::CarrierTrackingMode::kCarrierUnlocked);
+    EXPECT_FALSE(result.tracking.doppler_valid);
+    EXPECT_FALSE(result.tracking.adr_valid);
+}
+
+TEST(CarrierTrackingRuntime, DisabledSimulatorFeaturePreservesBytesAndPhysicalUrbanTruth) {
+    const std::filesystem::path baseline_dir = "gnss_sim_carrier_disabled_baseline";
+    const std::filesystem::path altered_dir = "gnss_sim_carrier_disabled_altered";
+    gnss_sim::SimConfig baseline = gnss_sim::default_sim_config();
+    baseline.scenario = gnss_sim::ScenarioType::KS;
+    baseline.atmosphere_mode = gnss_sim::AtmosphereMode::NONE;
+    baseline.elevation_mask_deg = 0.0;
+    baseline.sampling_rate_hz = 10;
+    baseline.duration_ns = 4LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    baseline.seed = 7U;
+    baseline.multipath_enabled = true;
+    ASSERT_FALSE(baseline.carrier_tracking.enabled);
+
+    gnss_sim::SimConfig altered = baseline;
+    altered.carrier_tracking.pll_noise_bandwidth_hz = 6.0;
+    altered.carrier_tracking.fll_noise_bandwidth_hz = 5.0;
+    altered.carrier_tracking.fll_pull_in_bandwidth_hz = 9.0;
+
+    gnss_sim::SimulatorRunSummary first_summary{};
+    gnss_sim::SimulatorRunSummary second_summary{};
+    std::string error_message;
+    ASSERT_TRUE(run_sim(baseline_dir, baseline, &first_summary, &error_message)) << error_message;
+    ASSERT_TRUE(run_sim(altered_dir, altered, &second_summary, &error_message)) << error_message;
+    EXPECT_EQ(read_file(baseline_dir / "simulated.log"), read_file(altered_dir / "simulated.log"));
+    EXPECT_EQ(read_file(baseline_dir / "urban_signal_truth.csv"), read_file(altered_dir / "urban_signal_truth.csv"));
+    EXPECT_EQ(read_file(baseline_dir / "urban_path_truth.csv"), read_file(altered_dir / "urban_path_truth.csv"));
+
+    cleanup(baseline_dir);
+    cleanup(altered_dir);
+}
+
+TEST(CarrierTrackingRuntime, EnabledSimulatorFeatureIsDeterministicAndLeavesPhysicalTruthUnchanged) {
+    const std::filesystem::path disabled_dir = "gnss_sim_carrier_physical_truth";
+    const std::filesystem::path enabled_a_dir = "gnss_sim_carrier_enabled_a";
+    const std::filesystem::path enabled_b_dir = "gnss_sim_carrier_enabled_b";
+    gnss_sim::SimConfig config = gnss_sim::default_sim_config();
+    config.scenario = gnss_sim::ScenarioType::KS;
+    config.atmosphere_mode = gnss_sim::AtmosphereMode::NONE;
+    config.elevation_mask_deg = 0.0;
+    config.sampling_rate_hz = 10;
+    config.duration_ns = 6LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    config.seed = 7U;
+    config.multipath_enabled = true;
+
+    gnss_sim::SimulatorRunSummary disabled_summary{};
+    gnss_sim::SimulatorRunSummary enabled_a_summary{};
+    gnss_sim::SimulatorRunSummary enabled_b_summary{};
+    std::string error_message;
+    ASSERT_TRUE(run_sim(disabled_dir, config, &disabled_summary, &error_message)) << error_message;
+
+    config.carrier_tracking.enabled = true;
+    ASSERT_TRUE(run_sim(enabled_a_dir, config, &enabled_a_summary, &error_message)) << error_message;
+    ASSERT_TRUE(run_sim(enabled_b_dir, config, &enabled_b_summary, &error_message)) << error_message;
+
+    EXPECT_EQ(read_file(enabled_a_dir / "simulated.log"), read_file(enabled_b_dir / "simulated.log"));
+    EXPECT_NE(read_file(disabled_dir / "simulated.log"), read_file(enabled_a_dir / "simulated.log"));
+    EXPECT_EQ(read_file(disabled_dir / "urban_signal_truth.csv"), read_file(enabled_a_dir / "urban_signal_truth.csv"));
+    EXPECT_EQ(read_file(disabled_dir / "urban_path_truth.csv"), read_file(enabled_a_dir / "urban_path_truth.csv"));
+
+    cleanup(disabled_dir);
+    cleanup(enabled_a_dir);
+    cleanup(enabled_b_dir);
+}
+
+} // namespace

--- a/tests/integration/test_carrier_tracking_truth.cpp
+++ b/tests/integration/test_carrier_tracking_truth.cpp
@@ -1,0 +1,324 @@
+#include "gnss/signal_definitions.h"
+#include "gnss_sim/sim_config.h"
+#include "gnss_sim/sim_time.h"
+#include "gnss_sim/simulator.h"
+#include "output/carrier_tracking_truth_writer.h"
+
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace {
+
+std::string nav_path() {
+    return std::string(GNSS_SIM_TEST_DATA_DIR) + "/gps_loopback_nav.rnx";
+}
+
+gnss_sim::SimTime start_time() {
+    gnss_sim::SimTime time{};
+    EXPECT_TRUE(gnss_sim::sim_time_from_week_sow(2253, 172900.0, &time));
+    return time;
+}
+
+std::string read_file(const std::filesystem::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    return std::string((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
+}
+
+std::vector<std::string> split_csv_line(const std::string& line) {
+    std::vector<std::string> fields;
+    std::size_t start = 0;
+    while (true) {
+        const std::size_t separator = line.find(',', start);
+        if (separator == std::string::npos) {
+            fields.push_back(line.substr(start));
+            return fields;
+        }
+        fields.push_back(line.substr(start, separator - start));
+        start = separator + 1U;
+    }
+}
+
+std::vector<std::vector<std::string>> read_csv(const std::filesystem::path& path) {
+    std::vector<std::vector<std::string>> rows;
+    std::ifstream input(path, std::ios::binary);
+    std::string line;
+    while (std::getline(input, line)) {
+        rows.push_back(split_csv_line(line));
+    }
+    return rows;
+}
+
+std::unordered_map<std::string, std::size_t> header_index(const std::vector<std::string>& header) {
+    std::unordered_map<std::string, std::size_t> result;
+    for (std::size_t index = 0; index < header.size(); ++index) {
+        result.emplace(header[index], index);
+    }
+    return result;
+}
+
+bool run_sim(const std::filesystem::path& directory, const gnss_sim::SimConfig& config,
+             gnss_sim::SimulatorRunSummary* summary, std::string* error_message) {
+    std::error_code error;
+    std::filesystem::remove_all(directory, error);
+    error.clear();
+    if (!std::filesystem::create_directories(directory, error) || error) {
+        if (error_message != nullptr) {
+            *error_message = "cannot create carrier truth test directory";
+        }
+        return false;
+    }
+    const std::filesystem::path output_path = directory / "simulated.log";
+    const std::string nav = nav_path();
+    const std::string output = output_path.string();
+    const gnss_sim::SimulatorRunOptions options{nav.c_str(), output.c_str(), start_time(), nullptr};
+    return gnss_sim::run_simulator(config, options, summary, error_message);
+}
+
+void cleanup(const std::filesystem::path& path) {
+    std::error_code error;
+    std::filesystem::remove_all(path, error);
+}
+
+void expect_consistent_columns(const std::vector<std::vector<std::string>>& rows) {
+    ASSERT_GT(rows.size(), 1U);
+    const std::size_t width = rows.front().size();
+    EXPECT_EQ(width, 61U);
+    for (std::size_t row = 1; row < rows.size(); ++row) {
+        EXPECT_EQ(rows[row].size(), width) << "row " << row + 1U;
+    }
+}
+
+TEST(CarrierTrackingTruth, WriterSerializesExactSnapshotWithoutRecomputation) {
+    const std::filesystem::path directory = "gnss_sim_carrier_truth_writer";
+    cleanup(directory);
+    ASSERT_TRUE(std::filesystem::create_directories(directory));
+
+    std::string error_message;
+    const std::filesystem::path receiver_path = directory / "simulated.log";
+    gnss_sim::CarrierTrackingTruthWriter* writer =
+        gnss_sim::create_carrier_tracking_truth_writer(receiver_path.string().c_str(), &error_message);
+    ASSERT_NE(writer, nullptr) << error_message;
+
+    gnss_sim::SatelliteGeometry geometry{};
+    geometry.satellite_number = 1;
+    geometry.receive_time = start_time();
+    const gnss_sim::SignalDefinition* signal = gnss_sim::find_signal_definition(gnss_sim::SignalId::kGpsL1Ca);
+    ASSERT_NE(signal, nullptr);
+
+    gnss_sim::SignalTracker tracker{};
+    tracker.phase = gnss_sim::SignalTrackingPhase::kTracking;
+    tracker.acquisition_context = gnss_sim::AcquisitionContext::kReacquisition;
+    tracker.loss_reason = gnss_sim::SignalTrackingLossReason::kLowCn0;
+
+    gnss_sim::CarrierTrackingTruthSnapshot snapshot{};
+    snapshot.carrier_tracking_enabled = true;
+    snapshot.result_available = true;
+    snapshot.reset_reason = gnss_sim::CarrierTrackingTruthResetReason::kNone;
+    snapshot.coherent_integration_sec = 0.02;
+    snapshot.effective_cn0_dbhz = 26.5;
+    snapshot.runtime_result.tracking.mode = gnss_sim::CarrierTrackingMode::kFllTrack;
+    snapshot.runtime_result.tracking.fll_phase = gnss_sim::CarrierTrackingFllPhase::kSteady;
+    snapshot.runtime_result.tracking.jitter.cn0_linear_hz = 446.683592150963;
+    snapshot.runtime_result.tracking.jitter.active_bandwidth_hz = 4.0;
+    snapshot.runtime_result.tracking.jitter.phase_sigma_rad = 0.125;
+    snapshot.runtime_result.tracking.jitter.sigma_hz = 1.25;
+    snapshot.runtime_result.tracking.jitter.sigma_mps = 0.25;
+    snapshot.runtime_result.tracking.jitter.correlation_tau_sec = 0.04;
+    snapshot.runtime_result.tracking.jitter.correlation_alpha = 0.6;
+    snapshot.runtime_result.tracking.tracking_error_hz = 2.5;
+    snapshot.runtime_result.tracking.tracking_error_mps = 0.5;
+    snapshot.runtime_result.tracking.carrier_segment_id = 7U;
+    snapshot.runtime_result.tracking.doppler_valid = true;
+    snapshot.runtime_result.tracking.adr_valid = false;
+    snapshot.runtime_result.tracking.mode_changed = true;
+    snapshot.runtime_result.tracking.new_carrier_segment = false;
+    snapshot.runtime_result.phase_segment_id = 3U;
+    snapshot.runtime_result.adr_cycle_offset_cycles = -17;
+    snapshot.runtime_result.cycle_slip_event = true;
+    snapshot.runtime_state.mode = gnss_sim::CarrierTrackingMode::kFllTrack;
+    snapshot.runtime_state.mode_age_sec = 0.7;
+    snapshot.runtime_state.carrier_lock_age_sec = 1.7;
+    snapshot.runtime_state.pll_age_sec = 0.0;
+    snapshot.runtime_state.fll_enter_persistence_sec = 0.1;
+    snapshot.runtime_state.fll_exit_persistence_sec = 0.2;
+    snapshot.runtime_state.pll_enter_persistence_sec = 0.3;
+    snapshot.runtime_state.pll_exit_persistence_sec = 0.4;
+    snapshot.environmental_range_rate_applicable = true;
+    snapshot.environmental_range_rate_valid = true;
+    snapshot.environmental_range_rate_mps = -0.75;
+    snapshot.physical_snapshot_available = true;
+    snapshot.physical_observation.observation_available = true;
+    snapshot.physical_observation.pseudorange_valid = true;
+    snapshot.physical_observation.doppler_valid = true;
+    snapshot.physical_observation.adr_valid = true;
+    snapshot.physical_observation.range_rate_mps = 12.0;
+    snapshot.physical_observation.doppler_hz = -50.0;
+    snapshot.physical_observation.adr_cycles = 1000.25;
+    snapshot.physical_range_rate_valid = true;
+    snapshot.post_carrier_snapshot_available = true;
+    snapshot.post_carrier_observation = snapshot.physical_observation;
+    snapshot.post_carrier_observation.range_rate_mps = 11.5;
+    snapshot.post_carrier_observation.doppler_hz = -47.5;
+    snapshot.post_carrier_observation.adr_valid = false;
+    snapshot.post_carrier_range_rate_valid = true;
+
+    ASSERT_TRUE(gnss_sim::carrier_tracking_truth_writer_write_signal(writer, geometry, *signal, 0, tracker, snapshot,
+                                                                     &error_message))
+        << error_message;
+    ASSERT_TRUE(gnss_sim::finalize_carrier_tracking_truth_writer(writer, &error_message)) << error_message;
+    gnss_sim::destroy_carrier_tracking_truth_writer(writer);
+
+    const std::vector<std::vector<std::string>> rows = read_csv(directory / "carrier_tracking_truth.csv");
+    ASSERT_EQ(rows.size(), 2U);
+    expect_consistent_columns(rows);
+    const auto columns = header_index(rows[0]);
+    const std::vector<std::string>& row = rows[1];
+    EXPECT_EQ(row.at(columns.at("carrier_truth_schema_version")), "1");
+    EXPECT_EQ(row.at(columns.at("carrier_mode")), "FLL_TRACK");
+    EXPECT_EQ(row.at(columns.at("fll_phase")), "STEADY");
+    EXPECT_EQ(row.at(columns.at("acquisition_context")), "REACQUISITION");
+    EXPECT_EQ(row.at(columns.at("signal_loss_reason")), "LOW_CN0");
+    EXPECT_DOUBLE_EQ(std::stod(row.at(columns.at("tracking_error_hz"))), 2.5);
+    EXPECT_DOUBLE_EQ(std::stod(row.at(columns.at("tracking_error_mps"))), 0.5);
+    EXPECT_DOUBLE_EQ(std::stod(row.at(columns.at("mode_age_sec"))), 0.7);
+    EXPECT_DOUBLE_EQ(std::stod(row.at(columns.at("pll_enter_persistence_sec"))), 0.3);
+    EXPECT_EQ(std::stoull(row.at(columns.at("carrier_segment_id"))), 7U);
+    EXPECT_EQ(std::stoull(row.at(columns.at("phase_segment_id"))), 3U);
+    EXPECT_EQ(std::stoll(row.at(columns.at("adr_cycle_offset_cycles"))), -17);
+    EXPECT_EQ(row.at(columns.at("cycle_slip_event")), "1");
+    EXPECT_DOUBLE_EQ(std::stod(row.at(columns.at("environmental_range_rate_mps"))), -0.75);
+    EXPECT_DOUBLE_EQ(std::stod(row.at(columns.at("physical_doppler_hz"))), -50.0);
+    EXPECT_DOUBLE_EQ(std::stod(row.at(columns.at("post_carrier_doppler_hz"))), -47.5);
+    EXPECT_EQ(row.at(columns.at("physical_adr_valid")), "1");
+    EXPECT_EQ(row.at(columns.at("post_carrier_adr_valid")), "0");
+    cleanup(directory);
+}
+
+TEST(CarrierTrackingTruth, EnabledSimulatorRowsAreDeterministicAndExposeCarrierBoundary) {
+    const std::filesystem::path first_dir = "gnss_sim_carrier_truth_enabled_a";
+    const std::filesystem::path second_dir = "gnss_sim_carrier_truth_enabled_b";
+    gnss_sim::SimConfig config = gnss_sim::default_sim_config();
+    config.scenario = gnss_sim::ScenarioType::KS;
+    config.atmosphere_mode = gnss_sim::AtmosphereMode::NONE;
+    config.elevation_mask_deg = 0.0;
+    config.sampling_rate_hz = 10;
+    config.duration_ns = 6LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    config.seed = 7U;
+    config.multipath_enabled = true;
+    config.measurement_noise_enabled = false;
+    config.carrier_tracking.enabled = true;
+
+    gnss_sim::SimulatorRunSummary first_summary{};
+    gnss_sim::SimulatorRunSummary second_summary{};
+    std::string error_message;
+    ASSERT_TRUE(run_sim(first_dir, config, &first_summary, &error_message)) << error_message;
+    ASSERT_TRUE(run_sim(second_dir, config, &second_summary, &error_message)) << error_message;
+    EXPECT_EQ(read_file(first_dir / "carrier_tracking_truth.csv"),
+              read_file(second_dir / "carrier_tracking_truth.csv"));
+
+    const std::vector<std::vector<std::string>> rows = read_csv(first_dir / "carrier_tracking_truth.csv");
+    expect_consistent_columns(rows);
+    const auto columns = header_index(rows[0]);
+    bool saw_result = false;
+    bool saw_environmental_range_rate = false;
+    bool saw_unlocked_code_only = false;
+    bool saw_fll_doppler_without_adr = false;
+    bool saw_pull_in = false;
+    bool saw_pll = false;
+    for (std::size_t index = 1; index < rows.size(); ++index) {
+        const std::vector<std::string>& row = rows[index];
+        if (row.at(columns.at("environmental_range_rate_applicable")) == "1" &&
+            row.at(columns.at("environmental_range_rate_valid")) == "1") {
+            saw_environmental_range_rate = true;
+        }
+        if (row.at(columns.at("carrier_result_available")) != "1" ||
+            row.at(columns.at("physical_snapshot_available")) != "1" ||
+            row.at(columns.at("post_carrier_snapshot_available")) != "1") {
+            continue;
+        }
+        saw_result = true;
+        const double physical_doppler = std::stod(row.at(columns.at("physical_doppler_hz")));
+        const double post_doppler = std::stod(row.at(columns.at("post_carrier_doppler_hz")));
+        const double error_hz = std::stod(row.at(columns.at("tracking_error_hz")));
+        const double physical_rate = std::stod(row.at(columns.at("physical_range_rate_mps")));
+        const double post_rate = std::stod(row.at(columns.at("post_carrier_range_rate_mps")));
+        const double error_mps = std::stod(row.at(columns.at("tracking_error_mps")));
+        EXPECT_NEAR(post_doppler, physical_doppler + error_hz, 1e-10);
+        EXPECT_NEAR(post_rate, physical_rate - error_mps, 1e-10);
+
+        const std::string& mode = row.at(columns.at("carrier_mode"));
+        const bool code_valid = row.at(columns.at("post_carrier_code_valid")) == "1";
+        const bool doppler_valid = row.at(columns.at("post_carrier_doppler_valid")) == "1";
+        const bool adr_valid = row.at(columns.at("post_carrier_adr_valid")) == "1";
+        if (mode == "CARRIER_UNLOCKED" && code_valid && !doppler_valid && !adr_valid) {
+            saw_unlocked_code_only = true;
+        }
+        if (mode == "FLL_TRACK" && code_valid && doppler_valid && !adr_valid) {
+            saw_fll_doppler_without_adr = true;
+        }
+        if (row.at(columns.at("fll_phase")) == "PULL_IN") {
+            saw_pull_in = true;
+        }
+        if (mode == "PLL_TRACK") {
+            saw_pll = true;
+        }
+    }
+    EXPECT_TRUE(saw_result);
+    EXPECT_TRUE(saw_environmental_range_rate);
+    EXPECT_TRUE(saw_unlocked_code_only);
+    EXPECT_TRUE(saw_fll_doppler_without_adr);
+    EXPECT_TRUE(saw_pull_in);
+    EXPECT_TRUE(saw_pll);
+    EXPECT_EQ(read_file(first_dir / "simulated.log").find("carrier_mode"), std::string::npos);
+    EXPECT_EQ(read_file(first_dir / "simulated.log").find("tracking_error_hz"), std::string::npos);
+
+    cleanup(first_dir);
+    cleanup(second_dir);
+}
+
+TEST(CarrierTrackingTruth, DisabledFeatureIsExplicitWhileCarrierBoundaryIsIdentity) {
+    const std::filesystem::path directory = "gnss_sim_carrier_truth_disabled";
+    gnss_sim::SimConfig config = gnss_sim::default_sim_config();
+    config.scenario = gnss_sim::ScenarioType::KS;
+    config.atmosphere_mode = gnss_sim::AtmosphereMode::NONE;
+    config.elevation_mask_deg = 0.0;
+    config.sampling_rate_hz = 10;
+    config.duration_ns = 4LL * gnss_sim::NANOSECONDS_PER_SECOND;
+    config.seed = 7U;
+    ASSERT_FALSE(config.carrier_tracking.enabled);
+
+    gnss_sim::SimulatorRunSummary summary{};
+    std::string error_message;
+    ASSERT_TRUE(run_sim(directory, config, &summary, &error_message)) << error_message;
+    const std::vector<std::vector<std::string>> rows = read_csv(directory / "carrier_tracking_truth.csv");
+    expect_consistent_columns(rows);
+    const auto columns = header_index(rows[0]);
+    bool saw_disabled_tracking_row = false;
+    bool saw_code_not_tracking_row = false;
+    for (std::size_t index = 1; index < rows.size(); ++index) {
+        const std::vector<std::string>& row = rows[index];
+        EXPECT_EQ(row.at(columns.at("carrier_tracking_enabled")), "0");
+        EXPECT_EQ(row.at(columns.at("carrier_result_available")), "0");
+        if (row.at(columns.at("carrier_reset_reason")) == "CODE_NOT_TRACKING") {
+            saw_code_not_tracking_row = true;
+        }
+        if (row.at(columns.at("carrier_reset_reason")) != "FEATURE_DISABLED" ||
+            row.at(columns.at("physical_snapshot_available")) != "1") {
+            continue;
+        }
+        saw_disabled_tracking_row = true;
+        EXPECT_EQ(row.at(columns.at("physical_doppler_hz")), row.at(columns.at("post_carrier_doppler_hz")));
+        EXPECT_EQ(row.at(columns.at("physical_range_rate_mps")), row.at(columns.at("post_carrier_range_rate_mps")));
+        EXPECT_EQ(row.at(columns.at("physical_adr_cycles")), row.at(columns.at("post_carrier_adr_cycles")));
+    }
+    EXPECT_TRUE(saw_disabled_tracking_row);
+    EXPECT_TRUE(saw_code_not_tracking_row);
+    cleanup(directory);
+}
+
+} // namespace

--- a/tests/unit/test_carrier_tracking.cpp
+++ b/tests/unit/test_carrier_tracking.cpp
@@ -1,0 +1,331 @@
+#include "model/carrier_tracking.h"
+
+#include <cmath>
+#include <gtest/gtest.h>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace gnss_sim {
+namespace {
+
+constexpr double kL1WavelengthM = 0.190293672798;
+
+CarrierTrackingResult step_tracker(const CarrierTrackingConfig& config, CarrierTrackingState* state, double cn0_dbhz,
+                                   double dt_sec = 0.1, double standard_normal_sample = 0.0,
+                                   bool signal_available = true) {
+    CarrierTrackingInput input{};
+    input.signal_available = signal_available;
+    input.effective_cn0_dbhz = cn0_dbhz;
+    input.wavelength_m = kL1WavelengthM;
+    input.dt_sec = dt_sec;
+    input.standard_normal_sample = standard_normal_sample;
+
+    CarrierTrackingResult result{};
+    std::string error;
+    EXPECT_TRUE(update_carrier_tracking(config, input, state, &result, &error)) << error;
+    return result;
+}
+
+TEST(CarrierTracking, DefaultConfigMatchesFrozenV1) {
+    const CarrierTrackingConfig config = default_carrier_tracking_config();
+
+    EXPECT_DOUBLE_EQ(config.coherent_integration_sec, 0.020);
+    EXPECT_DOUBLE_EQ(config.pll_noise_bandwidth_hz, 5.0);
+    EXPECT_DOUBLE_EQ(config.fll_noise_bandwidth_hz, 4.0);
+    EXPECT_DOUBLE_EQ(config.fll_pull_in_bandwidth_hz, 8.0);
+    EXPECT_DOUBLE_EQ(config.fll_pull_in_duration_sec, 0.5);
+    EXPECT_DOUBLE_EQ(config.pll_enter_cn0_dbhz, 30.0);
+    EXPECT_DOUBLE_EQ(config.pll_exit_cn0_dbhz, 27.0);
+    EXPECT_DOUBLE_EQ(config.pll_enter_persistence_sec, 1.0);
+    EXPECT_DOUBLE_EQ(config.pll_exit_persistence_sec, 0.3);
+    EXPECT_DOUBLE_EQ(config.fll_enter_cn0_dbhz, 22.0);
+    EXPECT_DOUBLE_EQ(config.fll_exit_cn0_dbhz, 18.0);
+    EXPECT_DOUBLE_EQ(config.fll_enter_persistence_sec, 0.2);
+    EXPECT_DOUBLE_EQ(config.fll_exit_persistence_sec, 0.5);
+    EXPECT_DOUBLE_EQ(config.doppler_valid_delay_sec, 0.2);
+    EXPECT_DOUBLE_EQ(config.adr_valid_after_pll_sec, 1.0);
+
+    std::string error;
+    EXPECT_TRUE(validate_carrier_tracking_config(config, &error)) << error;
+}
+
+TEST(CarrierTracking, ConfigValidationRejectsInvalidValuesAndOrdering) {
+    std::string error;
+
+    CarrierTrackingConfig config = default_carrier_tracking_config();
+    config.coherent_integration_sec = 0.0;
+    EXPECT_FALSE(validate_carrier_tracking_config(config, &error));
+
+    config = default_carrier_tracking_config();
+    config.fll_pull_in_bandwidth_hz = 3.0;
+    EXPECT_FALSE(validate_carrier_tracking_config(config, &error));
+
+    config = default_carrier_tracking_config();
+    config.pll_exit_cn0_dbhz = config.pll_enter_cn0_dbhz;
+    EXPECT_FALSE(validate_carrier_tracking_config(config, &error));
+
+    config = default_carrier_tracking_config();
+    config.fll_enter_cn0_dbhz = std::numeric_limits<double>::quiet_NaN();
+    EXPECT_FALSE(validate_carrier_tracking_config(config, &error));
+
+    config = default_carrier_tracking_config();
+    config.adr_valid_after_pll_sec = -1.0;
+    EXPECT_FALSE(validate_carrier_tracking_config(config, &error));
+}
+
+TEST(CarrierTracking, HysteresisAndPersistenceDriveUnlockedFllAndPll) {
+    const CarrierTrackingConfig config = default_carrier_tracking_config();
+    CarrierTrackingState state{};
+    reset_carrier_tracking_state(&state);
+
+    for (int index = 0; index < 10; ++index) {
+        const CarrierTrackingResult result = step_tracker(config, &state, 21.9);
+        EXPECT_EQ(result.mode, CarrierTrackingMode::kCarrierUnlocked);
+    }
+
+    EXPECT_EQ(step_tracker(config, &state, 22.0).mode, CarrierTrackingMode::kCarrierUnlocked);
+    CarrierTrackingResult result = step_tracker(config, &state, 22.0);
+    EXPECT_EQ(result.mode, CarrierTrackingMode::kFllTrack);
+    EXPECT_TRUE(result.new_carrier_segment);
+    EXPECT_EQ(result.carrier_segment_id, 1U);
+
+    for (int index = 0; index < 10; ++index) {
+        result = step_tracker(config, &state, 21.0);
+        EXPECT_EQ(result.mode, CarrierTrackingMode::kFllTrack);
+    }
+
+    for (int index = 0; index < 9; ++index) {
+        result = step_tracker(config, &state, 30.0);
+        EXPECT_EQ(result.mode, CarrierTrackingMode::kFllTrack);
+    }
+    result = step_tracker(config, &state, 30.0);
+    EXPECT_EQ(result.mode, CarrierTrackingMode::kPllTrack);
+
+    for (int index = 0; index < 5; ++index) {
+        result = step_tracker(config, &state, 27.0);
+        EXPECT_EQ(result.mode, CarrierTrackingMode::kPllTrack);
+    }
+    EXPECT_EQ(step_tracker(config, &state, 26.9).mode, CarrierTrackingMode::kPllTrack);
+    EXPECT_EQ(step_tracker(config, &state, 26.9).mode, CarrierTrackingMode::kPllTrack);
+    result = step_tracker(config, &state, 26.9);
+    EXPECT_EQ(result.mode, CarrierTrackingMode::kFllTrack);
+    EXPECT_EQ(result.fll_phase, CarrierTrackingFllPhase::kSteady);
+
+    for (int index = 0; index < 6; ++index) {
+        result = step_tracker(config, &state, 18.0);
+        EXPECT_EQ(result.mode, CarrierTrackingMode::kFllTrack);
+    }
+    for (int index = 0; index < 4; ++index) {
+        result = step_tracker(config, &state, 17.9);
+        EXPECT_EQ(result.mode, CarrierTrackingMode::kFllTrack);
+    }
+    result = step_tracker(config, &state, 17.9);
+    EXPECT_EQ(result.mode, CarrierTrackingMode::kCarrierUnlocked);
+    EXPECT_FALSE(result.doppler_valid);
+    EXPECT_FALSE(result.adr_valid);
+}
+
+TEST(CarrierTracking, FreshAcquisitionUsesPullInThenSteadyFll) {
+    const CarrierTrackingConfig config = default_carrier_tracking_config();
+    CarrierTrackingState state{};
+    reset_carrier_tracking_state(&state);
+
+    step_tracker(config, &state, 25.0);
+    CarrierTrackingResult result = step_tracker(config, &state, 25.0);
+    ASSERT_EQ(result.mode, CarrierTrackingMode::kFllTrack);
+    EXPECT_EQ(result.fll_phase, CarrierTrackingFllPhase::kPullIn);
+    EXPECT_DOUBLE_EQ(result.jitter.active_bandwidth_hz, 8.0);
+
+    for (int index = 0; index < 4; ++index) {
+        result = step_tracker(config, &state, 25.0);
+        EXPECT_EQ(result.fll_phase, CarrierTrackingFllPhase::kPullIn);
+        EXPECT_DOUBLE_EQ(result.jitter.active_bandwidth_hz, 8.0);
+    }
+    result = step_tracker(config, &state, 25.0);
+    EXPECT_EQ(result.fll_phase, CarrierTrackingFllPhase::kSteady);
+    EXPECT_DOUBLE_EQ(result.jitter.active_bandwidth_hz, 4.0);
+}
+
+TEST(CarrierTracking, DopplerAndAdrValidityHaveIndependentDelays) {
+    const CarrierTrackingConfig config = default_carrier_tracking_config();
+    CarrierTrackingState state{};
+    reset_carrier_tracking_state(&state);
+
+    step_tracker(config, &state, 25.0);
+    CarrierTrackingResult result = step_tracker(config, &state, 25.0);
+    ASSERT_EQ(result.mode, CarrierTrackingMode::kFllTrack);
+    EXPECT_FALSE(result.doppler_valid);
+    EXPECT_FALSE(result.adr_valid);
+
+    result = step_tracker(config, &state, 25.0);
+    EXPECT_FALSE(result.doppler_valid);
+    result = step_tracker(config, &state, 25.0);
+    EXPECT_TRUE(result.doppler_valid);
+    EXPECT_FALSE(result.adr_valid);
+
+    for (int index = 0; index < 9; ++index) {
+        result = step_tracker(config, &state, 30.0);
+        ASSERT_EQ(result.mode, CarrierTrackingMode::kFllTrack);
+        EXPECT_FALSE(result.adr_valid);
+    }
+    result = step_tracker(config, &state, 30.0);
+    ASSERT_EQ(result.mode, CarrierTrackingMode::kPllTrack);
+    EXPECT_TRUE(result.doppler_valid);
+    EXPECT_FALSE(result.adr_valid);
+
+    for (int index = 0; index < 9; ++index) {
+        result = step_tracker(config, &state, 30.0);
+        EXPECT_FALSE(result.adr_valid);
+    }
+    result = step_tracker(config, &state, 30.0);
+    EXPECT_TRUE(result.adr_valid);
+}
+
+TEST(CarrierTracking, PllLossImmediatelyInvalidatesAdrButKeepsDopplerInFll) {
+    const CarrierTrackingConfig config = default_carrier_tracking_config();
+    CarrierTrackingState state{};
+    reset_carrier_tracking_state(&state);
+
+    step_tracker(config, &state, 35.0);
+    step_tracker(config, &state, 35.0);
+    for (int index = 0; index < 10; ++index) {
+        step_tracker(config, &state, 35.0);
+    }
+    CarrierTrackingResult result{};
+    for (int index = 0; index < 10; ++index) {
+        result = step_tracker(config, &state, 35.0);
+    }
+    ASSERT_EQ(result.mode, CarrierTrackingMode::kPllTrack);
+    ASSERT_TRUE(result.adr_valid);
+
+    step_tracker(config, &state, 26.0);
+    step_tracker(config, &state, 26.0);
+    result = step_tracker(config, &state, 26.0);
+    EXPECT_EQ(result.mode, CarrierTrackingMode::kFllTrack);
+    EXPECT_TRUE(result.doppler_valid);
+    EXPECT_FALSE(result.adr_valid);
+}
+
+TEST(CarrierTracking, JitterFallsWithCn0AndScalesWithBandwidthIntegrationAndWavelength) {
+    const CarrierTrackingConfig config = default_carrier_tracking_config();
+    CarrierTrackingJitter fll_low{};
+    CarrierTrackingJitter fll_mid{};
+    CarrierTrackingJitter fll_high{};
+    CarrierTrackingJitter pll_low{};
+    CarrierTrackingJitter pll_high{};
+    std::string error;
+
+    ASSERT_TRUE(compute_carrier_tracking_jitter(config, CarrierTrackingMode::kFllTrack, false, 25.0, kL1WavelengthM,
+                                                0.1, &fll_low, &error))
+        << error;
+    ASSERT_TRUE(compute_carrier_tracking_jitter(config, CarrierTrackingMode::kFllTrack, false, 35.0, kL1WavelengthM,
+                                                0.1, &fll_mid, &error))
+        << error;
+    ASSERT_TRUE(compute_carrier_tracking_jitter(config, CarrierTrackingMode::kFllTrack, false, 45.0, kL1WavelengthM,
+                                                0.1, &fll_high, &error))
+        << error;
+    EXPECT_GT(fll_low.sigma_mps, fll_mid.sigma_mps);
+    EXPECT_GT(fll_mid.sigma_mps, fll_high.sigma_mps);
+
+    ASSERT_TRUE(compute_carrier_tracking_jitter(config, CarrierTrackingMode::kPllTrack, false, 25.0, kL1WavelengthM,
+                                                0.1, &pll_low, &error))
+        << error;
+    ASSERT_TRUE(compute_carrier_tracking_jitter(config, CarrierTrackingMode::kPllTrack, false, 45.0, kL1WavelengthM,
+                                                0.1, &pll_high, &error))
+        << error;
+    EXPECT_GT(pll_low.sigma_mps, pll_high.sigma_mps);
+
+    CarrierTrackingConfig wide = config;
+    wide.fll_noise_bandwidth_hz = 8.0;
+    wide.fll_pull_in_bandwidth_hz = 8.0;
+    CarrierTrackingJitter wider{};
+    ASSERT_TRUE(compute_carrier_tracking_jitter(wide, CarrierTrackingMode::kFllTrack, false, 35.0, kL1WavelengthM, 0.1,
+                                                &wider, &error))
+        << error;
+    EXPECT_GT(wider.sigma_hz, fll_mid.sigma_hz);
+
+    CarrierTrackingConfig short_integration = config;
+    short_integration.coherent_integration_sec = 0.010;
+    CarrierTrackingJitter shorter{};
+    ASSERT_TRUE(compute_carrier_tracking_jitter(short_integration, CarrierTrackingMode::kFllTrack, false, 35.0,
+                                                kL1WavelengthM, 0.1, &shorter, &error))
+        << error;
+    EXPECT_GT(shorter.sigma_hz, fll_mid.sigma_hz);
+
+    CarrierTrackingJitter short_wave{};
+    CarrierTrackingJitter long_wave{};
+    ASSERT_TRUE(compute_carrier_tracking_jitter(config, CarrierTrackingMode::kFllTrack, false, 35.0, 0.10, 0.1,
+                                                &short_wave, &error))
+        << error;
+    ASSERT_TRUE(compute_carrier_tracking_jitter(config, CarrierTrackingMode::kFllTrack, false, 35.0, 0.20, 0.1,
+                                                &long_wave, &error))
+        << error;
+    EXPECT_DOUBLE_EQ(short_wave.sigma_hz, long_wave.sigma_hz);
+    EXPECT_NEAR(long_wave.sigma_mps, 2.0 * short_wave.sigma_mps, 1e-15);
+}
+
+TEST(CarrierTracking, IdenticalInputsAndGaussianSequenceProduceIdenticalState) {
+    const CarrierTrackingConfig config = default_carrier_tracking_config();
+    CarrierTrackingState first{};
+    CarrierTrackingState second{};
+    reset_carrier_tracking_state(&first);
+    reset_carrier_tracking_state(&second);
+
+    const std::vector<double> cn0 = {25.0, 25.0, 25.0, 31.0, 31.0, 31.0, 31.0, 31.0,
+                                     31.0, 31.0, 31.0, 31.0, 31.0, 26.0, 26.0, 26.0};
+    const std::vector<double> gaussian = {0.1, -0.3, 1.2,  0.4, -0.7, 0.0,  0.9, -1.1,
+                                          0.2, 0.5,  -0.4, 0.8, 0.3,  -0.2, 1.0, -0.6};
+
+    for (std::size_t index = 0; index < cn0.size(); ++index) {
+        const CarrierTrackingResult first_result = step_tracker(config, &first, cn0[index], 0.1, gaussian[index]);
+        const CarrierTrackingResult second_result = step_tracker(config, &second, cn0[index], 0.1, gaussian[index]);
+        EXPECT_EQ(first_result.mode, second_result.mode);
+        EXPECT_EQ(first_result.fll_phase, second_result.fll_phase);
+        EXPECT_DOUBLE_EQ(first_result.tracking_error_hz, second_result.tracking_error_hz);
+        EXPECT_DOUBLE_EQ(first_result.tracking_error_mps, second_result.tracking_error_mps);
+        EXPECT_EQ(first_result.doppler_valid, second_result.doppler_valid);
+        EXPECT_EQ(first_result.adr_valid, second_result.adr_valid);
+        EXPECT_EQ(first_result.carrier_segment_id, second_result.carrier_segment_id);
+    }
+}
+
+TEST(CarrierTracking, SupportedExtremeCn0ValuesRemainFinite) {
+    const CarrierTrackingConfig config = default_carrier_tracking_config();
+    CarrierTrackingJitter low{};
+    CarrierTrackingJitter high{};
+    std::string error;
+
+    ASSERT_TRUE(compute_carrier_tracking_jitter(config, CarrierTrackingMode::kFllTrack, false, -100.0, kL1WavelengthM,
+                                                0.1, &low, &error))
+        << error;
+    ASSERT_TRUE(compute_carrier_tracking_jitter(config, CarrierTrackingMode::kPllTrack, false, 100.0, kL1WavelengthM,
+                                                0.1, &high, &error))
+        << error;
+
+    EXPECT_TRUE(std::isfinite(low.sigma_hz));
+    EXPECT_TRUE(std::isfinite(low.sigma_mps));
+    EXPECT_TRUE(std::isfinite(low.correlation_alpha));
+    EXPECT_TRUE(std::isfinite(high.sigma_hz));
+    EXPECT_TRUE(std::isfinite(high.sigma_mps));
+    EXPECT_TRUE(std::isfinite(high.correlation_alpha));
+}
+
+TEST(CarrierTracking, SignalUnavailableImmediatelyUnlocksAndClearsTrackingError) {
+    const CarrierTrackingConfig config = default_carrier_tracking_config();
+    CarrierTrackingState state{};
+    reset_carrier_tracking_state(&state);
+
+    step_tracker(config, &state, 30.0, 0.1, 1.0);
+    CarrierTrackingResult result = step_tracker(config, &state, 30.0, 0.1, 1.0);
+    ASSERT_EQ(result.mode, CarrierTrackingMode::kFllTrack);
+
+    result = step_tracker(config, &state, 30.0, 0.1, 1.0, false);
+    EXPECT_EQ(result.mode, CarrierTrackingMode::kCarrierUnlocked);
+    EXPECT_DOUBLE_EQ(result.tracking_error_hz, 0.0);
+    EXPECT_FALSE(result.doppler_valid);
+    EXPECT_FALSE(result.adr_valid);
+}
+
+} // namespace
+} // namespace gnss_sim

--- a/tests/unit/test_carrier_tracking_config.cpp
+++ b/tests/unit/test_carrier_tracking_config.cpp
@@ -1,0 +1,97 @@
+#include "gnss_sim/sim_config.h"
+
+#include <cstdio>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <string>
+
+namespace {
+
+constexpr const char* kConfigPath = "gnss_sim_carrier_tracking_config.json";
+
+void write_config(const char* text) {
+    std::ofstream output(kConfigPath, std::ios::binary | std::ios::trunc);
+    output << text;
+}
+
+class CarrierTrackingConfigTest : public ::testing::Test {
+  protected:
+    void TearDown() override {
+        static_cast<void>(std::remove(kConfigPath));
+    }
+};
+
+TEST_F(CarrierTrackingConfigTest, FrozenDefaultsRemainOptIn) {
+    const gnss_sim::SimConfig config = gnss_sim::default_sim_config();
+    EXPECT_FALSE(config.carrier_tracking.enabled);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.coherent_integration_sec, 0.020);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.pll_noise_bandwidth_hz, 5.0);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.fll_noise_bandwidth_hz, 4.0);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.fll_pull_in_bandwidth_hz, 8.0);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.fll_pull_in_duration_sec, 0.5);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.pll_enter_cn0_dbhz, 30.0);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.pll_exit_cn0_dbhz, 27.0);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.pll_enter_persistence_sec, 1.0);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.pll_exit_persistence_sec, 0.3);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.fll_enter_cn0_dbhz, 22.0);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.fll_exit_cn0_dbhz, 18.0);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.fll_enter_persistence_sec, 0.2);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.fll_exit_persistence_sec, 0.5);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.doppler_valid_delay_sec, 0.2);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.adr_valid_after_pll_sec, 1.0);
+}
+
+TEST_F(CarrierTrackingConfigTest, LoadsExplicitOverrides) {
+    write_config(R"json({
+        "carrier_tracking": {
+            "enabled": true,
+            "coherent_integration_sec": 0.01,
+            "pll_noise_bandwidth_hz": 6.0,
+            "fll_noise_bandwidth_hz": 5.0,
+            "fll_pull_in_bandwidth_hz": 9.0,
+            "fll_pull_in_duration_sec": 0.6,
+            "pll_enter_cn0_dbhz": 31.0,
+            "pll_exit_cn0_dbhz": 28.0,
+            "pll_enter_persistence_sec": 1.2,
+            "pll_exit_persistence_sec": 0.4,
+            "fll_enter_cn0_dbhz": 23.0,
+            "fll_exit_cn0_dbhz": 19.0,
+            "fll_enter_persistence_sec": 0.25,
+            "fll_exit_persistence_sec": 0.55,
+            "doppler_valid_delay_sec": 0.25,
+            "adr_valid_after_pll_sec": 1.1
+        }
+    })json");
+
+    gnss_sim::SimConfig config{};
+    std::string error_message;
+    ASSERT_TRUE(gnss_sim::load_sim_config_json(kConfigPath, &config, &error_message)) << error_message;
+    EXPECT_TRUE(config.carrier_tracking.enabled);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.coherent_integration_sec, 0.01);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.pll_noise_bandwidth_hz, 6.0);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.fll_noise_bandwidth_hz, 5.0);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.fll_pull_in_bandwidth_hz, 9.0);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.pll_enter_cn0_dbhz, 31.0);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.fll_exit_cn0_dbhz, 19.0);
+    EXPECT_DOUBLE_EQ(config.carrier_tracking.adr_valid_after_pll_sec, 1.1);
+}
+
+TEST_F(CarrierTrackingConfigTest, RejectsInvalidCoreOrderingEvenWhenDisabled) {
+    write_config(R"json({"carrier_tracking":{"enabled":false,"pll_exit_cn0_dbhz":35.0}})json");
+
+    gnss_sim::SimConfig config{};
+    std::string error_message;
+    EXPECT_FALSE(gnss_sim::load_sim_config_json(kConfigPath, &config, &error_message));
+    EXPECT_NE(error_message.find("carrier_tracking"), std::string::npos) << error_message;
+}
+
+TEST_F(CarrierTrackingConfigTest, RejectsUnknownCarrierKey) {
+    write_config(R"json({"carrier_tracking":{"doppler_sigma_mps":1.0}})json");
+
+    gnss_sim::SimConfig config{};
+    std::string error_message;
+    EXPECT_FALSE(gnss_sim::load_sim_config_json(kConfigPath, &config, &error_message));
+    EXPECT_NE(error_message.find("carrier_tracking"), std::string::npos) << error_message;
+}
+
+} // namespace


### PR DESCRIPTION
Merge the completed carrier-tracking integration chain into `main`.

Included completed work:
- #160 configurable CN0-driven PLL/FLL carrier-tracking core;
- #161 runtime Doppler/range-rate/ADR validity and reacquisition integration;
- #162 exact in-memory carrier-tracking truth diagnostics;
- #163 authentic-NAV static observation-level validation and permanent evidence.

Before opening this PR, current `main` was merged back into `integration/issues-103-104` through PR #172. CI #760 passed the combined state on Windows and Ubuntu, including the synchronized multi-seed batch regression, existing authentic-NAV urban/static Doppler checks, and the authentic carrier-tracking validation.

The integration branch is now 5 commits ahead of `main` and 0 behind. No NAV/EPH/ION is fabricated or retargeted, and the carrier model was not tuned to achieve a target RTKLIB velocity result.